### PR TITLE
Improve simulation test suite

### DIFF
--- a/simulator.cjs
+++ b/simulator.cjs
@@ -5,6 +5,27 @@ class GameSimulator {
     this.cash = 0;
     this.globalDamageLevel = 0;
     this.strategy = strategy;
+    // track upgrade unlocks
+    this.upgrades = {
+      cardSlots: { unlocked: false, unlockStage: 5 }
+    };
+
+    // analytics placeholders for future expansion
+    this.tracking = {
+      jokerActivations: 0,
+      manaSpent: 0,
+      abilityUsage: {},
+      cooldownUsage: {},
+      traitInteractions: {}
+    };
+  }
+
+  checkUpgradeUnlocks() {
+    Object.values(this.upgrades).forEach(up => {
+      if (!up.unlocked && this.stage >= up.unlockStage) {
+        up.unlocked = true;
+      }
+    });
   }
 
   run(ticks = 100) {
@@ -16,12 +37,18 @@ class GameSimulator {
         this.cash -= this.upgradeCost();
         this.globalDamageLevel++;
       }
+
+      this.checkUpgradeUnlocks();
     }
 
     return {
       finalStage: this.stage,
       totalCash: this.cash,
-      damageLevel: this.globalDamageLevel
+      damageLevel: this.globalDamageLevel,
+      unlockedUpgrades: Object.fromEntries(
+        Object.entries(this.upgrades).map(([k, v]) => [k, v.unlocked])
+      ),
+      tracking: this.tracking
     };
   }
 

--- a/test/advanced.simulation.test.cjs
+++ b/test/advanced.simulation.test.cjs
@@ -1,5 +1,6 @@
 const { expect } = require('chai');
 const { GameSimulator } = require('../simulator.cjs');
+const { saveCSV } = require('../utils/logger.cjs');
 
 // Helper simulator with HP tracking
 class HPSimulator extends GameSimulator {
@@ -69,14 +70,23 @@ describe('🧪 General Simulation Test Templates', () => {
     expect(res.damageLevel).to.be.greaterThan(0);
   });
 
+  it('Upgrade unlocks at correct stage', () => {
+    const sim = new GameSimulator('balanced');
+    const res = sim.run(5);
+    expect(res.unlockedUpgrades.cardSlots).to.be.true;
+  });
+
   it('Compare strategies side-by-side', () => {
     const strategies = ['aggressive', 'defensive', 'balanced'];
+    const results = [];
     strategies.forEach(strat => {
       const sim = strat === 'balanced' ? new BalancedBuySimulator(strat) : new GameSimulator(strat);
       const res = sim.run(150);
       expect(res.finalStage).to.be.a('number');
-      console.log(`${strat}: stage=${res.finalStage}, cash=${res.totalCash}, dmg=${res.damageLevel}`);
+      results.push({ strat, stage: res.finalStage, cash: res.totalCash, dmg: res.damageLevel });
     });
+    console.table(results);
+    saveCSV(results, 'strategy-results.csv');
   });
 
   it('Game over condition triggers', () => {
@@ -108,6 +118,9 @@ describe('🧪 General Simulation Test Templates', () => {
       expect(res.finalStage).to.not.equal(0);
       results.push({ strat, stage: res.finalStage, cash: res.totalCash });
     });
+    const maxGap = Math.max(...results.map(r => r.stage)) - Math.min(...results.map(r => r.stage));
+    expect(maxGap).to.be.below(50);
     console.table(results);
+    saveCSV(results, 'strategy-results.csv');
   });
 });

--- a/utils/logger.cjs
+++ b/utils/logger.cjs
@@ -1,0 +1,13 @@
+const fs = require('fs');
+
+function saveCSV(dataArray, filename) {
+  if (!Array.isArray(dataArray) || dataArray.length === 0) {
+    return;
+  }
+  const headers = Object.keys(dataArray[0]).join(',');
+  const rows = dataArray.map(obj => Object.values(obj).join(','));
+  const csv = [headers, ...rows].join('\n');
+  fs.writeFileSync(filename, csv);
+}
+
+module.exports = { saveCSV };


### PR DESCRIPTION
## Summary
- add `saveCSV` helper for logging strategy results
- track upgrade unlocks and analytics stats in the simulator
- export results for comparison tests and verify stage gaps
- test that cardSlots unlocks at stage 5

## Testing
- `npx mocha`

------
https://chatgpt.com/codex/tasks/task_e_68497191b5808326befdda4cf9776ee6