### PR TITLE
Add restart from stats screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Healing Mechanics: Cards recover 1 HP after each enemy defeat.
 
 Game Over Screen: A restart overlay appears when your deck is wiped out.
 Click the Restart button or wait five seconds to respawn automatically.
+Stats Screen: View lifetime progress and start a new run from the stats tab.
 
 Progression Systems:
 

--- a/script.js
+++ b/script.js
@@ -564,6 +564,15 @@ function renderGlobalStats() {
             list.appendChild(row);
         });
     container.appendChild(list);
+
+    // Add a restart button to allow starting a new run from the stats screen
+    const restartBtn = document.createElement("button");
+    restartBtn.textContent = "Start New Run";
+    restartBtn.addEventListener("click", () => {
+        respawnPlayer();
+        showTab(mainTab);
+    });
+    container.appendChild(restartBtn);
 }
 
 function renderDealerCard() {


### PR DESCRIPTION
## Summary
- allow players to restart a run from the stats tab
- document new stats screen option in README

## Testing
- `npm test` *(fails: karma not found)*

------
https://chatgpt.com/codex/tasks/task_e_68478f3673d48326b76afdfdac3a431f