### PR TITLE
Fix card layout to keep three per row

### DIFF
--- a/style.css
+++ b/style.css
@@ -569,7 +569,7 @@ body {
 
 .handContainer {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(90px, 1fr));
+    grid-template-columns: repeat(3, minmax(0, 1fr));
     justify-items: center;
     gap: 12px;
     padding: 2px 8px;


### PR DESCRIPTION
## Summary
- adjust hand container grid to always use three columns

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dcd5690c083269141a734cbba6ad7