### PR TITLE
Fix discard on card defeat

### DIFF
--- a/script.js
+++ b/script.js
@@ -757,15 +757,17 @@ function animateCardDeath(card, callback) {
     callback?.();
     return;
   }
+  const onEnd = () => {
+    w.classList.remove("card-death");
+    w.removeEventListener("animationend", onEnd);
+    callback?.();
+  };
+
+  w.addEventListener("animationend", onEnd, { once: true });
   w.classList.add("card-death");
-  w.addEventListener(
-    "animationend",
-    () => {
-      w.classList.remove("card-death");
-      callback?.();
-    },
-    { once: true }
-  );
+
+  // Fallback: ensure removal even if animation events don't fire
+  setTimeout(onEnd, 600);
 }
 
 function healCardsOnKill() {


### PR DESCRIPTION
## Summary
- ensure card death cleanup runs even if `animationend` never fires

## Testing
- `node -c script.js`

------
https://chatgpt.com/codex/tasks/task_e_68432ef7cc988326a6f9074af5be7d8f