### PR TITLE
Show average cash for each stage

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@
           Stage 1
         </div>
         <span id="kills">kills: 0</span>
-        <span id="cashPerSecDisplay">Cash/s: 0</span>
+        <span id="cashPerSecDisplay">Avg Cash: 0</span>
         <div class="dealerLifeDisplay">
           Life:10
         </div>

--- a/script.js
+++ b/script.js
@@ -246,10 +246,10 @@ const saveInterval = setInterval(saveGame, 30000);
 let playerAttackFill = null;
 let enemyAttackFill = null;
 let playerAttackTimer = 0;
-let lastCash = cash;
 let cashTimer = 0;
-let cashPerSec = 0;
-let cashDeltas = [];
+let stageCashSum = 0;
+let stageCashSamples = 0;
+let stageAverageTimer = 0;
 
 
 //=========tabs==========
@@ -765,6 +765,7 @@ function nextStage() {
     playerStats.stageKills[stageData.stage] = stageData.kills;
     stageData.stage += 1;
     stageData.kills = playerStats.stageKills[stageData.stage] || 0;
+    resetStageCashStats();
     killsDisplay.textContent = `Kills: ${stageData.kills}`;
     renderGlobalStats();
     nextStageChecker();
@@ -779,11 +780,23 @@ function nextWorld() {
     stageData.world += 1;
     stageData.stage = 1;
     stageData.kills = playerStats.stageKills[stageData.stage] || 0;
+    resetStageCashStats();
     killsDisplay.textContent = `Kills: ${stageData.kills}`;
     renderGlobalStats();
     nextStageChecker();
     renderStageInfo();
     checkUpgradeUnlocks();
+}
+
+// Reset tracking for average cash when a new stage begins
+function resetStageCashStats() {
+    stageCashSum = 0;
+    stageCashSamples = 0;
+    stageAverageTimer = 0;
+    cashTimer = 0;
+    if (cashPerSecDisplay) {
+        cashPerSecDisplay.textContent = "Avg Cash: 0";
+    }
 }
 
 // Enable the next stage button when kill requirements met
@@ -1724,6 +1737,7 @@ function loadGame() {
 // first strike doesn't trigger a full respawn
 spawnPlayer();
 spawnDealer();
+resetStageCashStats();
 renderStageInfo();
 nextStageChecker();
 checkUpgradeUnlocks();
@@ -1793,16 +1807,16 @@ function gameLoop(currentTime) {
     updatePlayerStats(stats);
     cashTimer += deltaTime;
     if (cashTimer >= 1000) {
-
-        const deltaCash = cash - lastCash;
-        lastCash = cash;
-        cashDeltas.push(deltaCash);
-        if (cashDeltas.length > 10) cashDeltas.shift();
-        const sum = cashDeltas.reduce((a, b) => a + b, 0);
-        cashPerSec = sum / Math.min(10, cashDeltas.length);
+        stageCashSum += cash;
+        stageCashSamples += 1;
+        stageAverageTimer += 1000;
         cashTimer = 0;
-        if (cashPerSecDisplay) {
-            cashPerSecDisplay.textContent = `Cash/s: ${cashPerSec.toFixed(2)}`;
+        if (stageAverageTimer >= 10000) {
+            const avgCash = stageCashSamples ? stageCashSum / stageCashSamples : 0;
+            if (cashPerSecDisplay) {
+                cashPerSecDisplay.textContent = `Avg Cash: ${avgCash.toFixed(2)}`;
+            }
+            stageAverageTimer = 0;
         }
     }
     playerAttackTimer += deltaTime;


### PR DESCRIPTION
## Summary
- track cash statistics for each stage
- reset the tracker when progressing to the next stage or world
- show `Avg Cash` in UI and refresh every ten seconds

## Testing
- `npm test` *(fails: Enemy Scaling Functions calculateEnemyHp)*

------
https://chatgpt.com/codex/tasks/task_e_684a3eefa724832695d285249d90a5f1