### PR TITLE
Implement upgrade tab with new bar upgrades

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,9 +35,10 @@
     </div>
 
     <!---tabs container--->
-    <div class=tabsContainer>
+    <div class="tabsContainer">
       <button class="mainTabButton">main</button>
       <button class="deckTabButton">deck</button>
+      <button class="upgradesTabButton">upgrades</button>
       <button class="starChartTabButton">star chart</button>
       <button class="playerStatsTabButton">stats</button>
       <button class="worldTabButton">worlds</button>
@@ -93,17 +94,6 @@
             </div>
           </div>
         </div>
-        <div class="vignette upgrades">
-          <button class="vignette-toggle">Upgrades</button>
-          <div class="casino-section vignette-content">
-            <div class="upgrade-list">
-              <div class="upgrade-item">
-                <span>Test Upgrade</span>
-                <button>Buy</button>
-              </div>
-            </div>
-          </div>
-        </div>
         <div class="vignette log">
           <button class="vignette-toggle">Log</button>
           <div class="casino-section vignette-content" id="log-panel">
@@ -153,6 +143,25 @@
         <div class="vignette-content">
           <div class="jokerContainer"></div>
         </div>
+      </div>
+    </div>
+    <div class="upgradesTab">
+      <div id="upgradePowerDisplay">Upgrade Power: 0</div>
+      <div class="bar-upgrades">
+        <div class="bar-upgrade" data-key="damage">
+          <div class="bar-label">Damage Lv. <span class="level">0</span> (<span class="mult">×1.0</span>)</div>
+          <div class="bar"><div class="fill"></div></div>
+          <button class="invest">Invest</button>
+        </div>
+        <div class="bar-upgrade" data-key="maxHp">
+          <div class="bar-label">Max HP Lv. <span class="level">0</span> (<span class="mult">×1.0</span>)</div>
+          <div class="bar"><div class="fill"></div></div>
+          <button class="invest">Invest</button>
+        </div>
+      </div>
+      <div class="card-upgrades">
+        <h4>Card Upgrades</h4>
+        <div class="card-upgrade-slots"></div>
       </div>
     </div>
     <div class="starChartTab">

--- a/style.css
+++ b/style.css
@@ -986,3 +986,57 @@ body {
     font-size: 12px;
     margin-left: 4px;
 }
+
+/* Upgrades tab */
+.upgradesTab {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    background-color: #7a6699;
+    padding: 5px;
+}
+
+.bar-upgrade {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    margin-bottom: 6px;
+}
+
+.bar-upgrade .bar {
+    position: relative;
+    width: 100%;
+    height: 12px;
+    background: #222;
+    border: 1px solid #555;
+    border-radius: 4px;
+    overflow: hidden;
+}
+
+.bar-upgrade .fill {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: 0;
+    background: linear-gradient(90deg, #4caf50, #81c784);
+}
+
+.bar-upgrade .invest {
+    width: 60px;
+    font-size: 0.6rem;
+    padding: 2px;
+}
+
+.card-upgrade-slots {
+    display: flex;
+    gap: 6px;
+}
+
+.card-upgrade-slots div {
+    padding: 4px;
+    border: 1px solid #333;
+    background: #ccc;
+    font-size: 0.6rem;
+    border-radius: 4px;
+}


### PR DESCRIPTION
## Summary
- add Upgrades tab in UI with bar upgrades and card upgrade slots
- implement basic bar upgrade logic using Upgrade Power
- save/load Upgrade Power and bar upgrade data
- hook up debug helpers for upgrade power and upgrade cards

## Testing
- `npm test` *(fails: `mocha` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dd7cdefb0832696a31c8b50dc0789