### PR TITLE
Add vignette groups to deck tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,9 +81,15 @@
     <div class="jokerContainer casino-section"></div>
   <!--------------deck tab----------------->
   <div class="deckTab">
-    
-    <div class=deckTabContainer>
-     <!-- <div id="deckDisplay"> Deck: 0</div> -->
+    <div class="vignette open">
+      <button class="vignette-toggle">Basic Deck</button>
+      <div class="deckTabContainer vignette-content">
+        <!-- <div id="deckDisplay"> Deck: 0</div> -->
+      </div>
+    </div>
+    <div class="vignette">
+      <button class="vignette-toggle">Jokers</button>
+      <div class="jokerContainer vignette-content"></div>
     </div>
   </div>
 <div id="tooltip"></div>

--- a/script.js
+++ b/script.js
@@ -77,7 +77,7 @@ const dealerLifeDisplay = document.getElementsByClassName("dealerLifeDisplay")[0
 const killsDisplay = document.getElementById("kills")
 const deckTabContainer = document.getElementsByClassName("deckTabContainer")[0];
 const dCardContainer = document.getElementsByClassName("dCardContainer")[0]
-const jokerContainer = document.getElementsByClassName("jokerContainer")[0]
+const jokerContainers = document.querySelectorAll(".jokerContainer")
 
 const unlockedJokers = [];
 
@@ -772,14 +772,16 @@ function healCardsOnKill() {
 }
 
 function renderJokers() {
-  if (!jokerContainer) return;
-  jokerContainer.innerHTML = "";
-  unlockedJokers.forEach(joker => {
-    const img = document.createElement("img");
-    img.classList.add("joker-card");
-    img.src = joker.image;
-    img.alt = joker.name;
-    jokerContainer.appendChild(img);
+  if (!jokerContainers.length) return;
+  jokerContainers.forEach(container => {
+    container.innerHTML = "";
+    unlockedJokers.forEach(joker => {
+      const img = document.createElement("img");
+      img.classList.add("joker-card");
+      img.src = joker.image;
+      img.alt = joker.name;
+      container.appendChild(img);
+    });
   });
 }
 

--- a/style.css
+++ b/style.css
@@ -560,28 +560,22 @@ body {
 
 
 /*============= deck tab panel============== */
-
 .deckTab {
-  display: grid;
-  grid-template-rows: 20px auto;
-  grid-template-areas: 
-    "tabs"
-    "deck";
-  background-color: #67a16c;
+  display: flex;
+  flex-direction: column;
   gap: 10px;
+  background-color: #67a16c;
   padding: 5px;
 }
 
 .deckTabContainer {
   display: flex;
   flex-wrap: wrap;
-  grid-area: deck;
   border: 2px solid grey;
 }
 
 /* Joker container and tiles */
 .jokerContainer {
-  grid-area: jokers;
   display: flex;
   justify-content: center;
   gap: 6px;


### PR DESCRIPTION
## Summary
- group deck tab contents with toggles
- show unlocked jokers in a vignette
- update styles for new layout

## Testing
- `npm install`
- `npm run start` *(fails: TypeError reading addEventListener)*

------
https://chatgpt.com/codex/tasks/task_e_684232bcd224832695430c27c62664b4