### PR TITLE
Round card HP to integers

### DIFF
--- a/card.js
+++ b/card.js
@@ -39,7 +39,7 @@ export class Card {
     const baseMultiplier = 1 + (value - 1) / 12;
     this.baseDamage = 5 * baseMultiplier;
     this.damage = this.baseDamage;
-    this.maxHp = 5 * baseMultiplier;
+    this.maxHp = Math.round(5 * baseMultiplier);
     this.currentHp = this.maxHp;
     this.baseHpBoost = 0;
 
@@ -66,12 +66,13 @@ export class Card {
     this.XpReq += this.currentLevel * 1.7 * (this.value ** 2);
     this.damage = this.baseDamage + 5 * (this.currentLevel - 1);
     const baseMultiplier = 1 + (this.value - 1) / 12;
-    this.maxHp = 5 * baseMultiplier + 5 * (this.currentLevel - 1) + this.baseHpBoost;
+    this.maxHp = Math.round(5 * baseMultiplier + 5 * (this.currentLevel - 1) + this.baseHpBoost);
     this.currentHp = this.maxHp;
   }
 
   healFromKill() {
-    this.currentHp = Math.min(this.maxHp, this.currentHp + this.hpPerKill);
+    const healed = Math.min(this.maxHp, this.currentHp + this.hpPerKill);
+    this.currentHp = Math.round(healed);
   }
 
   upgradeHpPerKill(amount = 1) {
@@ -79,7 +80,8 @@ export class Card {
   }
 
   takeDamage(amount) {
-    this.currentHp = Math.max(0, this.currentHp - amount);
+    const remaining = Math.max(0, this.currentHp - amount);
+    this.currentHp = Math.round(remaining);
   }
 
   isDefeated() {

--- a/script.js
+++ b/script.js
@@ -125,8 +125,8 @@ const upgrades = {
       player.baseCardHpBoost = newBoost;
       pDeck.forEach(card => {
         card.baseHpBoost = (card.baseHpBoost || 0) + diff;
-        card.maxHp += diff;
-        card.currentHp += diff;
+        card.maxHp = Math.round(card.maxHp + diff);
+        card.currentHp = Math.round(card.currentHp + diff);
       });
     }
   },
@@ -425,7 +425,7 @@ function renderTabCard(card) {
   cardPane.innerHTML = `
   <div class="card-value" style="color: ${card.color}">${card.value}</div>
   <div class="card-suit" style="color: ${card.color}">${card.symbol}</div>
-  <div class="card-hp">HP: ${card.currentHp}/${card.maxHp}</div>
+  <div class="card-hp">HP: ${Math.round(card.currentHp)}/${Math.round(card.maxHp)}</div>
   `;
 
   // 3) XP bar
@@ -492,12 +492,12 @@ function updateDeckDisplay() {
 
     // 3) Update HP in deck tab
     if (card.deckHpDisplay) {
-      card.deckHpDisplay.textContent = `HP: ${card.currentHp}/${card.maxHp}`;
+      card.deckHpDisplay.textContent = `HP: ${Math.round(card.currentHp)}/${Math.round(card.maxHp)}`;
     }
 
     // 4) If this card is currently on the field, update its HP too
     if (card.hpDisplay) {
-      card.hpDisplay.textContent = `HP: ${card.currentHp}/${card.maxHp}`;
+      card.hpDisplay.textContent = `HP: ${Math.round(card.currentHp)}/${Math.round(card.maxHp)}`;
     }
   });
 }
@@ -1029,14 +1029,14 @@ function cDealerDamage(damageAmount = null, ability = null, source = "dealer") {
   const card = drawnCards[0];
 
   // subtract **one** hit’s worth
-  card.currentHp = Math.max(0, card.currentHp - finalDamage);
+  card.currentHp = Math.round(Math.max(0, card.currentHp - finalDamage));
   addLog(
     `${source} hit ${card.value}${card.symbol} for ${finalDamage} damage!`,
     "damage"
   );
 
   // update its specific HP display
-  card.hpDisplay.textContent = `HP: ${card.currentHp}/${card.maxHp}`;
+  card.hpDisplay.textContent = `HP: ${Math.round(card.currentHp)}/${Math.round(card.maxHp)}`;
   updateDeckDisplay();
   if (card.wrapperElement) {
     animateCardHit(card);
@@ -1166,7 +1166,7 @@ function updateDrawButton() {
 function updateHandDisplay() {
   drawnCards.forEach(card => {
     if (!card || !card.hpDisplay) return; // Skip if card or elements are missing
-    card.hpDisplay.textContent = `HP: ${card.currentHp}/${card.maxHp}`;
+    card.hpDisplay.textContent = `HP: ${Math.round(card.currentHp)}/${Math.round(card.maxHp)}`;
     card.xpLabel.textContent = `LV: ${card.currentLevel}`;
     card.xpBarFill.style.width = `${(card.XpCurrent / card.XpReq) * 100}%`;
   });
@@ -1184,7 +1184,7 @@ function renderCard(card) {
   cardPane.innerHTML = `
   <div class="card-value" style="color: ${card.color}">${card.value}</div>
   <div class="card-suit" style="color: ${card.color}">${card.symbol}</div>
-  <div class="card-hp">HP: ${card.currentHp}/${card.maxHp}</div>
+  <div class="card-hp">HP: ${Math.round(card.currentHp)}/${Math.round(card.maxHp)}</div>
   `;
 
   // 3) XP bar
@@ -1239,14 +1239,13 @@ function heartHeal() {
 
   drawnCards.forEach(card => {
     if (card.suit === "Hearts") {
-      target.currentHp = Math.min(
-        target.currentHp + card.currentLevel,
-        target.maxHp
+      target.currentHp = Math.round(
+        Math.min(target.currentHp + card.currentLevel, target.maxHp)
       );
       animateCardHeal(target);
     }
   });
-  target.hpDisplay.textContent = `HP: ${target.currentHp}/${target.maxHp}`;
+  target.hpDisplay.textContent = `HP: ${Math.round(target.currentHp)}/${Math.round(target.maxHp)}`;
 }
 
 // Visual pulse when a card gains health
@@ -1367,9 +1366,9 @@ function useJoker(joker) {
       drawnCards.forEach(card => {
         if (!card) return;
         const before = card.currentHp;
-        card.currentHp = Math.min(card.maxHp, card.currentHp + healAmt);
+        card.currentHp = Math.round(Math.min(card.maxHp, card.currentHp + healAmt));
         if (card.currentHp > before) {
-          card.hpDisplay.textContent = `HP: ${card.currentHp}/${card.maxHp}`;
+          card.hpDisplay.textContent = `HP: ${Math.round(card.currentHp)}/${Math.round(card.maxHp)}`;
           animateCardHeal(card);
         }
       });

--- a/survival.js
+++ b/survival.js
@@ -15,7 +15,7 @@ export function simulateDeckSurvival({
   const deck = generateDeck();
   deck.forEach(card => {
     card.baseHpBoost = (card.baseHpBoost || 0) + baseCardHpLevel;
-    card.maxHp += baseCardHpLevel;
+    card.maxHp = Math.round(card.maxHp + baseCardHpLevel);
     card.currentHp = card.maxHp;
   });
 
@@ -39,7 +39,7 @@ export function simulateDeckSurvival({
       // heal surviving cards by 1 on kill
       deck.forEach(c => {
         if (c.currentHp > 0) {
-          c.currentHp = Math.min(c.maxHp, c.currentHp + 1);
+          c.currentHp = Math.round(Math.min(c.maxHp, c.currentHp + 1));
         }
       });
       continue;


### PR DESCRIPTION
## Summary
- round max HP when creating cards
- round HP when cards level up, heal, and take damage
- round HP effects from Base Card HP boost upgrade
- display rounded HP values in deck and hand UI
- update survival simulator to keep HP as integers

## Testing
- `npm test --silent` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cf3669f1083269a791227d5dbca22