### PR TITLE
Add joker unlock UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,6 +80,7 @@
 
     <div class="handContainer casino-section">
     </div>
+    <div class="jokerContainer casino-section"></div>
   <!--------------deck tab----------------->
   <div class="deckTab">
     

--- a/jokerTemplates.js
+++ b/jokerTemplates.js
@@ -1,0 +1,90 @@
+export const HealingJoker = {
+  id: "joker_heal",
+  name: "Healing Joker",
+  isJoker: true,
+  abilityType: "heal",
+  baseValue: 10,
+  image: "assets/jokers/healing_joker.png",
+  awardCondition: "defeat_boss_world_1",
+
+  getScaledPower(context = {}) {
+    const { healingBonus = 0 } = context;
+    return Math.floor(this.baseValue * (1 + healingBonus));
+  },
+
+  description: "Heal for 10 HP, increased by healing bonuses.",
+};
+
+
+export const DamageJoker = {
+  id: "joker_damage",
+  name: "Damage Joker",
+  isJoker: true,
+  abilityType: "damage",
+  baseValue: 8,
+  image: "assets/jokers/damage_joker.png",
+  awardCondition: "defeat_boss_world_2",
+
+  getScaledPower(context = {}) {
+    const { damageBonus = 0 } = context;
+    return Math.floor(this.baseValue * (1 + damageBonus));
+  },
+
+  description: "Deal 8 damage, increased by damage bonuses.",
+};
+
+
+export const ShieldJoker = {
+  id: "joker_shield",
+  name: "Shield Joker",
+  isJoker: true,
+  abilityType: "shield",
+  baseValue: 5,
+  image: "assets/jokers/shield_joker.png",
+  awardCondition: "defeat_boss_world_3",
+
+  getScaledPower(context = {}) {
+    const { shieldBonus = 0 } = context;
+    return Math.floor(this.baseValue * (1 + shieldBonus));
+  },
+
+  description: "Gain a 5-point shield, increased by shield bonuses.",
+};
+
+
+export const BuffJoker = {
+  id: "joker_buff",
+  name: "Buff Joker",
+  isJoker: true,
+  abilityType: "buff",
+  baseValue: 1.2,
+  baseDuration: 2,
+  image: "assets/jokers/buff_joker.png",
+  awardCondition: "defeat_boss_world_4",
+
+  getScaledPower(context = {}) {
+    const {
+      buffPowerBonus = 0,
+      buffDurationBonus = 0,
+    } = context;
+
+    const finalMultiplier = parseFloat(
+      (this.baseValue * (1 + buffPowerBonus)).toFixed(2)
+    );
+    const finalDuration = Math.floor(
+      this.baseDuration * (1 + buffDurationBonus)
+    );
+
+    return { finalMultiplier, finalDuration };
+  },
+
+  description: "Buff attack ×1.2 for 2 turns, scaled by bonuses.",
+};
+
+
+export const AllJokerTemplates = [
+  HealingJoker,
+  DamageJoker,
+  ShieldJoker,
+  BuffJoker,
+];

--- a/script.js
+++ b/script.js
@@ -4,6 +4,7 @@ import addLog from "./log.js";
 import Enemy from "./enemy.js";
 import { Boss, BossTemplates } from "./boss.js";
 import { AbilityRegistry } from "./dealerabilities.js";
