### PR TITLE
Restore layout container

### DIFF
--- a/style.css
+++ b/style.css
@@ -132,23 +132,8 @@ body {
 }
 
 #gameColumn {
-
-  /* wrap dealer, buttons, hand, jokers with mana bar */
-  display: grid;
-  grid-template-columns: 20px 1fr;
-  grid-template-rows: auto 1fr auto;
-  grid-template-areas:
-    ". buttons"
-    "mana hand"
-    "mana jokers";
-
-  /* wrap dealer, buttons, hand, jokers */
-  display: flex;
-  flex-direction: column;
-
-  overflow-y: auto;
-  gap: 10px;
-  position: relative;
+  /* preserve DOM structure without affecting layout */
+  display: contents;
 }
 
 .manaBar {


### PR DESCRIPTION
## Summary
- revert previous HTML restructure to keep original game column markup
- set `#gameColumn` to `display: contents` so its children participate in the main grid

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a0103469c8326a26b6a3864579185