### PR TITLE
Fix stats side panel width

### DIFF
--- a/style.css
+++ b/style.css
@@ -36,7 +36,7 @@ body {
 .mainTab {
   display: grid;
   grid-template-rows: 1fr 0.4fr 0.75fr 0.75fr;
-  grid-template-columns: 1fr 20%;
+  grid-template-columns: 1fr 15%;
   grid-template-areas:
     "dealer sidePanel"
     "buttons sidePanel"


### PR DESCRIPTION
## Summary
- shrink the stats side panel from 20% to 15%

## Testing
- `npm start` *(fails: Cannot read properties of undefined (reading 'addEventListener'))*

------
https://chatgpt.com/codex/tasks/task_e_68423265003c8326ad261f924833edfc