### PR TITLE
Implement restart overlay

### DIFF
--- a/script.js
+++ b/script.js
@@ -720,9 +720,9 @@ function calculateEnemyBasicDamage(stage, world) {
 }
 
 function cDealerDamage(damageAmount = null, ability = null, source = "dealer") {
-    // if there’s no card, nothing to do
-    if (drawnCards.length === 0 || drawnCards.length === 0) {
-        respawnPlayer();
+    // If no card is available to take the hit, trigger game over
+    if (drawnCards.length === 0) {
+        showRestartScreen();
         return;
     }
 
@@ -764,6 +764,9 @@ function cDealerDamage(damageAmount = null, ability = null, source = "dealer") {
             updatePlayerStats(stats);
             updateDrawButton();
             updateDeckDisplay();
+            if (drawnCards.length === 0 && deck.length === 0) {
+                showRestartScreen();
+            }
         });
     }
     // Optional ability logic (e.g., healing, fireball
@@ -1042,6 +1045,45 @@ function respawnPlayer() {
     pointsDisplay.textContent = stats.points;
     spawnPlayer();
     stageData.stage = 1;
+}
+
+let restartOverlay = null;
+let restartTimer = null;
+
+function showRestartScreen() {
+    if (restartOverlay) return;
+    restartOverlay = document.createElement("div");
+    restartOverlay.classList.add("restart-overlay");
+
+    const message = document.createElement("div");
+    message.classList.add("restart-message");
+    message.textContent = "Game Over";
+
+    const btn = document.createElement("button");
+    btn.textContent = "Restart";
+    btn.addEventListener("click", () => {
+        respawnPlayer();
+        hideRestartScreen();
+    });
+
+    restartOverlay.append(message, btn);
+    document.body.appendChild(restartOverlay);
+
+    restartTimer = setTimeout(() => {
+        respawnPlayer();
+        hideRestartScreen();
+    }, 5000);
+}
+
+function hideRestartScreen() {
+    if (restartOverlay) {
+        restartOverlay.remove();
+        restartOverlay = null;
+    }
+    if (restartTimer) {
+        clearTimeout(restartTimer);
+        restartTimer = null;
+    }
 }
 
 function redrawHand() {

--- a/style.css
+++ b/style.css
@@ -763,3 +763,28 @@ body {
   color: #080707;
 }
 
+.restart-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background: rgba(0, 0, 0, 0.8);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  z-index: 5000;
+}
+
+.restart-overlay .restart-message {
+  font-size: 2rem;
+  margin-bottom: 1rem;
+}
+
+.restart-overlay button {
+  padding: 6px 12px;
+  font-size: 1rem;
+  cursor: pointer;
+}
+


### PR DESCRIPTION
## Summary
- trigger restart overlay when player has no defending cards
- auto-restart when last card dies
- provide show/hide helpers and overlay styling

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6846e4cf628c832688e06ec0c2d9c833