### PR TITLE
Add cash/sec and DPS displays

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,6 +50,7 @@
           Stage 1
         </div>
         <span id="kills">kills: 0</span>
+        <span id="cashPerSecDisplay">Cash/s: 0</span>
         <div class="dealerLifeDisplay">
           Life:10
         </div>
@@ -84,6 +85,9 @@
               </div>
               <div id="manaRegenDisplay">
                 Mana Regen: 0/s
+              </div>
+              <div id="dpsDisplay">
+                DPS: 0
               </div>
             </div>
           </div>

--- a/script.js
+++ b/script.js
@@ -224,6 +224,7 @@ const discardContainer = document.getElementsByClassName("discardContainer")[0];
 const dealerLifeDisplay =
     document.getElementsByClassName("dealerLifeDisplay")[0];
 const killsDisplay = document.getElementById("kills");
+const cashPerSecDisplay = document.getElementById("cashPerSecDisplay");
 const deckTabContainer = document.getElementsByClassName("deckTabContainer")[0];
 const dCardContainer = document.getElementsByClassName("dCardContainer")[0];
 const jokerContainers = document.querySelectorAll(".jokerContainer");
@@ -231,6 +232,7 @@ const manaBar = document.getElementById("manaBar");
 const manaFill = document.getElementById("manaFill");
 const manaText = document.getElementById("manaText");
 const manaRegenDisplay = document.getElementById("manaRegenDisplay");
+const dpsDisplay = document.getElementById("dpsDisplay");
 
 const unlockedJokers = [];
 
@@ -243,6 +245,9 @@ const saveInterval = setInterval(saveGame, 30000);
 let playerAttackFill = null;
 let enemyAttackFill = null;
 let playerAttackTimer = 0;
+let lastCash = cash;
+let cashTimer = 0;
+let cashPerSec = 0;
 
 //=========tabs==========
 
@@ -571,6 +576,10 @@ function renderPlayerStats(stats) {
     attackSpeedDisplay.textContent = `Attack Speed: ${Math.floor(stats.attackSpeed / 1000)}s`;
     if (manaRegenDisplay) {
         manaRegenDisplay.textContent = `Mana Regen: ${stats.manaRegen.toFixed(2)}/s`;
+    }
+    if (dpsDisplay) {
+        const dps = stats.pDamage / (stats.attackSpeed / 1000);
+        dpsDisplay.textContent = `DPS: ${dps.toFixed(2)}`;
     }
 
     // Update HP per kill display
@@ -1714,6 +1723,15 @@ function gameLoop(currentTime) {
 
     updateDrawButton();
     updatePlayerStats(stats);
+    cashTimer += deltaTime;
+    if (cashTimer >= 1000) {
+        cashPerSec = ((cash - lastCash) * 1000) / cashTimer;
+        lastCash = cash;
+        cashTimer = 0;
+        if (cashPerSecDisplay) {
+            cashPerSecDisplay.textContent = `Cash/s: ${cashPerSec.toFixed(2)}`;
+        }
+    }
     playerAttackTimer += deltaTime;
     if (playerAttackFill) {
         const pratio = Math.min(1, playerAttackTimer / stats.attackSpeed);

--- a/style.css
+++ b/style.css
@@ -295,6 +295,11 @@ body {
     font-size: 0.8rem;
 }
 
+#cashPerSecDisplay {
+    align-self: flex-start;
+    font-size: 0.8rem;
+}
+
 #dealerBarFill {
     height: 30px;
     width: 100%;


### PR DESCRIPTION
## Summary
- show Cash gained per second below kill counter
- show DPS in stats panel
- style the new cash-per-second output
- compute cash/sec and DPS dynamically in the game loop

## Testing
- `npm test` *(fails: mocha not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684a2b020498832683dec83360e632f5