### PR TITLE
Preserve HP boosts when cards level

### DIFF
--- a/card.js
+++ b/card.js
@@ -40,6 +40,7 @@ export class Card {
     this.damage = this.baseDamage;
     this.maxHp = value;
     this.currentHp = this.maxHp;
+    this.baseHpBoost = 0;
 
     // Amount of HP this card recovers each time an enemy is killed
     this.hpPerKill = 1;
@@ -63,7 +64,7 @@ export class Card {
     this.currentLevel++;
     this.XpReq += this.currentLevel * 1.7 * (this.value ** 2);
     this.damage = this.baseDamage * this.currentLevel;
-    this.maxHp = this.value * this.currentLevel;
+    this.maxHp = this.value * this.currentLevel + this.baseHpBoost;
     this.currentHp = this.maxHp;
   }
 

--- a/script.js
+++ b/script.js
@@ -110,6 +110,7 @@ const upgrades = {
             const diff = newBoost - prev;
             player.baseCardHpBoost = newBoost;
             pDeck.forEach(card => {
+                card.baseHpBoost = (card.baseHpBoost || 0) + diff;
                 card.maxHp += diff;
                 card.currentHp += diff;
             });
@@ -1613,6 +1614,7 @@ function saveGame() {
         damage: card.damage,
         maxHp: card.maxHp,
         currentHp: card.currentHp,
+        baseHpBoost: card.baseHpBoost,
         hpPerKill: card.hpPerKill,
         job: card.job,
         traits: card.traits
@@ -1681,6 +1683,7 @@ function loadGame() {
                     damage: data.damage,
                     maxHp: data.maxHp,
                     currentHp: data.currentHp,
+                    baseHpBoost: data.baseHpBoost || 0,
                     hpPerKill: data.hpPerKill,
                     job: data.job,
                     traits: data.traits

--- a/survival.js
+++ b/survival.js
@@ -14,6 +14,7 @@ export function simulateDeckSurvival({
 } = {}) {
   const deck = generateDeck();
   deck.forEach(card => {
+    card.baseHpBoost = (card.baseHpBoost || 0) + baseCardHpLevel;
     card.maxHp += baseCardHpLevel;
     card.currentHp = card.maxHp;
   });


### PR DESCRIPTION
## Summary
- track bonus HP on each `Card`
- apply base HP boost changes on upgrades
- include bonus HP when saving/loading
- ensure survival sim handles HP boosts

## Testing
- `npm test --silent` *(fails: calculateEnemyHp expectations)*

------
https://chatgpt.com/codex/tasks/task_e_684b430657a88326b699892a11f8b5ec