### PR TITLE
Add player stats tab and persistent kill tracking

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,6 +37,7 @@
     <button class="mainTabButton">main</button>
     <button class="deckTabButton">deck</button>
     <button class="starChartTabButton">star chart</button>
+    <button class="playerStatsTabButton">stats</button>
   </div>
 
   <!--------------main tab panel----------------->
@@ -137,6 +138,9 @@
   </div>
   <div class="starChartTab">
     <div id="star-chart-container"></div>
+  </div>
+  <div class="playerStatsTab">
+    <div id="playerStatsContainer" class="casino-section"></div>
   </div>
   <div id="tooltip"></div>
 <script type="module" src="script.js"></script>

--- a/style.css
+++ b/style.css
@@ -690,6 +690,15 @@ body {
   overflow: hidden;
 }
 
+/* Player stats tab */
+.playerStatsTab {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  background-color: #556b7a;
+  padding: 5px;
+}
+
 /* Joker container and tiles */
 .joker-wrapper {
   max-width: 90px;


### PR DESCRIPTION
## Summary
- create a player statistics tab
- track stage kills across respawns and keep totals per stage
- count boss defeats and show prestige and deck info
- persist these stats in save data

## Testing
- `npm install`
- `npm test` *(fails: Karma server starts but Chrome isn't available)*

------
https://chatgpt.com/codex/tasks/task_e_68477bb51c608326866005a32bf819f1