### PR TITLE
Fix mana bar not activating after claiming joker

### DIFF
--- a/script.js
+++ b/script.js
@@ -1307,6 +1307,10 @@ function healCardsOnKill() {
 
 function renderJokers() {
   if (!jokerContainers.length) return;
+  // Ensure mana system activates once the Healing Joker is obtained
+  if (unlockedJokers.some(j => j.id === "joker_heal") && !systems.manaUnlocked) {
+    unlockManaSystem();
+  }
 
   jokerContainers.forEach(container => {
     container.innerHTML = "";


### PR DESCRIPTION
## Summary
- activate mana system automatically when Healing Joker is present

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684dee081900832687836317e6955088