### PR TITLE
Fix damage float display

### DIFF
--- a/script.js
+++ b/script.js
@@ -406,12 +406,12 @@ function animateCardHit(card) {
 }
 
 function showDamageFloat(card, amount) {
-  const w = card.wrapperElement;
-  if (!w) return;
+  const hp = card.hpDisplay;
+  if (!hp) return;
   const dmg = document.createElement("div");
   dmg.classList.add("damage-float");
   dmg.textContent = `-${amount}`;
-  w.appendChild(dmg);
+  hp.appendChild(dmg);
   dmg.addEventListener("animationend", () => dmg.remove(), { once: true });
 }
 

--- a/style.css
+++ b/style.css
@@ -501,6 +501,7 @@ body {
 }
 
 .card-hp {
+  position: relative;
   color: #000;
   font-size: 2em;
 }
@@ -675,14 +676,14 @@ body {
 
 .damage-float {
   position: absolute;
-  top: 40%;
+  top: 0;
   left: 50%;
   transform: translate(-50%, 0);
   color: red;
   font-weight: bold;
   pointer-events: none;
   text-shadow: 0 0 2px #000;
-  animation: damage-float 0.8s ease-out forwards;
+  animation: damage-float 0.6s ease-out forwards;
 }
 
 @keyframes damage-float {


### PR DESCRIPTION
## Summary
- show enemy damage floating text over card HP
- ensure HP display can position floating text
- tune floating damage animation

## Testing
- `npm start` *(fails: Cannot read properties of undefined (reading 'addEventListener'))*
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_684486ae90a88326909188d5a64b5fce