### PR TITLE
Fix damage float removal and display duration

### DIFF
--- a/script.js
+++ b/script.js
@@ -536,7 +536,9 @@ function showDamageFloat(card, amount) {
   dmg.classList.add("damage-float");
   dmg.textContent = `-${amount}`;
   hp.appendChild(dmg);
+  // ensure the element is removed even if the animationend event doesn't fire
   dmg.addEventListener("animationend", () => dmg.remove(), { once: true });
+  setTimeout(() => dmg.remove(), 1000);
 }
 
 

--- a/style.css
+++ b/style.css
@@ -679,7 +679,7 @@ body {
   font-weight: bold;
   pointer-events: none;
   text-shadow: 0 0 2px #000;
-  animation: damage-float 0.6s ease-out forwards;
+  animation: damage-float 1s ease-out forwards;
 }
 
 @keyframes damage-float {


### PR DESCRIPTION
## Summary
- ensure damage float text removes even if the animation event fails
- extend damage float display to 1 second

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6844cf341dd88326a0bbc65e40f36e41