### PR TITLE
Adjust card growth and enemy HP scaling

### DIFF
--- a/card.js
+++ b/card.js
@@ -36,9 +36,10 @@ export class Card {
     this.XpCurrent = 0;
     this.XpReq = 1;
 
-    this.baseDamage = value;
+    const baseMultiplier = 1 + (value - 1) / 12;
+    this.baseDamage = 5 * baseMultiplier;
     this.damage = this.baseDamage;
-    this.maxHp = value;
+    this.maxHp = 5 * baseMultiplier;
     this.currentHp = this.maxHp;
     this.baseHpBoost = 0;
 
@@ -63,8 +64,9 @@ export class Card {
   levelUp() {
     this.currentLevel++;
     this.XpReq += this.currentLevel * 1.7 * (this.value ** 2);
-    this.damage = this.baseDamage * this.currentLevel;
-    this.maxHp = this.value * this.currentLevel + this.baseHpBoost;
+    this.damage = this.baseDamage + 5 * (this.currentLevel - 1);
+    const baseMultiplier = 1 + (this.value - 1) / 12;
+    this.maxHp = 5 * baseMultiplier + 5 * (this.currentLevel - 1) + this.baseHpBoost;
     this.currentHp = this.maxHp;
   }
 

--- a/script.js
+++ b/script.js
@@ -943,7 +943,10 @@ function updateDealerLifeDisplay() {
 // Determine how much health an enemy or boss should have
 function calculateEnemyHp(stage, world, isBoss = false) {
     const baseHp = 10 + stage;
-    return Math.floor(baseHp * (isBoss ? 10 * Math.pow((stage+10*(world-1)), 1.1): Math.pow((stage+10*(world-1)), 1.1)));
+    const effectiveStage = stage + 10 * (world - 1);
+    let hp = baseHp * Math.pow(effectiveStage, 3);
+    if (isBoss) hp *= 10;
+    return Math.floor(hp);
 }
 
 // Base damage output scaled by stage and world
@@ -1589,7 +1592,7 @@ function updatePlayerStats() {
         if (card.suit === "Diamonds")
             stats.cashMulti += Math.floor(Math.pow(card.currentLevel, 0.5));
 
-        card.damage = card.baseDamage * card.currentLevel;
+        card.damage = card.baseDamage + 5 * (card.currentLevel - 1);
         stats.pDamage += card.damage;
         stats.points += card.value;
     }

--- a/test/enemy.scaling.test.cjs
+++ b/test/enemy.scaling.test.cjs
@@ -16,13 +16,13 @@ describe('🧮 Enemy Scaling Functions', () => {
   describe('calculateEnemyHp', () => {
     const cases = [
       { stage: 1, world: 1, hp: 11 },
-      { stage: 1, world: 2, hp: 111 },
-      { stage: 5, world: 1, hp: 33 },
-      { stage: 5, world: 2, hp: 257 },
-      { stage: 10, world: 1, hp: 63 },
-      { stage: 10, world: 2, hp: 379 },
-      { stage: 15, world: 1, hp: 96 },
-      { stage: 15, world: 2, hp: 484 }
+      { stage: 1, world: 2, hp: 14641 },
+      { stage: 5, world: 1, hp: 1875 },
+      { stage: 5, world: 2, hp: 50625 },
+      { stage: 10, world: 1, hp: 20000 },
+      { stage: 10, world: 2, hp: 160000 },
+      { stage: 15, world: 1, hp: 84375 },
+      { stage: 15, world: 2, hp: 390625 }
     ];
 
     cases.forEach(({ stage, world, hp }) => {


### PR DESCRIPTION
## Summary
- rebalance card stats to use a smoother growth curve
- adjust damage calculations in the main update loop
- overhaul enemy HP scaling with a cubic stage/world formula
- update tests to new HP curve

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ccd356398832694e2073161899538