### PR TITLE
Add defeat screen with restart overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,14 +92,18 @@
         </div>
       </div>
     </div>
-    <div class="vignette">
+  <div class="vignette">
       <button class="vignette-toggle">Jokers</button>
       <div class="vignette-content">
         <div class="jokerContainer"></div>
       </div>
     </div>
   </div>
-<div id="tooltip"></div>
+  <div id="defeatOverlay" class="defeat-overlay">
+    <div class="defeat-message">You were defeated!</div>
+    <button id="restartOverlayBtn">Restart</button>
+  </div>
+  <div id="tooltip"></div>
 </body>
 <script type="module" src="script.js"></script>
 </html>

--- a/script.js
+++ b/script.js
@@ -79,6 +79,30 @@ const killsDisplay = document.getElementById("kills")
 const deckTabContainer = document.getElementsByClassName("deckTabContainer")[0];
 const dCardContainer = document.getElementsByClassName("dCardContainer")[0]
 const jokerContainers = document.querySelectorAll(".jokerContainer")
+const defeatOverlay = document.getElementById("defeatOverlay")
+const restartOverlayBtn = document.getElementById("restartOverlayBtn")
+
+let defeatTimeout = null;
+
+function showDefeatScreen() {
+  if (!defeatOverlay) return;
+  defeatOverlay.style.display = "flex";
+  defeatTimeout = setTimeout(restartFromDefeat, 5000);
+}
+
+function hideDefeatScreen() {
+  if (!defeatOverlay) return;
+  defeatOverlay.style.display = "none";
+  if (defeatTimeout) {
+    clearTimeout(defeatTimeout);
+    defeatTimeout = null;
+  }
+}
+
+function restartFromDefeat() {
+  hideDefeatScreen();
+  respawnPlayer();
+}
 
 const unlockedJokers = [];
 
@@ -221,6 +245,7 @@ document.addEventListener("DOMContentLoaded", () => {
   renderDealerCard();
   initVignetteToggles();
   renderJokers();
+  if (restartOverlayBtn) restartOverlayBtn.addEventListener("click", restartFromDefeat);
   requestAnimationFrame(gameLoop)
 });
 
@@ -536,9 +561,9 @@ function calculateEnemyBasicDamage(stage, world) {
 
 function cDealerDamage(damageAmount = null, ability = null, source = "dealer") {
 
-  // if there’s no card, nothing to do
+  // Player has no defending cards
   if (drawnCards.length === 0) {
-    respawnPlayer();
+    showDefeatScreen();
     return;
   }
 
@@ -630,7 +655,10 @@ function cardXp(xpAmount) {
  */
 function drawCard() {
   // 1) Nothing to draw?
-  if (deck.length === 0) return null;
+  if (deck.length === 0) {
+    showDefeatScreen();
+    return null;
+  }
 
   // 2) Take the *same* object out of deck…
   const card = deck.shift();
@@ -814,6 +842,7 @@ function spawnPlayer() {
 }
 
 function respawnPlayer() {
+  hideDefeatScreen();
   drawnCards = [];
   deck = pDeck.filter(c => c.currentHp > 0);
   handContainer.innerHTML = "";

--- a/style.css
+++ b/style.css
@@ -618,3 +618,27 @@ body {
   object-fit: cover;
 }
 
+.defeat-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.8);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  z-index: 2000;
+}
+
+.defeat-overlay button {
+  margin-top: 10px;
+  padding: 6px 12px;
+  border: none;
+  border-radius: 4px;
+  background: #4CAF50;
+  color: #fff;
+  cursor: pointer;
+}
+


### PR DESCRIPTION
## Summary
- implement defeat overlay UI with restart button
- overlay auto-respawns player after 5 seconds or on button click
- handle defeat when enemy hits with no defending cards or when trying to draw with an empty deck

## Testing
- `npm start` *(fails: Cannot read properties of undefined (reading 'addEventListener'))*

------
https://chatgpt.com/codex/tasks/task_e_68432496ead08326b58cc8cc793dc262