### PR TITLE
Fix world reset bug

### DIFF
--- a/script.js
+++ b/script.js
@@ -1255,6 +1255,7 @@ function spawnPlayer() {
 function respawnPlayer() {
     // Reset stage progression
     stageData.stage = 0;
+    stageData.world = 1;
     stageData.kills = 0;
 
     // Reset upgrades to level 0 and reapply effects


### PR DESCRIPTION
## Summary
- ensure world resets to 1 when starting a new run

## Testing
- `npm install` *(fails: Failed to set up Chrome)*
- `npm test` *(fails: karma not found)*

------
https://chatgpt.com/codex/tasks/task_e_684792cb91848326848be0962d71e37b