### PR TITLE
Enhance simulation CSV logging

### DIFF
--- a/.github/workflows/simulation.yml
+++ b/.github/workflows/simulation.yml
@@ -20,6 +20,8 @@ jobs:
 
       - name: 📦 Install Dependencies
         run: npm install
+        env:
+          PUPPETEER_SKIP_DOWNLOAD: '1'
 
       - name: 🧪 Run Simulation Tests
         run: npm test

--- a/simulate.js
+++ b/simulate.js
@@ -1,9 +1,11 @@
-import { GameSimulator } from "./simulator.js";
+import { GameSimulator } from "./simulation.js";
 import fs from "fs";
 
 const strategy = process.argv[2] || "balanced";
 const sim = new GameSimulator(strategy);
-const log = sim.run();
+const log = sim.run(100, { timestamp: true });
 
-fs.writeFileSync("sim-output.log", log.join("\n"));
-console.log(log.join("\n"));
+if (Array.isArray(log)) {
+  fs.writeFileSync("sim-output.log", log.map(l => JSON.stringify(l)).join("\n"));
+  console.log(log);
+}

--- a/simulation.js
+++ b/simulation.js
@@ -3,6 +3,7 @@ import generateDeck from "./card.js";
 import { Enemy } from "./enemy.js"; // assume this works without DOM
 import { Boss } from "./boss.js";
 import { upgrades as allUpgrades } from "./script.js"; // if needed, or copy upgrade logic
+import { saveCSV } from "./utils/logger.cjs";
 
 export class GameSimulator {
   constructor(strategy = "balanced") {
@@ -15,11 +16,13 @@ export class GameSimulator {
       stage: 1,
       cash: 500,
       xp: 0,
+      hp: 100,
     };
     this.deck = generateDeck();
     this.strategy = strategy;
     this.upgrades = structuredClone(allUpgrades); // safe copy
     this.logs = [];
+    this.commitHash = process.env.GITHUB_SHA || "";
   }
 
   tick() {
@@ -51,14 +54,34 @@ export class GameSimulator {
     }
   }
 
-  run(maxTicks = 100) {
+  run(maxTicks = 100, options = {}) {
+    const { timestamp = false } = options;
     for (let i = 0; i < maxTicks; i++) {
       this.tick();
+      this.logs.push({
+        tick: i,
+        stage: this.stats.stage,
+        hp: this.stats.hp ?? 0,
+        cash: this.stats.cash,
+        damageLevel: this.upgrades.globalDamage?.level || 0,
+        strategy: this.strategy,
+        commitHash: this.commitHash
+      });
     }
 
-    this.logs.push(`Final stage: ${this.stats.stage}`);
-    this.logs.push(`XP: ${this.stats.xp}`);
-    this.logs.push(`Cash left: ${this.stats.cash}`);
+    const now = new Date().toISOString().replace(/[:.]/g, '-');
+    const detailed = timestamp ? `sim-${this.strategy}-${now}.csv` : 'detailed-sim.csv';
+    saveCSV(this.logs, detailed);
+    saveCSV([
+      {
+        strategy: this.strategy,
+        finalStage: this.stats.stage,
+        totalCash: this.stats.cash,
+        damageLevel: this.upgrades.globalDamage?.level || 0,
+        commitHash: this.commitHash
+      }
+    ], 'summary.csv');
+
     return this.logs;
   }
 }


### PR DESCRIPTION
## Summary
- log per-tick data with commit hash and optional timestamps
- write detailed tick logs and summary CSVs from GameSimulator
- update ESM simulator and CLI wrapper
- expand test simulators to record logs
- merge logs across strategies for comparison tests
- skip Puppeteer download in CI

## Testing
- `PUPPETEER_SKIP_DOWNLOAD=1 npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849af346ebc8326a7b5022712c8dfac