### PR TITLE
Add HP recovery on enemy kills

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A dynamic card-based combat game where cards represent characters. The player fi
 - Dealer and Boss types with unique abilities
 - Real-time cooldown logic and ability overlays
 - Realtime combat tick system
+- Cards recover 1 HP after each enemy kill
 - Reincarnation, experience, traits (planned)
 
 ## 🧠 Tech Stack

--- a/card.js
+++ b/card.js
@@ -39,6 +39,9 @@ export class Card {
     this.maxHp = value;
     this.currentHp = this.maxHp;
 
+    // Amount of HP this card recovers each time an enemy is killed
+    this.hpPerKill = 1;
+
     this.job = null;
     this.traits = [];
   }
@@ -60,6 +63,14 @@ export class Card {
     this.damage = this.baseDamage * this.currentLevel;
     this.maxHp = this.value * this.currentLevel;
     this.currentHp = this.maxHp;
+  }
+
+  healFromKill() {
+    this.currentHp = Math.min(this.maxHp, this.currentHp + this.hpPerKill);
+  }
+
+  upgradeHpPerKill(amount = 1) {
+    this.hpPerKill += amount;
   }
 
   takeDamage(amount) {

--- a/script.js
+++ b/script.js
@@ -407,9 +407,10 @@ function respawnDealerStage() {
 }
 
 function onDealerDefeat() {
-  
+
   cardXp(stageData.stage ** 1.2 * stageData.world);
   cashOut();
+  healCardsOnKill();
   stageData.kills += 1;
   killsDisplay.textContent = `Kills: ${stageData.kills}`;
   dealerDeathAnimation();
@@ -424,6 +425,7 @@ function onBossDefeat(boss) {
   addLog(`${boss.name} was defeated!`);
   currentEnemy = null;
 
+  healCardsOnKill();
   nextWorld();
   respawnDealerStage();
 }
@@ -666,6 +668,15 @@ function animateCardLevelUp(card) {
   const w = card.wrapperElement;
   w.classList.add("levelup-animate");
   w.addEventListener("animationend", () => w.classList.remove("levelup-animate"), { once: true });
+}
+
+function healCardsOnKill() {
+  drawnCards.forEach(card => {
+    if (!card) return;
+    card.healFromKill();
+  });
+  updateHandDisplay();
+  updateDeckDisplay();
 }
 
 //=========player functions===========


### PR DESCRIPTION
## Summary
- add base HP recovery per kill on Card
- implement `healCardsOnKill` and apply on enemy defeat
- document the feature in README

## Testing
- `node script.js` *(fails: Cannot find package 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_6840ca0121548326a7d73a22d30c468c