### PR TITLE
Add casino themed layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,15 +31,15 @@
 
   <!--------------main tab panel----------------->
   <div class="mainTab">
-    
-    <div class=dealerContainer> 
+
+    <div class="dealerContainer casino-section">
       <div id="stage">Stage 1</div>
       <span id="kills">kills: 0</span>
       <div class="dealerLifeDisplay">Life:10</div>   
       <div class="dCardContainer"></div>
     </div>
     
-    <div class=mainTabPanel>
+    <div class="mainTabPanel casino-section">
       <div id="pointsDisplay"> Attack: 0</div>
       <div id="cashDisplay"> Cash: 0</div>
       <div id="damageDisplay"> Damage: 0</div>
@@ -50,13 +50,13 @@
     </div>
     <div id=game-log></div>
     
-    <div class=buttonsContainer>
+    <div class="buttonsContainer casino-section">
       <button id="clickalipse">🃏 Draw</button>
       <button id="attackBtn">⚔️ Attack</button>
       <button id="nextStageBtn" disabled> 🚀 Next Stage</button>
     </div>
   
-    <div class=handContainer>
+    <div class="handContainer casino-section">
     </div>
   </div>
   <!--------------deck tab----------------->

--- a/style.css
+++ b/style.css
@@ -7,9 +7,18 @@
 }
 
 body {
-  background-color: #67a16c;
+  background: radial-gradient(circle, #0b5121 0%, #052a13 100%);
   font-family: Trebuchet MS;
   padding: 5px;
+  color: #fff;
+}
+
+.casino-section {
+  border: 3px solid #d4af37;
+  border-radius: 8px;
+  padding: 8px;
+  background: rgba(0, 0, 0, 0.2);
+  box-shadow: 0 0 10px #d4af37;
 }
 
 #tooltip {
@@ -61,14 +70,22 @@ body {
 /*============ main tab panel============== */
 .mainTabPanel {
   grid-area: panel;
-  border: 2px solid grey;
-  border-radius: 8px;
-  background: #85a38b;
-  box-shadow: 0 0 10px #4CAF50;
+  background: rgba(133, 163, 139, 0.5);
   color: white;
   text-shadow: 0 0 5px black;
   font-size: 1rem;
-  cursor: pointer
+}
+
+.mainTabPanel > div {
+  border: 1px solid #d4af37;
+  border-radius: 4px;
+  padding: 2px 4px;
+  margin-bottom: 4px;
+  background: rgba(0, 0, 0, 0.2);
+}
+
+.mainTabPanel > div:last-child {
+  margin-bottom: 0;
 }
 
 #log-panel {


### PR DESCRIPTION
## Summary
- apply casino background gradient
- add `.casino-section` styling
- decorate dealer, panel, buttons and hand areas with the theme
- style the stat panel items with golden borders

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6840caa692a08326a4c89a552b2d8d28