### PR TITLE
Add boss XP property and test

### DIFF
--- a/script.js
+++ b/script.js
@@ -894,6 +894,7 @@ function spawnBoss() {
         name: template.name,
         icon: template.icon,
         iconColor: template.iconColor,
+        xp: Math.pow(stage, 1.5) * world,
         abilities,
         onAttack: boss => {
             const { minDamage, maxDamage } = calculateEnemyBasicDamage(

--- a/test/advanced.simulation.test.cjs
+++ b/test/advanced.simulation.test.cjs
@@ -167,4 +167,24 @@ describe('🧪 General Simulation Test Templates', () => {
     console.table(summary);
     saveCSV(results, 'strategy-comparison.csv');
   });
+
+  it('Boss defeat grants card XP', async () => {
+    const { Card } = await import('../card.js');
+    const { Boss } = await import('../boss.js');
+
+    const card = new Card('Hearts', 2);
+    const drawn = [card];
+    const cardXp = amt => drawn.forEach(c => c.gainXp(amt));
+
+    const boss = new Boss(5, 1, {
+      maxHp: 1,
+      xp: Math.pow(5, 1.5) * 1,
+      onDefeat: b => cardXp(b.xp)
+    });
+
+    const before = card.XpCurrent;
+    boss.takeDamage(1);
+    if (boss.isDefeated()) boss.onDefeat(boss);
+    expect(card.XpCurrent).to.be.greaterThan(before);
+  });
 });


### PR DESCRIPTION
## Summary
- give bosses an xp value on spawn
- keep boss defeat awarding card XP
- test that bosses grant card XP

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849fb0702f883268e8659be32d3570b