### PR TITLE
Fix upgrade button text size

### DIFF
--- a/style.css
+++ b/style.css
@@ -749,7 +749,7 @@ body {
 .upgrade-item button {
   width: 60px;
   height: 24px;
-  font-size: 0.8rem;
+  font-size: 0.5rem; /* Match side panel text size */
   line-height: 1;
   padding: 2px 4px;
   background: linear-gradient(135deg, #f0f0f0, #fafafa);


### PR DESCRIPTION
## Summary
- reduce `font-size` of upgrade buttons in the main side panel to match panel text

## Testing
- `npm test` *(fails: karma not found)*

------
https://chatgpt.com/codex/tasks/task_e_68476f58188083268062162ee1bc38e0