### PR TITLE
Remove mana system, add card HP per kill

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Resource Management:
 
 Cash: Earned based on active card values and current stage/world.
 
-Mana: Unlock and manage mana for casting abilities and activating jokers.
+Card HP per Kill: Each enemy defeated heals your cards.
 
 
 Attributes and Stats:
@@ -50,7 +50,7 @@ Chaos: Amplifies critical damage and ability power.
 Holy: Reduces cooldowns.
 
 
-Jokers: Active abilities requiring mana, with limited slots and customizable effects.
+Jokers: Active abilities with cooldowns and limited slots.
 
 Traits: Late-game mechanics where enemies possess special traits (e.g., double damage, shields) that can be inherited by player cards.
 
@@ -98,13 +98,11 @@ A structured approach to manage and balance game elements.
 
 Upgrade Name	Base Value	Max Value	Cost Formula	Notes
 
-Card Slots	3	?	100 * level^2	Increase the number of active cards
+Card Slots      3       ?       1000 * level^3	Increase the number of active cards
 Global Damage Multiplier	1.0	?	200 * level^2	Amplify all damage dealt
 Auto-Attack Speed	10000 ms	2000 ms	300 * level^2.2	Reduce time between automated attacks
-Mana Regeneration	0	?	150 * level^2	Increase mana recovery rate
-Maximum Mana	0	?	200 * level^2.3	Increase total mana capacity
 Base Card HP	value	?	100 * level^2	Enhance base HP for all cards
-Card HP per Kill	1	?	100 * level	HP recovered by cards after each kill
+Card HP per Kill        1       ?       150 * level^2	HP recovered by cards after each kill
 
 
 🃏 Card Progression
@@ -155,7 +153,7 @@ Priest	Holy	Healing and support abilities
 
 🃏 Jokers
 
-Active abilities that require mana to use.
+Active abilities that operate on cooldowns.
 
 Feature	Base Value	Cost Formula	Notes
 
@@ -174,7 +172,7 @@ Complete main layout polish with casino theme variations per world
 
 Introduce joker system with active abilities
 
-Develop comprehensive upgrade and mana systems
+Develop comprehensive card progression systems
 
 Implement jobs, traits, and reincarnation mechanics
 

--- a/index.html
+++ b/index.html
@@ -53,8 +53,7 @@
             <div id="cashMultiDisplay"> Cash Multi: 0</div>
             <div id="lifeMultiDisplay"> Life Multi: 0</div>
             <div id="cardPointsDisplay"> Card Points: 0</div>
-            <div id="manaDisplay"> Mana: 0/0</div>
-            <div id="manaRegenDisplay"> Mana Regen: 0</div>
+            <div id="hpPerKillDisplay"> HP per Kill: 1</div>
             </div>
           </div>
         </div>

--- a/script.js
+++ b/script.js
@@ -37,9 +37,7 @@ const stats = {
   upgradeDamageMultiplier: 1,
   cardSlots: 3, //at start max
   attackSpeed: 5000, //ms between automatic attacks
-  maxMana: 0,
-  currentMana: 0,
-  manaRegen: 0,
+  hpPerKill: 1,
 }
 
 
@@ -60,7 +58,7 @@ const upgrades = {
     name: "Card Slots",
     level: 0,
     baseValue: 3,
-    costFormula: level => 100 * (level ** 2),
+    costFormula: level => 1000 * (level ** 3),
     effect: player => {
       player.cardSlots = upgrades.cardSlots.baseValue + upgrades.cardSlots.level;
     }
@@ -87,26 +85,14 @@ const upgrades = {
       );
     }
   },
-  manaRegen: {
-    name: "Mana Regeneration",
+  cardHpPerKill: {
+    name: "Card HP per Kill",
     level: 0,
-    baseValue: 0,
+    baseValue: 1,
     costFormula: level => 150 * (level ** 2),
     effect: player => {
-      player.manaRegen = upgrades.manaRegen.baseValue + upgrades.manaRegen.level;
-    }
-  },
-  maxMana: {
-    name: "Maximum Mana",
-    level: 0,
-    baseValue: 0,
-    costFormula: level => Math.floor(200 * (level ** 2.3)),
-    effect: player => {
-      player.maxMana =
-        upgrades.maxMana.baseValue + 5 * upgrades.maxMana.level;
-      if (player.currentMana > player.maxMana) {
-        player.currentMana = player.maxMana;
-      }
+      player.hpPerKill = upgrades.cardHpPerKill.baseValue + upgrades.cardHpPerKill.level;
+      pDeck.forEach(card => (card.hpPerKill = player.hpPerKill));
     }
   }
 };
@@ -394,19 +380,15 @@ function renderPlayerStats(stats) {
   const damageDisplay = document.getElementById("damageDisplay");
   const cashMultiDisplay = document.getElementById("cashMultiDisplay");
   const regenDisplay = document.getElementById("regenDisplay");
-  const manaDisplay = document.getElementById("manaDisplay");
-  const manaRegenDisplay = document.getElementById("manaRegenDisplay");
+  const hpPerKillDisplay = document.getElementById("hpPerKillDisplay");
 
   damageDisplay.textContent = `Damage: ${Math.floor(stats.pDamage)}`;
   cashMultiDisplay.textContent = `Cash Multi: ${Math.floor(stats.cashMulti)}`;
   regenDisplay.textContent = `Regen: ${stats.pRegen}`;
   pointsDisplay.textContent = `Points: ${stats.points}`;
   cardPointsDisplay.textContent = `Card Points: ${cardPoints}`;
-  if (manaDisplay) {
-    manaDisplay.textContent = `Mana: ${Math.floor(stats.currentMana)}/${stats.maxMana}`;
-  }
-  if (manaRegenDisplay) {
-    manaRegenDisplay.textContent = `Mana Regen: ${stats.manaRegen}`;
+  if (hpPerKillDisplay) {
+    hpPerKillDisplay.textContent = `HP per Kill: ${stats.hpPerKill}`;
   }
 
 }


### PR DESCRIPTION
## Summary
- swap mana stats for card HP per kill
- add new upgrade that increases card HP gained after kills
- steepen card slot upgrade costs
- update UI and README

## Testing
- `npm install`
- `node script.js` *(fails: Cannot read properties of undefined)*

------
https://chatgpt.com/codex/tasks/task_e_6844cefa44a483269fc654a192b69c6c