### PR TITLE
Add save/load feature

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,9 @@
     <button onclick="devTools.advanceStage()">Next Stage</button>
     <br>
     <button onclick="devTools.logEnemy()">Log Enemy</button>
+    <br>
+    <button onclick="devTools.save()">Save Game</button>
+    <button onclick="devTools.load()">Load Game</button>
   </div>
 
   <!---tabs container--->


### PR DESCRIPTION
## Summary
- implement saveGame and loadGame using localStorage
- auto-load at startup and auto-save periodically
- expose save/load through dev tools and add buttons in debug panel

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6844d3c794208326998665a9f302e93b