### PR TITLE
Add floating damage text

### DIFF
--- a/script.js
+++ b/script.js
@@ -373,6 +373,16 @@ function animateCardHit(card) {
   w.addEventListener("animationend", () => w.classList.remove("hit-animate"), { once: true });
 }
 
+function showDamageFloat(card, amount) {
+  const w = card.wrapperElement;
+  if (!w) return;
+  const dmg = document.createElement("div");
+  dmg.classList.add("damage-float");
+  dmg.textContent = `-${amount}`;
+  w.appendChild(dmg);
+  dmg.addEventListener("animationend", () => dmg.remove(), { once: true });
+}
+
 
 
 //=========stage functions===========
@@ -559,6 +569,7 @@ function cDealerDamage(damageAmount = null, ability = null, source = "dealer") {
   updateDeckDisplay()
   if (card.wrapperElement) {
     animateCardHit(card)
+    showDamageFloat(card, dDamage)
   }
   // if it’s dead, remove it
   if (card.currentHp === 0) {

--- a/style.css
+++ b/style.css
@@ -465,6 +465,7 @@ body {
 }
 
 .card-wrapper {
+  position: relative;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 .card-wrapper:hover {
@@ -616,5 +617,22 @@ body {
   border-radius: 8px;
   border: 2px solid grey;
   object-fit: cover;
+}
+
+.damage-float {
+  position: absolute;
+  top: 40%;
+  left: 50%;
+  transform: translate(-50%, 0);
+  color: red;
+  font-weight: bold;
+  pointer-events: none;
+  text-shadow: 0 0 2px #000;
+  animation: damage-float 0.8s ease-out forwards;
+}
+
+@keyframes damage-float {
+  from { opacity: 1; transform: translate(-50%, 0); }
+  to { opacity: 0; transform: translate(-50%, -20px); }
 }
 


### PR DESCRIPTION
## Summary
- highlight card damage with floating red numbers when dealer attacks
- support damage text via new function and CSS animation

## Testing
- `npm test` *(fails: missing script)*
- `node script.js` *(fails: Cannot find package 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_68431d87a4e88326a1f61c0baeecf696