### PR TITLE
Make containers use full width

### DIFF
--- a/style.css
+++ b/style.css
@@ -133,6 +133,8 @@ body {
 .dealerContainer {
   grid-area: dealer;
   justify-content: center;
+  width: 100%;             /* use full grid width */
+  overflow-x: hidden;       /* prevent side scroll from large content */
 }
 
 .dealerContainer > .dealerLifeDisplay {
@@ -187,7 +189,10 @@ body {
   display: flex;
   justify-content: center;
   gap: 10px;
-} 
+  flex-wrap: wrap;    /* allow cards to wrap within the container */
+  width: 100%;        /* fill available space */
+  overflow-x: hidden; /* avoid horizontal scrolling */
+}
 
 /* Dealer card base */
 .dCardWrapper {
@@ -585,6 +590,9 @@ body {
   display: flex;
   justify-content: center;
   gap: 6px;
+  flex-wrap: wrap;    /* wrap joker cards when necessary */
+  width: 100%;        /* take up full width of grid area */
+  overflow-x: hidden; /* prevent sideways scrolling */
 }
 
 


### PR DESCRIPTION
## Summary
- revert shrink-to-fit behavior
- ensure dealer, card and joker containers fill their grid space
- wrap card/joker contents to avoid side scroll

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68423225be708326a91a4c9f519ae2f8