### PR TITLE
Improve cash rate tracking

### DIFF
--- a/test/cashRateTracker.test.cjs
+++ b/test/cashRateTracker.test.cjs
@@ -1,0 +1,20 @@
+const { expect } = require('chai');
+
+describe('💰 CashRateTracker', () => {
+  it('calculates cash per second over sliding window', async () => {
+    const { CashRateTracker } = await import('../utils/cashRateTracker.js');
+    const tracker = new CashRateTracker(5000); // 5s window
+
+    tracker.record(0, 0);
+    tracker.record(10, 1000); // +10 after 1s
+    tracker.record(20, 2000); // +10 after another 1s
+
+    const rate1 = tracker.getRate(2000);
+    expect(rate1).to.be.closeTo(10, 0.001);
+
+    tracker.record(30, 6000); // +10 after 4s; first sample (0) is out of window
+    const rate2 = tracker.getRate(6000);
+    // now window from t=1000..6000: cash 10->30 over 5s => 4/sec
+    expect(rate2).to.be.closeTo(4, 0.001);
+  });
+});

--- a/utils/cashRateTracker.js
+++ b/utils/cashRateTracker.js
@@ -1,0 +1,35 @@
+export class CashRateTracker {
+  constructor(windowMs = 10000) {
+    this.windowMs = windowMs;
+    this.samples = [];
+  }
+
+  record(cash, time = Date.now()) {
+    this.samples.push({ time, cash });
+    this.prune(time);
+  }
+
+  prune(now = Date.now()) {
+    const cutoff = now - this.windowMs;
+    while (this.samples.length && this.samples[0].time < cutoff) {
+      this.samples.shift();
+    }
+  }
+
+  getRate(now = Date.now()) {
+    this.prune(now);
+    if (this.samples.length < 2) return 0;
+    const first = this.samples[0];
+    const last = this.samples[this.samples.length - 1];
+    const deltaCash = last.cash - first.cash;
+    const deltaTime = last.time - first.time;
+    return deltaTime > 0 ? deltaCash / (deltaTime / 1000) : 0;
+  }
+
+  reset(initialCash = 0, time = Date.now()) {
+    this.samples = [];
+    this.record(initialCash, time);
+  }
+}
+
+export default CashRateTracker;


### PR DESCRIPTION
## Summary
- add `CashRateTracker` utility for sliding-window cash rate
- integrate tracker into `script.js` and update UI logic
- track cash events on load, stage reset, and manual cash gain
- add unit test verifying tracker math

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684dc93e2ce883269d3696a8a173593f