### PR TITLE
Add jsdom bootstrap for Node tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,20 @@ To get started:
 ## 👾 Author
 Built in collaboration with ChatGPT & Codex.
 
+## 🧪 Node-based Testing
+When running automated tests in Node, there is no browser `document` object.
+`script.js` now detects this case and creates a minimal DOM using
+[JSDOM](https://github.com/jsdom/jsdom). Install the dependency and import the
+script in your tests:
+
+```bash
+npm install --save-dev jsdom
+```
+
+```javascript
+import "./script.js";
+```
+
+This will bootstrap `window`, `document` and `performance` globals so modules
+depending on them can run under Node.
+

--- a/script.js
+++ b/script.js
@@ -1,9 +1,18 @@
 
-import generateDeck from "./card.js"
-import addLog from "./log.js"
-import Enemy from "./enemy.js"
-import {Boss, BossTemplates} from "./boss.js"
-import { AbilityRegistry } from "./dealerabilities.js"; 
+import generateDeck from "./card.js";
+import addLog from "./log.js";
+import Enemy from "./enemy.js";
+import { Boss, BossTemplates } from "./boss.js";
+import { AbilityRegistry } from "./dealerabilities.js";
+
+// If running in Node (no `document` global), bootstrap a minimal DOM.
+if (typeof document === "undefined") {
+  const { JSDOM } = await import("jsdom");
+  const dom = new JSDOM("<!DOCTYPE html><body></body></html>");
+  global.window = dom.window;
+  global.document = dom.window.document;
+  global.performance = dom.window.performance;
+}
 
 
 


### PR DESCRIPTION
## Summary
- detect when `document` is undefined in `script.js` and create a JSDOM instance
- document Node-based testing in README

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68405af360e083268fcfac05fe2c5be4