### PR TITLE
Fix worlds tab visibility

### DIFF
--- a/style.css
+++ b/style.css
@@ -951,7 +951,11 @@ body {
 
 /* worlds menu */
 .worldsTab {
-    display: none;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    background-color: #556b7a;
+    padding: 5px;
 }
 .world-entry {
     margin-bottom: 8px;


### PR DESCRIPTION
## Summary
- fix CSS so Worlds tab is visible when selected

## Testing
- `npm test` *(fails: `mocha` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684da91af3a483269bce33f0f5196291