### PR TITLE
Add discard pile to game

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ To get started:
 ## 👾 Author
 Built in collaboration with ChatGPT & Codex.
 
-=======
 ## 🧪 Node-based Testing
 When running automated tests in Node, there is no browser `document` object.
 `script.js` now detects this case and creates a minimal DOM using
@@ -67,4 +66,4 @@ import "./script.js";
 
 This will bootstrap `window`, `document` and `performance` globals so modules
 depending on them can run under Node.
-main
+

--- a/card.js
+++ b/card.js
@@ -22,13 +22,15 @@ const names = {
 };
 
 export class Card {
-  constructor(suit, value) {
+  constructor(suit, value, backType = 'basic-red') {
     this.suit = suit;
     this.value = value;
     this.name = names[value] || String(value);
     this.symbol = suitSymbols[suit];
     this.color = suitColors[suit];
     this.id = `${value}_of_${suit}`;
+
+    this.backType = backType;
 
     this.currentLevel = 1;
     this.XpCurrent = 0;

--- a/index.html
+++ b/index.html
@@ -55,7 +55,8 @@
       <button id="attackBtn">⚔️ Attack</button>
       <button id="nextStageBtn" disabled> 🚀 Next Stage</button>
     </div>
-  
+
+    <div class="discardContainer casino-section"></div>
     <div class="handContainer casino-section">
     </div>
   </div>

--- a/script.js
+++ b/script.js
@@ -519,11 +519,16 @@ function cDealerDamage(damageAmount = null, ability = null, source = "dealer") {
   animateCardHit(card)
   // if it’s dead, remove it
   if (card.currentHp === 0) {
-    // 1) from your data
-    drawnCards.shift();
-    // 2) from the DOM
-    card.wrapperElement.remove();
-    discardCard(card);
+    animateCardDeath(card, () => {
+      // 1) from your data
+      drawnCards.shift();
+      // 2) from the DOM
+      card.wrapperElement.remove();
+      discardCard(card);
+      updatePlayerStats(stats);
+      updateDrawButton();
+      updateDeckDisplay();
+    });
   }
   // Optional ability logic (e.g., healing, fireball
 }
@@ -683,6 +688,19 @@ function animateCardLevelUp(card) {
   const w = card.wrapperElement;
   w.classList.add("levelup-animate");
   w.addEventListener("animationend", () => w.classList.remove("levelup-animate"), { once: true });
+}
+
+function animateCardDeath(card, callback) {
+  const w = card.wrapperElement;
+  w.classList.add("card-death");
+  w.addEventListener(
+    "animationend",
+    () => {
+      w.classList.remove("card-death");
+      callback?.();
+    },
+    { once: true }
+  );
 }
 
 function healCardsOnKill() {

--- a/script.js
+++ b/script.js
@@ -17,6 +17,7 @@ if (typeof document === "undefined") {
 
 
 let drawnCards = []
+let discardPile = []
 let cash = 0
 let cardPoints = 0
 let currentEnemy = null;
@@ -55,6 +56,7 @@ const pointsDisplay = document.getElementById("pointsDisplay")
 const cashDisplay = document.getElementById("cashDisplay")
 const cardPointsDisplay = document.getElementById("cardPointsDisplay")
 const handContainer = document.getElementsByClassName("handContainer")[0]
+const discardContainer = document.getElementsByClassName("discardContainer")[0]
 const dealerLifeDisplay = document.getElementsByClassName("dealerLifeDisplay")[0]
 const killsDisplay = document.getElementById("kills")
 const deckTabContainer = document.getElementsByClassName("deckTabContainer")[0];
@@ -521,6 +523,7 @@ function cDealerDamage(damageAmount = null, ability = null, source = "dealer") {
     drawnCards.shift();
     // 2) from the DOM
     card.wrapperElement.remove();
+    discardCard(card);
   }
   // Optional ability logic (e.g., healing, fireball
 }
@@ -640,6 +643,18 @@ function renderCard(card) {
   card.xpLabel = xpLabel;
 }
 
+function renderDiscardCard(card) {
+  const cardBack = document.createElement("div");
+  cardBack.classList.add("card-back", card.backType);
+  discardContainer.appendChild(cardBack);
+  card.discardElement = cardBack;
+}
+
+function discardCard(card) {
+  discardPile.push(card);
+  renderDiscardCard(card);
+}
+
 function heartHeal() {
   if (drawnCards.length === 0) return;
 
@@ -690,8 +705,10 @@ function spawnPlayer() {
 
 function respawnPlayer() {
   drawnCards = [];
-  deck = [...pDeck];
+  deck = pDeck.filter(c => c.currentHp > 0);
   handContainer.innerHTML = "";
+  discardContainer.innerHTML = "";
+  discardPile = [];
   stats.points = 0;
   pointsDisplay.textContent = stats.points;
   spawnPlayer();

--- a/style.css
+++ b/style.css
@@ -453,6 +453,21 @@ body {
   animation: card-level-up 0.6s ease-out both;
 }
 
+@keyframes card-death {
+  0% {
+    opacity: 1;
+    transform: scale(1);
+  }
+  100% {
+    opacity: 0;
+    transform: scale(0.5);
+  }
+}
+
+.card-death {
+  animation: card-death 0.5s ease-out forwards;
+}
+
 
 /*============= deck tab panel============== */
 

--- a/style.css
+++ b/style.css
@@ -36,11 +36,11 @@ body {
 .mainTab {
   display: grid;
   grid-template-rows: 1.5fr 0.5fr 1fr;
-  grid-template-columns: 1fr 20%;
-  grid-template-areas: 
-  "dealer panel"
-  "buttons panel"
-  "hand logPanel";
+  grid-template-columns: auto 1fr 20%;
+  grid-template-areas:
+    "dealer dealer panel"
+    "buttons buttons panel"
+    "discard hand logPanel";
   padding: 5px;
   height: 100vh;
 }
@@ -308,6 +308,15 @@ body {
   gap: 10px;
 }
 
+.discardContainer {
+  display: flex;
+  grid-area: discard;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: flex-start;
+  gap: 5px;
+}
+
 
 .card-wrapper {
   display: inline-flex;    /* let multiple cards sit side-by-side */ 
@@ -328,6 +337,18 @@ body {
   background: white;
   border: 2px solid grey ;
   margin-bottom: 4px;         /* a little gap before the bar */
+}
+
+.card-back {
+  height: 95px;
+  width: 75px;
+  border-radius: 8px;
+  border: 2px solid grey;
+  margin-bottom: 4px;
+}
+
+.card-back.basic-red {
+  background: repeating-linear-gradient(45deg, #b00, #b00 10px, #f66 10px, #f66 20px);
 }
 
 .card-value {


### PR DESCRIPTION
## Summary
- add discard pile container in the main tab
- style discard pile and card backside visuals
- update grid layout for new discard area
- introduce card back type property
- handle discarding defeated cards and respawn logic

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6840e3e1610c83269c7e378e2c58e3b8