### PR TITLE
Add survival simulator and tests

### DIFF
--- a/survival.js
+++ b/survival.js
@@ -1,0 +1,73 @@
+import generateDeck from './card.js';
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const { saveCSV } = require('./utils/logger.cjs');
+
+export function simulateDeckSurvival({
+  globalDamageLevel = 0,
+  baseCardHpLevel = 0,
+  maxTicks = 1000,
+  enemyDamage = 7,
+  playerDamage = 2,
+  enemyHp = 30,
+  spawnDelay = 2
+} = {}) {
+  const deck = generateDeck();
+  deck.forEach(card => {
+    card.maxHp += baseCardHpLevel;
+    card.currentHp = card.maxHp;
+  });
+
+  let ticks = 0;
+  let delay = 0;
+  let eHp = enemyHp;
+  const dmgMulti = 1 + 0.1 * globalDamageLevel;
+
+  while (ticks < maxTicks && deck.some(c => c.currentHp > 0)) {
+    ticks++;
+    if (delay > 0) {
+      delay--;
+      continue;
+    }
+
+    // Player attacks first
+    eHp -= playerDamage * dmgMulti;
+    if (eHp <= 0) {
+      delay = spawnDelay;
+      eHp = enemyHp;
+      // heal surviving cards by 1 on kill
+      deck.forEach(c => {
+        if (c.currentHp > 0) {
+          c.currentHp = Math.min(c.maxHp, c.currentHp + 1);
+        }
+      });
+      continue;
+    }
+
+    // Enemy damages the first alive card
+    const target = deck.find(c => c.currentHp > 0);
+    if (target) target.takeDamage(enemyDamage);
+  }
+
+  return ticks;
+}
+
+export function runSurvivalMatrix({
+  globalDamageLevels = [0, 2, 4, 6, 8],
+  baseCardHpLevels = [0, 3],
+  ...params
+} = {}) {
+  const results = [];
+  globalDamageLevels.forEach(g => {
+    baseCardHpLevels.forEach(h => {
+      const ticks = simulateDeckSurvival({
+        globalDamageLevel: g,
+        baseCardHpLevel: h,
+        ...params
+      });
+      results.push({ globalDamageLevel: g, baseCardHpLevel: h, ticks });
+    });
+  });
+  saveCSV(results, 'survival-summary.csv');
+  return results;
+}

--- a/test/survival.test.cjs
+++ b/test/survival.test.cjs
@@ -1,0 +1,24 @@
+const { expect } = require('chai');
+
+describe('🛡️ Deck survival simulator', () => {
+  it('base deck falls within default range', async () => {
+    const { simulateDeckSurvival } = await import('../survival.js');
+    const ticks = simulateDeckSurvival({ globalDamageLevel: 0, baseCardHpLevel: 0 });
+    expect(ticks).to.be.at.least(80);
+    expect(ticks).to.be.below(110);
+  });
+
+  it('upgraded deck survives longer', async () => {
+    const { simulateDeckSurvival } = await import('../survival.js');
+    const ticks = simulateDeckSurvival({ globalDamageLevel: 8, baseCardHpLevel: 3 });
+    expect(ticks).to.be.above(120);
+    expect(ticks).to.be.below(150);
+  });
+
+  it('matrix helper generates summary', async () => {
+    const { runSurvivalMatrix } = await import('../survival.js');
+    const res = runSurvivalMatrix({ globalDamageLevels: [0, 2], baseCardHpLevels: [0] });
+    expect(res).to.have.length(2);
+    res.forEach(r => expect(r).to.have.keys(['globalDamageLevel', 'baseCardHpLevel', 'ticks']));
+  });
+});


### PR DESCRIPTION
## Summary
- create `survival.js` helper for damage-based deck survival
- generate CSV summaries for upgrade combos
- add mocha tests covering survival thresholds

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a164573588326a06b8ff1993d6336