### PR TITLE
Add auto attack progress bars

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,8 +72,8 @@
     </div>
     
     <div class="buttonsContainer casino-section">
+      <div id="playerAttackBar" class="playerAttackBar"><div class="playerAttackFill"></div></div>
       <button id="clickalipse" title="Draw">🃏</button>
-      <button id="attackBtn" title="Attack">⚔️</button>
       <button id="redrawBtn" title="Re-draw">🔄</button>
       <button id="nextStageBtn" disabled title="Next Stage">🚀</button>
     </div>

--- a/script.js
+++ b/script.js
@@ -66,7 +66,6 @@ let pDeck = generateDeck()
 let deck = [...pDeck]
 
 const btn = document.getElementById("clickalipse")
-const attackBtn = document.getElementById("attackBtn")
 const redrawBtn = document.getElementById("redrawBtn")
 const nextStageBtn = document.getElementById("nextStageBtn")
 const pointsDisplay = document.getElementById("pointsDisplay")
@@ -82,8 +81,10 @@ const jokerContainers = document.querySelectorAll(".jokerContainer")
 
 const unlockedJokers = [];
 
-// Track auto attack interval
-let autoAttackId = null;
+// attack progress bars
+let playerAttackFill = null;
+let enemyAttackFill = null;
+let playerAttackTimer = 0;
 
 
 //=========tabs==========
@@ -221,6 +222,7 @@ document.addEventListener("DOMContentLoaded", () => {
   renderDealerCard();
   initVignetteToggles();
   renderJokers();
+  renderPlayerAttackBar();
   requestAnimationFrame(gameLoop)
 });
 
@@ -237,6 +239,27 @@ function renderDealerLifeBar() {
   dealerContainerLife.appendChild(dealerBarFill);
   dealerLifeDisplay.insertAdjacentElement("afterend", dealerContainerLife);
   dealerLifeDisplay.textContent = `Life: ${currentEnemy.maxHp}`;
+}
+
+function renderEnemyAttackBar() {
+  const existing = document.querySelector('.enemyAttackBar');
+  if (existing) existing.remove();
+  const bar = document.createElement('div');
+  const fill = document.createElement('div');
+  bar.classList.add('enemyAttackBar');
+  fill.classList.add('enemyAttackFill');
+  bar.appendChild(fill);
+  enemyAttackFill = fill;
+  const lifeContainer = document.querySelector('.dealerLifeContainer');
+  if (lifeContainer) lifeContainer.insertAdjacentElement('afterend', bar);
+}
+
+function renderPlayerAttackBar() {
+  const container = document.querySelector('.buttonsContainer');
+  if (!container) return;
+  const bar = document.getElementById('playerAttackBar');
+  if (!bar) return;
+  playerAttackFill = bar.querySelector('.playerAttackFill');
 }
 
 function renderDealerLifeBarFill() {
@@ -430,6 +453,7 @@ function spawnDealer() {
   });
 
   updateDealerLifeDisplay();
+  renderEnemyAttackBar();
   dealerDeathAnimation();
 }
 
@@ -444,6 +468,8 @@ function updateDealerLifeBar(enemy) {
 function removeDealerLifeBar() {
   const bar = document.querySelector(".dealerLifeContainer");
   if (bar) bar.remove();
+  const atk = document.querySelector('.enemyAttackBar');
+  if (atk) atk.remove();
   dealerLifeDisplay.textContent = '';
 }
 
@@ -509,6 +535,7 @@ function spawnBoss() {
   });
 
   updateDealerLifeDisplay();
+  renderEnemyAttackBar();
   dealerDeathAnimation()
 } 
 
@@ -876,17 +903,6 @@ function attack() {
   }
 }
 
-function toggleAutoAttack() {
-  if (autoAttackId) {
-    clearInterval(autoAttackId);
-    autoAttackId = null;
-    attackBtn.classList.remove("active");
-  } else {
-    attack(); // immediate attack when toggled on
-    autoAttackId = setInterval(attack, stats.attackSpeed);
-    attackBtn.classList.add("active");
-  }
-}
 /*if (currentEnemy instanceof Boss) {
   // Handle boss damage
   currentEnemy.takeDamage(stats.pDamage);
@@ -964,7 +980,6 @@ nextStageChecker();
 
 
 btn.addEventListener("click", drawCard)
-attackBtn.addEventListener("click", toggleAutoAttack)
 redrawBtn.addEventListener("click", redrawHand)
 nextStageBtn.addEventListener("click", nextStage)
 
@@ -1011,6 +1026,11 @@ function gameLoop(currentTime) {
     currentEnemy.tick(deltaTime);
     updateDealerLifeBar(currentEnemy);
 
+    if (enemyAttackFill) {
+      const eratio = Math.min(1, currentEnemy.attackTimer / currentEnemy.attackInterval);
+      enemyAttackFill.style.width = `${eratio * 100}%`;
+    }
+
     // Update cooldown overlays
     const overlays = document.querySelectorAll(".cooldown-overlay");
     overlays.forEach((overlay, i) => {
@@ -1026,6 +1046,16 @@ function gameLoop(currentTime) {
 
   updateDrawButton();
   updatePlayerStats(stats);
+  playerAttackTimer += deltaTime;
+  if (playerAttackFill) {
+    const pratio = Math.min(1, playerAttackTimer / stats.attackSpeed);
+    playerAttackFill.style.width = `${pratio * 100}%`;
+  }
+  if (playerAttackTimer >= stats.attackSpeed) {
+    attack();
+    playerAttackTimer = 0;
+    if (playerAttackFill) playerAttackFill.style.width = '0%';
+  }
   requestAnimationFrame(gameLoop);
 }
 

--- a/style.css
+++ b/style.css
@@ -381,6 +381,47 @@ body {
   transition: transform 0.1s ease, box-shadow 0.1s ease;
 }
 
+/* auto attack progress bars */
+.playerAttackBar {
+  width: 80%;
+  height: 6px;
+  background: #090b09;
+  border: 1px solid grey;
+  border-radius: 8px;
+  overflow: hidden;
+  margin-bottom: 4px;
+  position: relative;
+}
+
+.playerAttackFill {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 0;
+  background: grey;
+}
+
+.enemyAttackBar {
+  width: 50%;
+  height: 4px;
+  background: #090b09;
+  border: 1px solid grey;
+  border-radius: 8px;
+  overflow: hidden;
+  margin: 4px auto 0;
+  position: relative;
+}
+
+.enemyAttackFill {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 0;
+  background: grey;
+}
+
 .buttonsContainer > button:hover {
   transform: translateY(-2px);
   box-shadow: 0 4px 12px rgba(0, 128, 0, 0.6);


### PR DESCRIPTION
## Summary
- implement automatic attack timer for player and enemy
- show new progress bar over player buttons
- show enemy attack timer below enemy life bar
- remove manual attack button

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684480e1d2d483269f07b94ba58e8759