+import { AllJokerTemplates } from "./jokerTemplates.js";
 
 // If running in Node (no `document` global), bootstrap a minimal DOM.
 if (typeof document === "undefined") {
@@ -76,6 +77,9 @@ const dealerLifeDisplay = document.getElementsByClassName("dealerLifeDisplay")[0
 const killsDisplay = document.getElementById("kills")
 const deckTabContainer = document.getElementsByClassName("deckTabContainer")[0];
 const dCardContainer = document.getElementsByClassName("dCardContainer")[0]
+const jokerContainer = document.getElementsByClassName("jokerContainer")[0]
+
+const unlockedJokers = [];
 
 
 //=========tabs==========
@@ -211,6 +215,7 @@ document.addEventListener("DOMContentLoaded", () => {
   // now the DOM is in, and lucide.js has run, so window.lucide is defined
   renderDealerCard();
   initVignetteToggles();
+  renderJokers();
   requestAnimationFrame(gameLoop)
 });
 
@@ -452,8 +457,7 @@ function onDealerDefeat() {
 
 function onBossDefeat(boss) {
   cardXp(boss.xp);
-  //awardJokerCard();
-  //nextWorld(); // or stageData.world++
+  awardJokerCard();
   addLog(`${boss.name} was defeated!`);
   currentEnemy = null;
 
@@ -758,6 +762,39 @@ function healCardsOnKill() {
   });
   updateHandDisplay();
   updateDeckDisplay();
+}
+
+function renderJokers() {
+  if (!jokerContainer) return;
+  jokerContainer.innerHTML = "";
+  unlockedJokers.forEach(joker => {
+    const tile = document.createElement("div");
+    tile.classList.add("joker-tile");
+    tile.textContent = joker.name;
+    tile.addEventListener("click", () => openJokerDetails(joker));
+    jokerContainer.appendChild(tile);
+  });
+}
+
+function openJokerDetails(joker) {
+  const overlay = document.createElement("div");
+  overlay.classList.add("joker-overlay");
+  overlay.innerHTML = `
+    <div class="joker-card">
+      <img src="${joker.image}" alt="${joker.name}">
+      <div class="joker-desc">${joker.description}</div>
+    </div>`;
+  overlay.addEventListener("click", () => overlay.remove());
+  document.body.appendChild(overlay);
+}
+
+function awardJokerCard() {
+  const template = AllJokerTemplates[stageData.world - 1];
+  if (!template) return;
+  if (unlockedJokers.find(j => j.id === template.id)) return;
+  unlockedJokers.push(template);
+  addLog(`${template.name} unlocked!`, "info");
+  renderJokers();
 }
 
 //=========player functions===========

--- a/style.css
+++ b/style.css
@@ -35,12 +35,13 @@ body {
 }
 .mainTab {
   display: grid;
-  grid-template-rows: 1.5fr 0.5fr 1fr;
+  grid-template-rows: 1.5fr 0.5fr 1fr 0.4fr;
   grid-template-columns: 20% 1fr 20%;
   grid-template-areas:
     "dealer dealer sidePanel"
     "buttons buttons sidePanel"
-    "hand hand sidePanel";
+    "hand hand sidePanel"
+    "jokers jokers sidePanel";
   padding: 5px;
   height: 100vh;
 }
@@ -577,4 +578,53 @@ body {
   flex-wrap: wrap;
   grid-area: deck;
   border: 2px solid grey;
+}
+
+/* Joker container and tiles */
+.jokerContainer {
+  grid-area: jokers;
+  display: flex;
+  justify-content: center;
+  gap: 6px;
+}
+
+.joker-tile {
+  flex: 0 0 30%;
+  padding: 4px;
+  background: rgba(0, 0, 0, 0.4);
+  border: 2px solid #d4af37;
+  border-radius: 6px;
+  color: #fff;
+  font-size: 0.8rem;
+  text-align: center;
+  cursor: pointer;
+}
+
+.joker-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.8);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.joker-card {
+  background: #222;
+  border: 2px solid #d4af37;
+  border-radius: 8px;
+  padding: 10px;
+  max-width: 90%;
+  text-align: center;
+  color: #fff;
+}
+
+.joker-card img {
+  max-width: 100%;
+  border-radius: 4px;
+  margin-bottom: 8px;
 }


### PR DESCRIPTION
## Summary
- add joker container to main tab layout
- style joker tiles and overlay
- unlock joker cards when defeating bosses
- render unlocked jokers and show details on click

## Testing
- `npm install`
- `node script.js` *(fails: Cannot read properties of undefined (reading 'addEventListener'))*

------
https://chatgpt.com/codex/tasks/task_e_68420b8e54cc8326a8ab9bbe0c666e9d