### PR TITLE
Add mana bar system

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,6 +83,9 @@
             <div id="attackSpeedDisplay">
               Attack Speed: 10
             </div>
+            <div id="manaRegenDisplay">
+              Mana Regen: 0/s
+            </div>
           </div>
         </div>
       </div>
@@ -118,6 +121,12 @@
       <div class="handContainer casino-section">
       </div>
       <div class="jokerContainer casino-section">
+      </div>
+      <div class="manaBar" id="manaBar" style="display:none;">
+        <div class="manaBarInner">
+          <div class="manaFill" id="manaFill"></div>
+          <div class="manaText" id="manaText">0/0</div>
+        </div>
       </div>
     </div>
   </div>

--- a/style.css
+++ b/style.css
@@ -120,6 +120,7 @@ body {
 .buttonsContainer  { grid-area: buttons;  }
 .handContainer     { grid-area: hand;     }
 .joker-wrapper     { grid-area: jokers;   } /* or add a .jokerContainer alias */
+.jokerContainer    { grid-area: jokers;   }
 .discardContainer  { grid-area: discard;  }
 .sidePanel         { grid-area: sidePanel;
                      overflow-y: auto;   /* only sidebar scrolls */
@@ -129,12 +130,52 @@ body {
   /*overflow: hidden;*/
 }
 
-#gameColumn { 
-  /* wrap dealer, buttons, hand, jokers */
-  display: flex;
-  flex-direction: column;
+#gameColumn {
+  /* wrap dealer, buttons, hand, jokers with mana bar */
+  display: grid;
+  grid-template-columns: 20px 1fr;
+  grid-template-rows: auto 1fr auto;
+  grid-template-areas:
+    ". buttons"
+    "mana hand"
+    "mana jokers";
   overflow-y: auto;
   gap: 10px;
+  position: relative;
+}
+
+.manaBar {
+  grid-area: mana;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.manaBarInner {
+  position: relative;
+  width: 20px;
+  height: 100%;
+  background: black;
+  border: 1px solid #333;
+}
+
+.manaFill {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 0%;
+  background: #222;
+}
+
+.manaText {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) rotate(-90deg);
+  color: #fff;
+  font-size: 0.7rem;
+  white-space: nowrap;
 }
 /*============ main tab side panel============== */
 


### PR DESCRIPTION
## Summary
- add a vertical mana bar unlocked after defeating the first world boss
- display mana regeneration rate in the stats panel
- regenerate mana each frame and persist stats
- fix layout so the mana bar no longer pushes other containers left

## Testing
- `npm test` *(fails: karma not found)*
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_684863dbfcf48326841f9c0791dd09c6