### PR TITLE
Fix card removal and hit animation

### DIFF
--- a/script.js
+++ b/script.js
@@ -358,6 +358,7 @@ function renderDealerCard() {
 
 function animateCardHit(card) {
   const w = card.wrapperElement;
+  if (!w) return;
   w.classList.add("hit-animate");
   w.addEventListener("animationend", () => w.classList.remove("hit-animate"), { once: true });
 }
@@ -547,14 +548,16 @@ function cDealerDamage(damageAmount = null, ability = null, source = "dealer") {
   card.hpDisplay.textContent =
     `HP: ${card.currentHp}/${card.maxHp}`;
   updateDeckDisplay()
-  animateCardHit(card)
+  if (card.wrapperElement) {
+    animateCardHit(card)
+  }
   // if it’s dead, remove it
   if (card.currentHp === 0) {
     animateCardDeath(card, () => {
       // 1) from your data
       drawnCards.shift();
       // 2) from the DOM
-      card.wrapperElement.remove();
+      card.wrapperElement?.remove();
 
       discardCard(card);
       updatePlayerStats(stats);
@@ -740,6 +743,10 @@ function animateCardLevelUp(card) {
 
 function animateCardDeath(card, callback) {
   const w = card.wrapperElement;
+  if (!w) {
+    callback?.();
+    return;
+  }
   w.classList.add("card-death");
   w.addEventListener(
     "animationend",


### PR DESCRIPTION
## Summary
- guard hit/death animation functions if the wrapper isn't found
- ensure enemy damage only plays a hit animation when wrapper exists
- safely remove wrapper element after death

## Testing
- `node -c script.js`


------
https://chatgpt.com/codex/tasks/task_e_6841dd3d9ce4832686e559d205a3b77a