### PR TITLE
Implement jsdom fallback

### DIFF
--- a/script.js
+++ b/script.js
@@ -5,6 +5,14 @@ import { Boss, BossTemplates } from "./boss.js";
 import { AbilityRegistry } from "./dealerabilities.js";
 import { AllJokerTemplates } from "./jokerTemplates.js";
 import { initStarChart } from "./starChart.js";
+import { JSDOM } from "jsdom";
+
+if (typeof window === "undefined" || typeof document === "undefined") {
+    const dom = new JSDOM("<!doctype html><html><body></body></html>");
+    globalThis.window = dom.window;
+    globalThis.document = dom.window.document;
+    globalThis.performance = dom.window.performance;
+}
 
 
 let drawnCards = [];


### PR DESCRIPTION
## Summary
- detect missing DOM globals in script.js
- use jsdom to create a DOM for Node-based usage

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `node script.js` *(fails: PIXI is not loaded)*

------
https://chatgpt.com/codex/tasks/task_e_6846ddac0c9c832680e880a24f610bfc