### PR TITLE
Remove damage & cash multiplier summary

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,9 +48,6 @@
         Stage 1
       </div>
       <span id="kills">kills: 0</span>
-      <div id="statsSummary">
-        Damage: 0 | Cash Multi: 1
-      </div>
       <div class="dealerLifeDisplay">
         Life:10
       </div>

--- a/script.js
+++ b/script.js
@@ -219,7 +219,6 @@ const nextStageBtn = document.getElementById("nextStageBtn");
 const pointsDisplay = document.getElementById("pointsDisplay");
 const cashDisplay = document.getElementById("cashDisplay");
 const cardPointsDisplay = document.getElementById("cardPointsDisplay");
-const statsSummaryDisplay = document.getElementById("statsSummary");
 const handContainer = document.getElementsByClassName("handContainer")[0];
 const discardContainer = document.getElementsByClassName("discardContainer")[0];
 const dealerLifeDisplay =
@@ -567,10 +566,6 @@ function renderPlayerStats(stats) {
 
     damageDisplay.textContent = `Damage: ${Math.floor(stats.pDamage)}`;
     cashMultiDisplay.textContent = `Cash Multi: ${Math.floor(stats.cashMulti)}`;
-    if (statsSummaryDisplay) {
-        statsSummaryDisplay.textContent =
-            `Damage: ${Math.floor(stats.pDamage)} | Cash Multi: ${Math.floor(stats.cashMulti)}`;
-    }
     pointsDisplay.textContent = `Points: ${stats.points}`;
     cardPointsDisplay.textContent = `Card Points: ${cardPoints}`;
     attackSpeedDisplay.textContent = `Attack Speed: ${Math.floor(stats.attackSpeed / 1000)}s`;

--- a/style.css
+++ b/style.css
@@ -252,12 +252,6 @@ body {
   margin-bottom: 5px
 }
 
-#statsSummary {
-  font-size: 16px;
-  color: #2c252b;
-  text-shadow: 0 0 5px black;
-  margin-bottom: 5px;
-}
 
 #dealerBarFill {
   height: 30px;


### PR DESCRIPTION
## Summary
- remove damage/cash multiplier summary from index
- remove summary logic from script
- drop unused CSS

## Testing
- `npm test` *(fails: ChromeHeadless not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6848d9558ff4832681de31654d25882a