### PR TITLE
Update cash display to per-second

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@
           Stage 1
         </div>
         <span id="kills">kills: 0</span>
-        <span id="cashPerSecDisplay">Avg Cash: 0</span>
+        <span id="cashPerSecDisplay">Avg Cash/sec: 0</span>
         <div class="dealerLifeDisplay">
           Life:10
         </div>

--- a/script.js
+++ b/script.js
@@ -782,7 +782,7 @@ function resetStageCashStats() {
     stageAverageTimer = 0;
     cashTimer = 0;
     if (cashPerSecDisplay) {
-        cashPerSecDisplay.textContent = "Avg Cash: 0";
+        cashPerSecDisplay.textContent = "Avg Cash/sec: 0";
     }
 }
 
@@ -1803,7 +1803,7 @@ function gameLoop(currentTime) {
         if (stageAverageTimer >= 10000) {
             const avgCash = stageCashSamples ? stageCashSum / stageCashSamples : 0;
             if (cashPerSecDisplay) {
-                cashPerSecDisplay.textContent = `Avg Cash: ${avgCash.toFixed(2)}`;
+                cashPerSecDisplay.textContent = `Avg Cash/sec: ${avgCash.toFixed(2)}`;
             }
             stageAverageTimer = 0;
         }


### PR DESCRIPTION
## Summary
- clarify that cash displayed is averaged per second

## Testing
- `npm test` *(fails: calculateEnemyBasicDamage tests)*

------
https://chatgpt.com/codex/tasks/task_e_684a4cc14cd4832690b4e4b9192b7c53