### PR TITLE
Fix card hit animation

### DIFF
--- a/script.js
+++ b/script.js
@@ -369,8 +369,16 @@ function renderDealerCard() {
 function animateCardHit(card) {
   const w = card.wrapperElement;
   if (!w) return;
+  // Remove the class if it's already applied so the animation can restart
+  w.classList.remove("hit-animate");
+  // Trigger a reflow to ensure the browser acknowledges the removal
+  void w.offsetWidth;
   w.classList.add("hit-animate");
-  w.addEventListener("animationend", () => w.classList.remove("hit-animate"), { once: true });
+  w.addEventListener(
+    "animationend",
+    () => w.classList.remove("hit-animate"),
+    { once: true }
+  );
 }
 
 


### PR DESCRIPTION
## Summary
- restart hit animation by removing existing class and forcing reflow before reapplying

## Testing
- `npm test` *(fails: Missing script)*
- `node script.js` *(fails: Cannot read properties of undefined (reading 'addEventListener'))*

------
https://chatgpt.com/codex/tasks/task_e_68432ea3dd948326b0cb6c20d9a43868