### PR TITLE
Add damage summary display

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,6 +48,9 @@
         Stage 1
       </div>
       <span id="kills">kills: 0</span>
+      <div id="statsSummary">
+        Damage: 0 | Cash Multi: 1
+      </div>
       <div class="dealerLifeDisplay">
         Life:10
       </div>

--- a/script.js
+++ b/script.js
@@ -218,6 +218,7 @@ const nextStageBtn = document.getElementById("nextStageBtn");
 const pointsDisplay = document.getElementById("pointsDisplay");
 const cashDisplay = document.getElementById("cashDisplay");
 const cardPointsDisplay = document.getElementById("cardPointsDisplay");
+const statsSummaryDisplay = document.getElementById("statsSummary");
 const handContainer = document.getElementsByClassName("handContainer")[0];
 const discardContainer = document.getElementsByClassName("discardContainer")[0];
 const dealerLifeDisplay =
@@ -540,6 +541,10 @@ function renderPlayerStats(stats) {
 
     damageDisplay.textContent = `Damage: ${Math.floor(stats.pDamage)}`;
     cashMultiDisplay.textContent = `Cash Multi: ${Math.floor(stats.cashMulti)}`;
+    if (statsSummaryDisplay) {
+        statsSummaryDisplay.textContent =
+            `Damage: ${Math.floor(stats.pDamage)} | Cash Multi: ${Math.floor(stats.cashMulti)}`;
+    }
     pointsDisplay.textContent = `Points: ${stats.points}`;
     cardPointsDisplay.textContent = `Card Points: ${cardPoints}`;
     attackSpeedDisplay.textContent = `Attack Speed: ${Math.floor(stats.attackSpeed / 1000)}s`;

--- a/style.css
+++ b/style.css
@@ -195,6 +195,13 @@ body {
   margin-bottom: 5px
 }
 
+#statsSummary {
+  font-size: 16px;
+  color: #2c252b;
+  text-shadow: 0 0 5px black;
+  margin-bottom: 5px;
+}
+
 #dealerBarFill {
   height: 30px;
   width: 100%;


### PR DESCRIPTION
## Summary
- show current Damage and Cash Multi near the stage info
- style new summary container
- keep renderPlayerStats updating the summary

## Testing
- `npm test` *(fails: karma not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847a0e61bb48326abb26e2fe26b01db