### PR TITLE
Update grid and card sizing for desktop

### DIFF
--- a/style.css
+++ b/style.css
@@ -564,7 +564,7 @@ body {
 
 .handContainer {
     display: grid;
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(90px, 1fr));
     justify-items: center;
     gap: 12px;
     padding: 2px 8px;
@@ -590,7 +590,7 @@ body {
     align-items: center;
     /*height: max-content;*/
     width: 100%;
-    max-width: 90px;
+    max-width: 120px;
     max-height: 120px;
 }
 
@@ -941,4 +941,10 @@ body {
     padding: 6px 12px;
     font-size: 1rem;
     cursor: pointer;
+}
+
+@media (min-width: 768px) {
+    .handContainer {
+        gap: 8px;
+    }
 }


### PR DESCRIPTION
## Summary
- improve `.handContainer` layout to use responsive columns
- allow wider cards by increasing `.card-wrapper` max width
- add media query to tweak hand gap on larger screens

## Testing
- `PUPPETEER_SKIP_DOWNLOAD=1 npm install`
- `npm test` *(fails: calculateEnemyHp tests)*

------
https://chatgpt.com/codex/tasks/task_e_684cce75a77c8326a48363b94a422a27