### PR TITLE
Fix deck tab visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,7 +79,8 @@
     <div class="handContainer casino-section">
     </div>
     <div class="jokerContainer casino-section"></div>
-  <!--------------deck tab----------------->
+  </div> <!-- close mainTab -->
+<!--------------deck tab----------------->
   <div class="deckTab">
     <div class="vignette open">
       <button class="vignette-toggle">Basic Deck</button>


### PR DESCRIPTION
## Summary
- close `.mainTab` before inserting the deck tab so deck content isn't hidden

## Testing
- `npm install jsdom`
- `npm start` *(fails: Cannot read properties of undefined due to missing DOM)*

------
https://chatgpt.com/codex/tasks/task_e_6842382634b48326b83b12c208e1fa20