### PR TITLE
Fix first attack for newly spawned enemies

### DIFF
--- a/script.js
+++ b/script.js
@@ -462,6 +462,12 @@ function spawnDealer() {
     }
   });
 
+  // Ensure the dealer gets an initial hit off immediately
+  if (typeof currentEnemy.onAttack === "function") {
+    currentEnemy.onAttack(currentEnemy);
+    currentEnemy.attackTimer = 0;
+  }
+
   updateDealerLifeDisplay();
   renderEnemyAttackBar();
   dealerDeathAnimation();
@@ -544,10 +550,16 @@ function spawnBoss() {
     }
   });
 
+  // Ensure the boss gets an initial hit off immediately
+  if (typeof currentEnemy.onAttack === "function") {
+    currentEnemy.onAttack(currentEnemy);
+    currentEnemy.attackTimer = 0;
+  }
+
   updateDealerLifeDisplay();
   renderEnemyAttackBar();
   dealerDeathAnimation()
-} 
+}
 
 function updateDealerLifeDisplay() {
   dealerLifeDisplay.textContent =


### PR DESCRIPTION
## Summary
- ensure dealer enemies attack right after they spawn
- ensure bosses attack right after they spawn

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6844835c3ebc832690ca0be2d60d43aa