### PR TITLE
Fix discard on card death

### DIFF
--- a/script.js
+++ b/script.js
@@ -558,10 +558,11 @@ function cDealerDamage(damageAmount = null, ability = null, source = "dealer") {
   }
   // if it’s dead, remove it
   if (card.currentHp === 0) {
+    // immediately remove from data so new draws don't shift the wrong card
+    drawnCards.shift();
+
     animateCardDeath(card, () => {
-      // 1) from your data
-      drawnCards.shift();
-      // 2) from the DOM
+      // 1) from the DOM
       card.wrapperElement?.remove();
 
       discardCard(card);


### PR DESCRIPTION
## Summary
- ensure dead cards are removed from the hand array before death animation completes

## Testing
- `npm run start` *(fails: Cannot read properties of undefined)*
- `npm run test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68423c52e62483268859a81e10dd994c