### PR TITLE
Add upgrade button updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,15 +53,17 @@
             <div id="cashMultiDisplay"> Cash Multi: 0</div>
             <div id="lifeMultiDisplay"> Life Multi: 0</div>
             <div id="cardPointsDisplay"> Card Points: 0</div>
+            <div id="manaDisplay"> Mana: 0/0</div>
+            <div id="manaRegenDisplay"> Mana Regen: 0</div>
+            </div>
           </div>
         </div>
-      </div>
-      <div class="vignette upgrades">
-        <button class="vignette-toggle">Upgrades</button>
+        <div class="vignette upgrades">
+          <button class="vignette-toggle">Upgrades</button>
         <div class="casino-section vignette-content">
-          <p>Coming soon...</p>
+          <div class="upgrade-list"></div>
         </div>
-      </div>
+        </div>
       <div class="vignette log">
         <button class="vignette-toggle">Log</button>
         <div class="casino-section vignette-content" id="log-panel">

--- a/style.css
+++ b/style.css
@@ -690,3 +690,25 @@ body {
   to { opacity: 0; transform: translate(-50%, -20px); }
 }
 
+.upgrade-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  font-size: 0.5rem;
+}
+
+.upgrade-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.upgrade-item button {
+  padding: 1px 4px;
+  font-size: 0.5rem;
+  background: linear-gradient(135deg, #f0f0f0, #fafafa);
+  border: 1px solid #4CAF50;
+  border-radius: 4px;
+  cursor: pointer;
+}
+


### PR DESCRIPTION
## Summary
- update upgrade list rendering to store key
- add function to update upgrade buttons when cash changes
- refresh buttons in cashOut and devTools cash helper
- shrink upgrade element styles for better fit

## Testing
- `node --check script.js`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68448e5440e88326b11b6b770637c2a3