### PR TITLE
Fix joker card layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -604,7 +604,9 @@ body {
 
 /* Joker container and tiles */
 .jokerContainer {
+  grid-area: jokers;
   display: flex;
+  flex-wrap: wrap;
   justify-content: center;
   gap: 6px;
 }


### PR DESCRIPTION
## Summary
- keep joker container in the grid
- allow its cards to wrap inside the area

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68432384f84483269f4492dca3fc26be