### PR TITLE
Improve tracker utilities

### DIFF
--- a/test/cashRateTracker.test.cjs
+++ b/test/cashRateTracker.test.cjs
@@ -1,0 +1,20 @@
+const { expect } = require('chai');
+
+describe('💰 CashRateTracker', () => {
+  it('calculates cash per second over sliding window', async () => {
+    const { CashRateTracker } = await import('../utils/trackers.js');
+    const tracker = new CashRateTracker(5000); // 5s window
+
+    tracker.record(0, 0);
+    tracker.record(10, 1000); // +10 after 1s
+    tracker.record(20, 2000); // +10 after another 1s
+
+    const rate1 = tracker.getRate(2000);
+    expect(rate1).to.be.closeTo(10, 0.001);
+
+    tracker.record(30, 6000); // +10 after 4s; first sample (0) is out of window
+    const rate2 = tracker.getRate(6000);
+    // now window from t=1000..6000: cash 10->30 over 5s => 4/sec
+    expect(rate2).to.be.closeTo(4, 0.001);
+  });
+});

--- a/test/worldProgressTracker.test.cjs
+++ b/test/worldProgressTracker.test.cjs
@@ -1,0 +1,12 @@
+const { expect } = require('chai');
+
+describe('🌎 WorldProgressTracker', () => {
+  it('computes weighted progress', async () => {
+    const { WorldProgressTracker } = await import('../utils/trackers.js');
+    const progress = { 1: { stageKills: {} } };
+    const tracker = new WorldProgressTracker(progress, 10, s => s); // simple weight
+    tracker.record(1, 1); // weight 1
+    tracker.record(1, 2); // weight 2
+    expect(tracker.compute(1)).to.be.closeTo(0.3, 0.001);
+  });
+});

--- a/utils/trackers.js
+++ b/utils/trackers.js
@@ -1,0 +1,58 @@
+export class CashRateTracker {
+  constructor(windowMs = 10000) {
+    this.windowMs = windowMs;
+    this.samples = [];
+  }
+
+  record(cash, time = Date.now()) {
+    this.samples.push({ time, cash });
+    this.prune(time);
+  }
+
+  prune(now = Date.now()) {
+    const cutoff = now - this.windowMs;
+    while (this.samples.length && this.samples[0].time < cutoff) {
+      this.samples.shift();
+    }
+  }
+
+  getRate(now = Date.now()) {
+    this.prune(now);
+    if (this.samples.length < 2) return 0;
+    const first = this.samples[0];
+    const last = this.samples[this.samples.length - 1];
+    const deltaCash = last.cash - first.cash;
+    const deltaTime = last.time - first.time;
+    return deltaTime > 0 ? deltaCash / (deltaTime / 1000) : 0;
+  }
+
+  reset(initialCash = 0, time = Date.now()) {
+    this.samples = [];
+    this.record(initialCash, time);
+  }
+}
+
+export class WorldProgressTracker {
+  constructor(progressData = {}, target = 1820, stageWeightFn = s => (s <= 10 ? s : 10 + Math.sqrt(s - 10))) {
+    this.progressData = progressData;
+    this.target = target;
+    this.stageWeightFn = stageWeightFn;
+  }
+
+  record(world, stage, count = 1) {
+    const data = this.progressData[world];
+    if (!data) return;
+    data.stageKills[stage] = (data.stageKills[stage] || 0) + count;
+  }
+
+  compute(world) {
+    const data = this.progressData[world];
+    if (!data) return 0;
+    let weight = 0;
+    for (const [stage, kills] of Object.entries(data.stageKills)) {
+      weight += this.stageWeightFn(parseInt(stage)) * kills;
+    }
+    return Math.min(weight / this.target, 1);
+  }
+}
+


### PR DESCRIPTION
## Summary
- merge `WorldProgressTracker` with cash rate tracker
- integrate new tracker into `script.js`
- restore upgrade level increment
- add unit tests for world progress tracking

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684dc93e2ce883269d3696a8a173593f