### PR TITLE
Fix syntax error in gameLoop

### DIFF
--- a/script.js
+++ b/script.js
@@ -1953,11 +1953,10 @@ const avgCash = cashRateTracker.getRate();
 if (cashPerSecDisplay) {
   cashPerSecDisplay.textContent = `Avg Cash/sec: ${avgCash.toFixed(2)}`;
 }
-}
 playerAttackTimer += deltaTime;
 if (playerAttackFill) {
-const pratio = Math.min(1, playerAttackTimer / stats.attackSpeed);
-playerAttackFill.style.width = `${pratio * 100}%`;
+  const pratio = Math.min(1, playerAttackTimer / stats.attackSpeed);
+  playerAttackFill.style.width = `${pratio * 100}%`;
 }
 if (playerAttackTimer >= stats.attackSpeed) {
 attack();


### PR DESCRIPTION
## Summary
- remove stray closing bracket inside `gameLoop`

## Testing
- `node --check script.js`
- `node script.js` *(fails: document is not defined)*
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dddca81d88326899faeaf45e7b45e