### PR TITLE
Fix mana unlock persistence on load

### DIFF
--- a/script.js
+++ b/script.js
@@ -1868,10 +1868,18 @@ deck = [...pDeck];
 
 unlockedJokers.length = 0;
 if (Array.isArray(state.unlockedJokers)) {
-state.unlockedJokers.forEach(id => {
-const j = AllJokerTemplates.find(t => t.id === id);
-if (j) unlockedJokers.push(j);
-});
+  state.unlockedJokers.forEach(id => {
+    const j = AllJokerTemplates.find(t => t.id === id);
+    if (j) unlockedJokers.push(j);
+  });
+}
+
+// ensure mana system initializes if the healing joker was saved
+if (
+  !systems.manaUnlocked &&
+  unlockedJokers.find(j => j.id === "joker_heal")
+) {
+  unlockManaSystem();
 }
 
 Object.values(upgrades).forEach(u => u.effect(stats));


### PR DESCRIPTION
## Summary
- ensure the mana system initializes when loading a save that already has the Healing Joker

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_684df1773f2083268e42826c8d3f5ca2