### PR TITLE
Update docs with simulator notes

### DIFF
--- a/.codex/tasks.md
+++ b/.codex/tasks.md
@@ -15,6 +15,9 @@
   - Include references to job affinity and trait bonuses
 -Add appropriate icons to each dealer/boss card
 -Increase size/intensity of icons depending on stage
+-Add fast mode toggle to debug panel
+-Implement Node-based GameSimulator with simulation tests
+-Add restart option in stats screen to begin a new run
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ Development Tools: Replit, GitHub integration, Codex-enabled development
 
 Debug Panel: Toggleable tools for spawning enemies, adjusting stats, and now a fast mode to speed up time ticks during testing
 
+Node Simulation: Run `node simulate.js [strategy]` to test upgrade progressions without a browser
+
 
 🗂️ Project Structure
 
@@ -81,6 +83,9 @@ Debug Panel: Toggleable tools for spawning enemies, adjusting stats, and now a f
 /card.js            ← Card class & deck generation
 /script.js          ← Game logic
 /.codex/tasks.md    ← Codex task manager
+/simulate.js        ← CLI to run the Node-based simulator
+/simulation.js      ← Simulator library used for tests
+/simulator.cjs      ← Minimal CommonJS version for CI tests
 
 🌠 Star Chart Setup
 
@@ -88,7 +93,7 @@ Include `pixi.min.js` and `pixi-filters.min.js` in your page. The chart initiali
 
 🔧 Codex Integration
 
-This repository utilizes Codex for smart task automation. Tasks are listed in .codex/tasks.md.
+This repository utilizes Codex for smart task automation. The active task list lives in `.codex/tasks.md` along with completed items.
 
 Getting Started:
 


### PR DESCRIPTION
## Summary
- document Node-based simulation utility in README
- mention `.codex/tasks.md` task tracker
- list simulator and debug tool tasks as completed

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684971a5f1ac83269cc2b8af79892036