### PR TITLE
Fix star chart initialization with local pixi

### DIFF
--- a/index.html
+++ b/index.html
@@ -136,9 +136,9 @@
     <div id="star-chart-container"></div>
   </div>
   <div id="tooltip"></div>
-<!-- PixiJS & Filters from CDN to avoid local loading issues -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/pixi.js/6.5.8/pixi.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/pixi-filters@4.2.2/dist/pixi-filters.min.js"></script>
+<!-- PixiJS & Filters loaded locally to work offline -->
+<script src="pixi.min.js"></script>
+<script src="pixi-filters.min.js"></script>
 <script type="module" src="script.js"></script>
 </body>
 </html>

--- a/star-chart.html
+++ b/star-chart.html
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body>
-  <!-- PixiJS & Filters -->
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/pixi.js/6.5.8/pixi.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/pixi-filters@4.2.2/dist/pixi-filters.min.js"></script>
+  <!-- PixiJS & Filters loaded locally for offline use -->
+  <script src="pixi.min.js"></script>
+  <script src="pixi-filters.min.js"></script>
 
   <script>
     window.addEventListener("DOMContentLoaded", () => {


### PR DESCRIPTION
## Summary
- fix star chart loading by referencing local pixi scripts

## Testing
- `npm test` *(fails: karma not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846ed62459483268f8d2c59a993818a