### PR TITLE
Fix joker display and discard pile

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,9 +66,7 @@
           <div id="game-log"></div>
         </div>
       </div>
-      <div class="discardContainer casino-section">
-        <img src="img/basic deck.png" alt="Card Back" class="card-back" />
-      </div>
+      <div class="discardContainer casino-section"></div>
     </div>
     
     <div class="buttonsContainer casino-section">

--- a/script.js
+++ b/script.js
@@ -768,24 +768,16 @@ function renderJokers() {
   if (!jokerContainer) return;
   jokerContainer.innerHTML = "";
   unlockedJokers.forEach(joker => {
-    const tile = document.createElement("div");
-    tile.classList.add("joker-tile");
-    tile.textContent = joker.name;
-    tile.addEventListener("click", () => openJokerDetails(joker));
-    jokerContainer.appendChild(tile);
+    const img = document.createElement("img");
+    img.classList.add("joker-card");
+    img.src = joker.image;
+    img.alt = joker.name;
+    jokerContainer.appendChild(img);
   });
 }
 
 function openJokerDetails(joker) {
-  const overlay = document.createElement("div");
-  overlay.classList.add("joker-overlay");
-  overlay.innerHTML = `
-    <div class="joker-card">
-      <img src="${joker.image}" alt="${joker.name}">
-      <div class="joker-desc">${joker.description}</div>
-    </div>`;
-  overlay.addEventListener("click", () => overlay.remove());
-  document.body.appendChild(overlay);
+  // Legacy overlay display no longer used
 }
 
 function awardJokerCard() {

--- a/style.css
+++ b/style.css
@@ -372,11 +372,10 @@ body {
 .discardContainer {
   display: flex;
   width: 75px;
-  height: 95px;
+  height: 100px;
   justify-content: center;
   align-items: center;
-  border: 2px solid rgba(255, 255, 100, 0.6);
-  border-radius: 8px;
+  border-bottom: 2px solid rgba(255, 255, 100, 0.3);
   overflow: hidden;
   position: relative;
   margin-top: auto;
@@ -588,44 +587,12 @@ body {
   gap: 6px;
 }
 
-.joker-tile {
-  flex: 0 0 30%;
-  padding: 4px;
-  background: rgba(0, 0, 0, 0.4);
-  border: 2px solid #d4af37;
-  border-radius: 6px;
-  color: #fff;
-  font-size: 0.8rem;
-  text-align: center;
-  cursor: pointer;
-}
-
-.joker-overlay {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background: rgba(0, 0, 0, 0.8);
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  z-index: 1000;
-}
 
 .joker-card {
-  background: #222;
-  border: 2px solid #d4af37;
+  width: 75px;
+  height: 95px;
   border-radius: 8px;
-  padding: 10px;
-  max-width: 90%;
-  text-align: center;
-  color: #fff;
-}
-
-.joker-card img {
-  max-width: 100%;
-  border-radius: 4px;
-  margin-bottom: 8px;
+  border: 2px solid grey;
   object-fit: cover;
 }
+


### PR DESCRIPTION
## Summary
- show joker images in the joker panel with same size as other cards
- remove initial discard image and tweak discard container styling
- simplify joker CSS and remove old overlay styles

## Testing
- `npm install`
- `npm start` *(fails: Cannot read properties of undefined)*

------
https://chatgpt.com/codex/tasks/task_e_68422bba899083269afe3db06fdb5834