### PR TITLE
Improve tracker utilities

### DIFF
--- a/script.js
+++ b/script.js
@@ -18,7 +18,7 @@ import {
 import {
   initStarChart
 } from "./starChart.js"; // optional star chart tab
-
+import { CashRateTracker, WorldProgressTracker } from "./utils/trackers.js";
 
 // --- Game State ---
 // `drawnCards` holds the cards currently in the player's hand
@@ -31,6 +31,7 @@ const cardBackImages = {
 };
 // resources and progress trackers
 let cash = 0;
+const cashRateTracker = new CashRateTracker();
 let cardPoints = 0;
 let currentEnemy = null;
 
@@ -92,6 +93,7 @@ Object.keys(BossTemplates).forEach(id => {
     stageKills: {}
   };
 });
+const worldProgressTracker = new WorldProgressTracker(worldProgress, WORLD_PROGRESS_TARGET, stageWeight);
 
 const playerStats = {
   timesPrestiged: 0,
@@ -286,10 +288,6 @@ let playerAttackFill = null;
 let enemyAttackFill = null;
 let playerAttackTimer = 0;
 let enemyAttackProgress = 0; // carryover ratio of enemy attack timer
-let cashTimer = 0;
-let stageCashSum = 0;
-let stageCashSamples = 0;
-let stageAverageTimer = 0;
 
 
 //=========tabs==========
@@ -430,6 +428,7 @@ function purchaseUpgrade(key) {
   cash -= cost;
   cashDisplay.textContent = `Cash: $${cash}`;
   up.level += 1;
+
   up.effect(stats);
   if (key === "cardSlots") {
     while (drawnCards.length < stats.cardSlots && deck.length > 0) {
@@ -804,20 +803,12 @@ function showDamageFloat(card, amount) {
 //=========stage functions===========
 
 function recordWorldKill(world, stage) {
-  const data = worldProgress[world];
-  if (!data) return;
-  data.stageKills[stage] = (data.stageKills[stage] || 0) + 1;
+  worldProgressTracker.record(world, stage);
   updateWorldProgressUI(world);
 }
 
 function computeWorldProgress(id) {
-  const data = worldProgress[id];
-  if (!data) return 0;
-  let weight = 0;
-  for (const [stage, kills] of Object.entries(data.stageKills)) {
-    weight += stageWeight(parseInt(stage)) * kills;
-  }
-  return Math.min(weight / WORLD_PROGRESS_TARGET, 1);
+  return worldProgressTracker.compute(id);
 }
 
 function updateWorldProgressUI(id) {
@@ -903,14 +894,13 @@ function nextWorld() {
 
 // Reset tracking for average cash when a new stage begins
 function resetStageCashStats() {
-  stageCashSum = 0;
-  stageCashSamples = 0;
-  stageAverageTimer = 0;
-  cashTimer = 0;
+  cashRateTracker.reset(cash);
   if (cashPerSecDisplay) {
     cashPerSecDisplay.textContent = "Avg Cash/sec: 0";
   }
 }
+
+
 
 // Enable the next stage button when kill requirements met
 function nextStageChecker() {
@@ -1552,6 +1542,7 @@ function respawnPlayer() {
   deck.forEach(card => renderTabCard(card));
 
   cashDisplay.textContent = `Cash: $${cash}`;
+
   updateUpgradeButtons();
   renderStageInfo();
 
@@ -1687,6 +1678,8 @@ stats.points *
 stats.cashMulti
 );
 cashDisplay.textContent = `Cash: $${cash}`;
+
+  cashRateTracker.record(cash);
 updateUpgradeButtons();
 return cash;
 }
@@ -1777,6 +1770,7 @@ try {
 const state = JSON.parse(json);
 cash = state.cash || 0;
 cardPoints = state.cardPoints || 0;
+  cashRateTracker.reset(cash);
 Object.assign(stats, state.stats || {});
 systems.manaUnlocked = (state.stats && state.stats.maxMana > 0);
 Object.assign(stageData, state.stageData || {});
@@ -1831,6 +1825,7 @@ if (j) unlockedJokers.push(j);
 Object.values(upgrades).forEach(u => u.effect(stats));
 
 cashDisplay.textContent = `Cash: $${cash}`;
+
 cardPointsDisplay.textContent = `Card Points: ${cardPoints}`;
 
 renderUpgrades();
@@ -1935,18 +1930,9 @@ overlay.style.setProperty("--cooldown", ratio);
 
 updateDrawButton();
 updatePlayerStats(stats);
-cashTimer += deltaTime;
-if (cashTimer >= 1000) {
-stageCashSum += cash;
-stageCashSamples += 1;
-stageAverageTimer += 1000;
-cashTimer = 0;
-if (stageAverageTimer >= 10000) {
-const avgCash = stageCashSamples ? stageCashSum / stageCashSamples: 0;
+const avgCash = cashRateTracker.getRate(Date.now(), cash);
 if (cashPerSecDisplay) {
-cashPerSecDisplay.textContent = `Avg Cash/sec: ${avgCash.toFixed(2)}`;
-}
-stageAverageTimer = 0;
+  cashPerSecDisplay.textContent = `Avg Cash/sec: ${avgCash.toFixed(2)}`;
 }
 }
 playerAttackTimer += deltaTime;
@@ -2012,8 +1998,10 @@ advanceStage: () => nextStage(),
 giveCash: () => {
 const amount =
 parseInt(document.getElementById("debugCash").value) || 0;
-cash += amount;
-cashDisplay.textContent = `Cash: $${cash}`;
+  cash += amount;
+  cashRateTracker.record(cash);
+  cashDisplay.textContent = `Cash: $${cash}`;
+
 updateUpgradeButtons();
 },
 

--- a/test/cashRateTracker.test.cjs
+++ b/test/cashRateTracker.test.cjs
@@ -1,0 +1,20 @@
+const { expect } = require('chai');
+
+describe('💰 CashRateTracker', () => {
+  it('calculates cash per second over sliding window', async () => {
+    const { CashRateTracker } = await import('../utils/trackers.js');
+    const tracker = new CashRateTracker(5000); // 5s window
+
+    tracker.record(0, 0);
+    tracker.record(10, 1000); // +10 after 1s
+    tracker.record(20, 2000); // +10 after another 1s
+
+    const rate1 = tracker.getRate(2000, 20);
+    expect(rate1).to.be.closeTo(10, 0.001);
+
+    tracker.record(30, 6000); // +10 after 4s; first sample (0) is out of window
+    const rate2 = tracker.getRate(6000, 30);
+    // now window from t=1000..6000: cash 10->30 over 5s => 4/sec
+    expect(rate2).to.be.closeTo(4, 0.001);
+  });
+});

--- a/test/worldProgressTracker.test.cjs
+++ b/test/worldProgressTracker.test.cjs
@@ -1,0 +1,12 @@
+const { expect } = require('chai');
+
+describe('🌎 WorldProgressTracker', () => {
+  it('computes weighted progress', async () => {
+    const { WorldProgressTracker } = await import('../utils/trackers.js');
+    const progress = { 1: { stageKills: {} } };
+    const tracker = new WorldProgressTracker(progress, 10, s => s); // simple weight
+    tracker.record(1, 1); // weight 1
+    tracker.record(1, 2); // weight 2
+    expect(tracker.compute(1)).to.be.closeTo(0.3, 0.001);
+  });
+});

--- a/utils/trackers.js
+++ b/utils/trackers.js
@@ -1,0 +1,57 @@
+export class CashRateTracker {
+  constructor(windowMs = 10000) {
+    this.windowMs = windowMs;
+    this.samples = [];
+  }
+
+  record(cash, time = Date.now()) {
+    this.samples.push({ time, cash });
+    this.prune(time);
+  }
+
+  prune(now = Date.now()) {
+    const cutoff = now - this.windowMs;
+    while (this.samples.length && this.samples[0].time < cutoff) {
+      this.samples.shift();
+    }
+  }
+
+  getRate(now = Date.now(), currentCash = this.samples.length ? this.samples[this.samples.length - 1].cash : 0) {
+    this.prune(now);
+    if (!this.samples.length) return 0;
+    const first = this.samples[0];
+    const deltaCash = currentCash - first.cash;
+    const deltaTime = now - first.time;
+    return deltaTime > 0 ? deltaCash / (deltaTime / 1000) : 0;
+  }
+
+  reset(initialCash = 0, time = Date.now()) {
+    this.samples = [];
+    this.record(initialCash, time);
+  }
+}
+
+export class WorldProgressTracker {
+  constructor(progressData = {}, target = 1820, stageWeightFn = s => (s <= 10 ? s : 10 + Math.sqrt(s - 10))) {
+    this.progressData = progressData;
+    this.target = target;
+    this.stageWeightFn = stageWeightFn;
+  }
+
+  record(world, stage, count = 1) {
+    const data = this.progressData[world];
+    if (!data) return;
+    data.stageKills[stage] = (data.stageKills[stage] || 0) + count;
+  }
+
+  compute(world) {
+    const data = this.progressData[world];
+    if (!data) return 0;
+    let weight = 0;
+    for (const [stage, kills] of Object.entries(data.stageKills)) {
+      weight += this.stageWeightFn(parseInt(stage)) * kills;
+    }
+    return Math.min(weight / this.target, 1);
+  }
+}
+


### PR DESCRIPTION
## Summary
- merge `WorldProgressTracker` with cash rate tracker
- integrate new tracker into `script.js`
- restore upgrade level increment
- add unit tests for world progress tracking
- improve cash rate tracker calculations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684dc93e2ce883269d3696a8a173593f