### PR TITLE
Add card death effect

### DIFF
--- a/script.js
+++ b/script.js
@@ -517,10 +517,15 @@ function cDealerDamage(damageAmount = null, ability = null, source = "dealer") {
   animateCardHit(card)
   // if it’s dead, remove it
   if (card.currentHp === 0) {
-    // 1) from your data
-    drawnCards.shift();
-    // 2) from the DOM
-    card.wrapperElement.remove();
+    animateCardDeath(card, () => {
+      // 1) from your data
+      drawnCards.shift();
+      // 2) from the DOM
+      card.wrapperElement.remove();
+      updatePlayerStats(stats);
+      updateDrawButton();
+      updateDeckDisplay();
+    });
   }
   // Optional ability logic (e.g., healing, fireball
 }
@@ -668,6 +673,19 @@ function animateCardLevelUp(card) {
   const w = card.wrapperElement;
   w.classList.add("levelup-animate");
   w.addEventListener("animationend", () => w.classList.remove("levelup-animate"), { once: true });
+}
+
+function animateCardDeath(card, onComplete) {
+  const w = card.wrapperElement;
+  w.classList.add("death-animate");
+  w.addEventListener(
+    "animationend",
+    () => {
+      w.classList.remove("death-animate");
+      if (typeof onComplete === "function") onComplete();
+    },
+    { once: true }
+  );
 }
 
 function healCardsOnKill() {

--- a/style.css
+++ b/style.css
@@ -412,6 +412,16 @@ body {
   animation: card-heal 0.6s ease-out both;
 }
 
+@keyframes card-death {
+  0%   { transform: scale(1);   opacity: 1; }
+  50%  { transform: scale(0.8); opacity: 0.7; }
+  100% { transform: scale(0.5); opacity: 0; }
+}
+
+.death-animate {
+  animation: card-death 0.5s ease-out forwards;
+}
+
 @keyframes card-level-up {
   0% {
     transform: scale(1);


### PR DESCRIPTION
## Summary
- add death animation classes and keyframes
- implement `animateCardDeath` helper
- trigger card death effect when HP hits 0

## Testing
- `node script.js` *(fails: Cannot find package 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_6840e11dec44832689f675d1d783ed3e