### PR TITLE
Add fast mode debug toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ Icons: Lucide Icons
 
 Development Tools: Replit, GitHub integration, Codex-enabled development
 
+Debug Panel: Toggleable tools for spawning enemies, adjusting stats, and now a fast mode to speed up time ticks during testing
+
 
 🗂️ Project Structure
 

--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
 
     <label>Damage Mult: <input id="debugDamageMult" type="number" value="1" step="0.1" style="width: 50px;"></label>
     <button onclick="devTools.setDamageMult()">Set</button>
+    <button onclick="devTools.toggleFastMode()">Fast Mode</button>
     <br><br>
 
     <button onclick="devTools.spawnBoss()">Spawn Boss</button>

--- a/script.js
+++ b/script.js
@@ -41,6 +41,10 @@ let stageData = {
     attackspeed: 10000 //10 sec at start
 };
 
+// Debug time scaling
+const FAST_MODE_SCALE = 10;
+let timeScale = 1;
+
 const upgrades = {
     cardSlots: {
         name: "Card Slots",
@@ -1289,8 +1293,9 @@ setInterval(() => {
 let lastFrameTime = performance.now();
 
 function gameLoop(currentTime) {
-    const deltaTime = currentTime - lastFrameTime;
+    const rawDelta = currentTime - lastFrameTime;
     lastFrameTime = currentTime;
+    const deltaTime = rawDelta * timeScale;
 
     if (currentEnemy) {
         currentEnemy.tick(deltaTime);
@@ -1402,6 +1407,9 @@ window.devTools = {
             stats.damageMultiplier = mult;
             renderPlayerStats(stats);
         }
+    },
+    toggleFastMode: () => {
+        timeScale = timeScale === 1 ? FAST_MODE_SCALE : 1;
     },
     save: saveGame,
     load: loadGame


### PR DESCRIPTION
## Summary
- add time scaling variable for debug fast mode
- implement fast mode toggle in the devTools
- expose Fast Mode button in debug panel
- document fast mode in README

## Testing
- `npm run lint` *(fails: cannot find `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_684650928b388326b6ca517c16a6db45