### PR TITLE
Fix full reset for new run

### DIFF
--- a/script.js
+++ b/script.js
@@ -237,7 +237,7 @@ const unlockedJokers = [];
 // Load saved state if available
 loadGame();
 window.addEventListener("beforeunload", saveGame);
-setInterval(saveGame, 30000);
+const saveInterval = setInterval(saveGame, 30000);
 
 // attack progress bars
 let playerAttackFill = null;
@@ -1390,6 +1390,8 @@ function startNewGame() {
     if (typeof localStorage !== "undefined") {
         localStorage.removeItem("gameSave");
     }
+    window.removeEventListener("beforeunload", saveGame);
+    clearInterval(saveInterval);
     location.reload();
 }
 


### PR DESCRIPTION
## Summary
- store autosave interval so it can be cleared
- stop saving before reloading when starting a new game

## Testing
- `npm test` *(fails: `mocha: not found`)*
- `npm install` *(fails: puppeteer download 403)*

------
https://chatgpt.com/codex/tasks/task_e_684a231551d8832686e6786fded4c801