### PR TITLE
Implement dealer card visual enhancements

### DIFF
--- a/script.js
+++ b/script.js
@@ -229,6 +229,8 @@ function renderDealerCard() {
     
   const dCardPane = document.createElement("div");
   dCardPane.classList.add("dCardPane");
+  const typeClass = currentEnemy instanceof Boss ? "boss" : "dealer";
+  dCardPane.classList.add(typeClass);
   
   const dCardAbilityPane = document.createElement("div");
   dCardAbilityPane.classList.add("dCardAbilityPane");

--- a/style.css
+++ b/style.css
@@ -148,6 +148,17 @@ body {
   position: relative;
 }
 
+.dCardPane.dealer {
+  background: linear-gradient(to bottom right, #fff, #eee);
+  border-color: #888;
+}
+
+.dCardPane.boss {
+  background: linear-gradient(to bottom right, #441414, #6b0000);
+  border-color: #aa3333;
+  box-shadow: 0 0 15px rgba(255, 0, 0, 0.5);
+}
+
 .dCard__icon {
   width: 3em;
   height: 3em;


### PR DESCRIPTION
## Summary
- enhance dealer card visuals by adding boss/dealer styles
- tag dealer cards as boss or dealer in the renderer

## Testing
- `node -e "require('./script.js')"` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_684053c068188326ad389db41a22c73b