### PR TITLE
Adjust auto attack speed upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+*.csv

--- a/script.js
+++ b/script.js
@@ -130,16 +130,16 @@ const upgrades = {
     autoAttackSpeed: {
         name: "Auto-Attack Speed",
         level: 0,
-        baseValue: 10000,
+        baseValue: 5000,
         unlocked: false,
         unlockCondition: () => stageData.stage >= 3,
-        costFormula: level => Math.floor(300 * level ** 2.2),
+        costFormula: level => Math.floor(300 * level ** 2),
         effect: player => {
-            player.attackSpeed = Math.max(
-                2000,
-                upgrades.autoAttackSpeed.baseValue -
-                    100 * upgrades.autoAttackSpeed.level
-            );
+            const lvl = upgrades.autoAttackSpeed.level;
+            const base = upgrades.autoAttackSpeed.baseValue;
+            const fastReduction = 500 * Math.min(lvl, 4);
+            const diminishing = 250 * Math.max(lvl - 4, 0);
+            player.attackSpeed = Math.max(2000, base - fastReduction - diminishing);
         }
     },
     maxMana: {

--- a/test/attackSpeedUpgrade.test.cjs
+++ b/test/attackSpeedUpgrade.test.cjs
@@ -1,0 +1,45 @@
+const { expect } = require('chai');
+
+describe('⚙️ autoAttackSpeed Upgrade', () => {
+  function setup() {
+    const stats = { attackSpeed: 5000 };
+    const upgrades = {
+      autoAttackSpeed: {
+        level: 0,
+        baseValue: 5000,
+        costFormula: level => Math.floor(300 * level ** 2),
+        effect: player => {
+          const lvl = upgrades.autoAttackSpeed.level;
+          const base = upgrades.autoAttackSpeed.baseValue;
+          const fast = 500 * Math.min(lvl, 4);
+          const slow = 250 * Math.max(lvl - 4, 0);
+          player.attackSpeed = Math.max(2000, base - fast - slow);
+        }
+      }
+    };
+    const purchase = () => {
+      upgrades.autoAttackSpeed.level += 1;
+      upgrades.autoAttackSpeed.effect(stats);
+    };
+    return { stats, upgrades, purchase };
+  }
+
+  it('reduces attack interval with each purchase', () => {
+    const { stats, purchase } = setup();
+    const expected = [
+      4500,
+      4000,
+      3500,
+      3000,
+      2750,
+      2500,
+      2250,
+      2000,
+      2000
+    ];
+    expected.forEach(val => {
+      purchase();
+      expect(stats.attackSpeed).to.equal(val);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- balance auto attack speed upgrade with diminishing returns
- update regression test for new scaling
- ignore generated csv files

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6849fb58748c832682a9ee6a11558190