### PR TITLE
Add visual polish and discard pile

### DIFF
--- a/boss.js
+++ b/boss.js
@@ -29,7 +29,7 @@ export const BossTemplates = {
   },
   2: {
     name: "Ogre",
-    icon: "shield",
+    icon: "frog",
     abilityKeys: ["defense.shield"],
   },
   // Add more worlds here

--- a/index.html
+++ b/index.html
@@ -47,6 +47,7 @@
       <div id="cashMultiDisplay"> Cash Multi: 0</div>
       <div id="lifeMultiDisplay"> Life Multi: 0</div>
       <div id="cardPointsDisplay"> Card Points: 0</div>
+      <div id="discardDisplay"> Discarded: 0</div>
     </div>
     <div id=game-log></div>
     

--- a/style.css
+++ b/style.css
@@ -14,11 +14,44 @@ body {
 }
 
 .casino-section {
+  position: relative;
   border: 3px solid #d4af37;
   border-radius: 8px;
   padding: 8px;
   background: rgba(0, 0, 0, 0.2);
   box-shadow: 0 0 10px #d4af37;
+  overflow: hidden;
+}
+
+.casino-section.slot-animate::after,
+.casino-section.slot-animate-boss::after {
+  content: "";
+  position: absolute;
+  left: -3px;
+  top: -3px;
+  right: -3px;
+  bottom: -3px;
+  border-radius: inherit;
+  pointer-events: none;
+  background: linear-gradient(to bottom, rgba(255,215,0,0.8), rgba(255,215,0,0));
+  transform: translateY(-100%);
+}
+
+.casino-section.slot-animate::after {
+  animation: slotRun 0.6s linear forwards;
+}
+
+.casino-section.slot-animate-boss::after {
+  background: linear-gradient(to bottom, rgba(255,215,0,1), rgba(255,215,0,0));
+  animation: slotRunBoss 1s linear forwards;
+}
+
+@keyframes slotRun {
+  to { transform: translateY(100%); }
+}
+
+@keyframes slotRunBoss {
+  to { transform: translateY(100%) scale(1.1); opacity: 0; }
 }
 
 #tooltip {
@@ -120,6 +153,14 @@ body {
   background: red;
   border: 2px solid grey;
   transition: width 0.3s;
+}
+
+#dealerBarFill.bar-dead {
+  animation: barDeath 0.5s ease-out forwards;
+}
+
+@keyframes barDeath {
+  to { background: darkred; opacity: 0; }
 }
 
 
@@ -344,6 +385,10 @@ body {
   line-height: 1;            /* so it doesn’t add extra space */
 }
 
+.card-hp {
+  color: black;
+}
+
 .card-wrapper {
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
@@ -363,6 +408,15 @@ body {
 
 .hit-animate {
   animation: card-hit 0.4s ease-out both;
+}
+
+.card-dead {
+  animation: cardDeath 0.5s ease-out forwards;
+}
+
+@keyframes cardDeath {
+  0% { opacity: 1; transform: scale(1); }
+  100% { opacity: 0; transform: scale(0.5); }
 }
 
 /* track (the “container” behind the fill) */


### PR DESCRIPTION
## Summary
- improve card HP visibility
- animate casino panels and life bar on enemy death
- vary dealer icon color by stage
- add frog icon to world 2 boss
- add discard pile for fallen cards

## Testing
- `node -c script.js`

------
https://chatgpt.com/codex/tasks/task_e_6840d56ed0c08326be7d7a1011733ed9