### PR TITLE
Improve Pixi loading for star chart

### DIFF
--- a/index.html
+++ b/index.html
@@ -136,9 +136,9 @@
     <div id="star-chart-container"></div>
   </div>
   <div id="tooltip"></div>
-<!-- PixiJS & Filters from CDN to avoid local loading issues -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/pixi.js/6.5.8/pixi.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/pixi-filters@4.2.2/dist/pixi-filters.min.js"></script>
+<!-- PixiJS & Filters loaded locally to work offline -->
+<script src="pixi.min.js"></script>
+<script src="pixi-filters.min.js"></script>
 <script type="module" src="script.js"></script>
 </body>
 </html>

--- a/star-chart.html
+++ b/star-chart.html
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body>
-  <!-- PixiJS & Filters -->
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/pixi.js/6.5.8/pixi.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/pixi-filters@4.2.2/dist/pixi-filters.min.js"></script>
+  <!-- PixiJS & Filters loaded locally for offline use -->
+  <script src="pixi.min.js"></script>
+  <script src="pixi-filters.min.js"></script>
 
   <script>
     window.addEventListener("DOMContentLoaded", () => {

--- a/starChart.js
+++ b/starChart.js
@@ -3,18 +3,49 @@
 let initialized = false;
 let app = null;
 
+async function loadScript(src) {
+  return new Promise((resolve, reject) => {
+    const el = document.createElement("script");
+    el.src = src;
+    el.onload = resolve;
+    el.onerror = reject;
+    document.head.appendChild(el);
+  });
+}
+
+async function ensurePixiAvailable() {
+  if (typeof PIXI !== "undefined" && PIXI?.filters?.GlowFilter) return;
+
+  const localPixi = [
+    "./pixi.min.js",
+    "./pixi-filters.min.js"
+  ];
+  const cdnPixi = [
+    "https://cdn.jsdelivr.net/npm/pixi.js@6.5.8/dist/browser/pixi.min.js",
+    "https://cdn.jsdelivr.net/npm/pixi-filters@4.2.2/dist/pixi-filters.min.js"
+  ];
+
+  for (let i = 0; i < localPixi.length; i++) {
+    try {
+      await loadScript(localPixi[i]);
+    } catch {
+      await loadScript(cdnPixi[i]);
+    }
+  }
+}
+
 
 export async function initStarChart(containerId = "star-chart-container") {
   if (initialized) return;
-  // Guard against running in a non-browser environment or without PIXI loaded
 
-  if (
-    typeof window === "undefined" ||
-    typeof document === "undefined" ||
-    typeof PIXI === "undefined" ||
-    !PIXI.filters ||
-    !PIXI.filters.GlowFilter
-  ) {
+  if (typeof window === "undefined" || typeof document === "undefined") {
+    console.warn("Not running in browser; skipping star chart initialization.");
+    return;
+  }
+
+  await ensurePixiAvailable();
+
+  if (typeof PIXI === "undefined" || !PIXI.filters || !PIXI.filters.GlowFilter) {
     console.warn("Pixi.js unavailable; skipping star chart initialization.");
     return;
   }


### PR DESCRIPTION
## Summary
- add helper in `starChart.js` to load PixiJS dynamically from local files and fall back to CDN
- call the helper before initializing the star chart

## Testing
- `npm test` *(fails: karma not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846ed62459483268f8d2c59a993818a