### PR TITLE
Implement toggleable auto attack

### DIFF
--- a/script.js
+++ b/script.js
@@ -35,6 +35,7 @@ const stats = {
   pLifeCurrent: 10,
   damageMultiplier: 1,
   cardSlots: 3, //at start max
+  attackSpeed: 5000, //ms between automatic attacks
 }
 
 
@@ -80,6 +81,9 @@ const dCardContainer = document.getElementsByClassName("dCardContainer")[0]
 const jokerContainers = document.querySelectorAll(".jokerContainer")
 
 const unlockedJokers = [];
+
+// Track auto attack interval
+let autoAttackId = null;
 
 
 //=========tabs==========
@@ -848,6 +852,18 @@ function attack() {
     renderDealerLifeBarFill();
   }
 }
+
+function toggleAutoAttack() {
+  if (autoAttackId) {
+    clearInterval(autoAttackId);
+    autoAttackId = null;
+    attackBtn.classList.remove("active");
+  } else {
+    attack(); // immediate attack when toggled on
+    autoAttackId = setInterval(attack, stats.attackSpeed);
+    attackBtn.classList.add("active");
+  }
+}
 /*if (currentEnemy instanceof Boss) {
   // Handle boss damage
   currentEnemy.takeDamage(stats.pDamage);
@@ -925,7 +941,7 @@ nextStageChecker();
 
 
 btn.addEventListener("click", drawCard)
-attackBtn.addEventListener("click", attack)
+attackBtn.addEventListener("click", toggleAutoAttack)
 redrawBtn.addEventListener("click", redrawHand)
 nextStageBtn.addEventListener("click", nextStage)
 


### PR DESCRIPTION
## Summary
- add `attackSpeed` to player stats object
- allow attacks to toggle on/off via attack button
- run automatic attacks every 5 seconds when enabled

## Testing
- `node --check script.js`
- `npm start` *(fails: Cannot read properties of undefined (reading 'addEventListener'))*
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_68427186b1748326ba147fbbe7cdb25b