### PR TITLE
Reduce enemy HP growth

### DIFF
--- a/script.js
+++ b/script.js
@@ -972,7 +972,7 @@ function updateDealerLifeDisplay() {
 function calculateEnemyHp(stage, world, isBoss = false) {
   const baseHp = 10 + stage;
   const effectiveStage = stage + 10 * (world - 1);
-  let hp = baseHp * Math.pow(effectiveStage, 1.2);
+  let hp = baseHp * Math.pow(effectiveStage, 1.1);
   if (isBoss) hp *= 5;
   return Math.floor(hp);
 }

--- a/test/enemy.scaling.test.cjs
+++ b/test/enemy.scaling.test.cjs
@@ -16,13 +16,13 @@ describe('🧮 Enemy Scaling Functions', () => {
   describe('calculateEnemyHp', () => {
     const cases = [
       { stage: 1, world: 1, hp: 11 },
-      { stage: 1, world: 2, hp: 14641 },
-      { stage: 5, world: 1, hp: 1875 },
-      { stage: 5, world: 2, hp: 50625 },
-      { stage: 10, world: 1, hp: 20000 },
-      { stage: 10, world: 2, hp: 160000 },
-      { stage: 15, world: 1, hp: 84375 },
-      { stage: 15, world: 2, hp: 390625 }
+      { stage: 1, world: 2, hp: 153 },
+      { stage: 5, world: 1, hp: 88 },
+      { stage: 5, world: 2, hp: 294 },
+      { stage: 10, world: 1, hp: 251 },
+      { stage: 10, world: 2, hp: 539 },
+      { stage: 15, world: 1, hp: 491 },
+      { stage: 15, world: 2, hp: 862 }
     ];
 
     cases.forEach(({ stage, world, hp }) => {


### PR DESCRIPTION
## Summary
- decrease HP exponent in `calculateEnemyHp`
- update scaling test expectations

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ce9310d008326ace0d621e668c1bb