### PR TITLE
Fix immediate enemy strike causing double player spawn

### DIFF
--- a/script.js
+++ b/script.js
@@ -996,9 +996,11 @@ function updatePlayerStats() {
 
 //=========game start===========
 
+// Spawn the player's cards before the enemy so the initial
+// first strike doesn't trigger a full respawn
+spawnPlayer();
 spawnDealer();
 renderStageInfo();
-spawnPlayer();
 nextStageChecker();
 
 


### PR DESCRIPTION
## Summary
- spawn player cards before the enemy so the initial strike doesn't redraw a second hand

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68448552aa9083268a2805a2890bd72d