### PR TITLE
Style upgrade affordances

### DIFF
--- a/script.js
+++ b/script.js
@@ -287,7 +287,12 @@ function renderUpgrades() {
         const cost = up.costFormula(up.level + 1);
         const btn = document.createElement("button");
         btn.textContent = `Buy $${cost}`;
-        if (cash < cost) btn.disabled = true;
+        if (cash < cost) {
+            btn.disabled = true;
+            row.classList.add("unaffordable");
+        } else {
+            row.classList.add("affordable");
+        }
         btn.addEventListener("click", () => purchaseUpgrade(key));
 
         row.append(label, btn);
@@ -302,8 +307,11 @@ function updateUpgradeButtons() {
         if (!key || !btn) return;
         const up = upgrades[key];
         const cost = up.costFormula(up.level + 1);
-        btn.disabled = cash < cost;
+        const affordable = cash >= cost;
+        btn.disabled = !affordable;
         btn.textContent = `Buy $${cost}`;
+        row.classList.toggle("affordable", affordable);
+        row.classList.toggle("unaffordable", !affordable);
     });
 }
 

--- a/style.css
+++ b/style.css
@@ -744,15 +744,18 @@ body {
   display: flex;
   justify-content: space-between;
   align-items: center;
+  padding: 2px 4px;
+  border-radius: 4px;
+  transition: background 0.2s ease, opacity 0.2s ease;
 }
 
 .upgrade-item button {
-  width: 60px;
+  width: 70px;
   height: 24px;
   font-size: 0.5rem; /* Match side panel text size */
   line-height: 1;
   padding: 2px 4px;
-  background: linear-gradient(135deg, #f0f0f0, #fafafa);
+  background: linear-gradient(135deg, #e8ffe8, #c8facc);
   border: 1px solid #4CAF50;
   border-radius: 4px;
   cursor: pointer;
@@ -761,6 +764,21 @@ body {
   justify-content: center;
   align-items: center;
   color: #080707;
+  transition: background 0.2s ease, box-shadow 0.2s ease;
+}
+
+.upgrade-item button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.upgrade-item.affordable {
+  background: rgba(76, 175, 80, 0.2);
+  opacity: 1;
+}
+
+.upgrade-item.unaffordable {
+  opacity: 0.5;
 }
 
 .restart-overlay {


### PR DESCRIPTION
## Summary
- highlight purchasable upgrades in green
- dim upgrades that can't be bought
- improve upgrade button visuals

## Testing
- `npm test` *(fails: `karma: not found`)*
- `npm run lint` *(fails: cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6847871c94d883268908e240df18a21c