### PR TITLE
Add dealer life bar death animation

### DIFF
--- a/script.js
+++ b/script.js
@@ -414,8 +414,10 @@ function onDealerDefeat() {
   stageData.kills += 1;
   killsDisplay.textContent = `Kills: ${stageData.kills}`;
   dealerDeathAnimation();
-  nextStageChecker();
-  respawnDealerStage();
+  dealerBarDeathAnimation(() => {
+    nextStageChecker();
+    respawnDealerStage();
+  });
 } // need to define xp formula
 
 function onBossDefeat(boss) {
@@ -535,8 +537,21 @@ function cDealerDamage(damageAmount = null, ability = null, source = "dealer") {
     dCardPane.classList.add("dealer-dead")
 
     dCardWrapper.addEventListener("animationend", () => {
-       dCardContainer.innerHTML = "";
+      dCardContainer.innerHTML = "";
       renderDealerCard()
+    }, { once: true });
+  }
+
+  function dealerBarDeathAnimation(callback) {
+    const bar = document.querySelector(".dealerLifeContainer");
+    if (!bar) {
+      if (callback) callback();
+      return;
+    }
+    bar.classList.add("bar-dead");
+    bar.addEventListener("animationend", () => {
+      removeDealerLifeBar();
+      if (callback) callback();
     }, { once: true });
   }
 

--- a/style.css
+++ b/style.css
@@ -132,6 +132,23 @@ body {
   overflow: hidden;
 }
 
+.dealerLifeContainer.bar-dead {
+  animation: barDeath 0.5s ease-out forwards;
+}
+
+@keyframes barDeath {
+  0% {
+    background: #090b09;
+    opacity: 1;
+    transform: scaleY(1);
+  }
+  100% {
+    background: red;
+    opacity: 0;
+    transform: scaleY(0);
+  }
+}
+
 /* Card container */
 .dCardContainer {
   margin-top: 5px;


### PR DESCRIPTION
## Summary
- animate the dealer's life bar when a dealer dies
- trigger new life bar animation during the dealer defeat routine

## Testing
- `node script.js` *(fails: Cannot find package 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_6840df89a5ac832691a4d3494361a314