### PR TITLE
Add basic upgrades tab with upgrade power

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,6 +40,7 @@
       <button class="deckTabButton">deck</button>
       <button class="starChartTabButton">star chart</button>
       <button class="playerStatsTabButton">stats</button>
+      <button class="upgradesTabButton">upgrades</button>
       <button class="worldTabButton">worlds</button>
     </div>
 
@@ -93,17 +94,6 @@
             </div>
           </div>
         </div>
-        <div class="vignette upgrades">
-          <button class="vignette-toggle">Upgrades</button>
-          <div class="casino-section vignette-content">
-            <div class="upgrade-list">
-              <div class="upgrade-item">
-                <span>Test Upgrade</span>
-                <button>Buy</button>
-              </div>
-            </div>
-          </div>
-        </div>
         <div class="vignette log">
           <button class="vignette-toggle">Log</button>
           <div class="casino-section vignette-content" id="log-panel">
@@ -153,6 +143,14 @@
         <div class="vignette-content">
           <div class="jokerContainer"></div>
         </div>
+      </div>
+    </div>
+    <div class="upgradesTab">
+      <div id="upgradePowerDisplay">Upgrade Power: 0</div>
+      <div class="bar-upgrades"></div>
+      <div class="card-upgrades">
+        <h3>Card Upgrades</h3>
+        <div class="card-upgrade-list"></div>
       </div>
     </div>
     <div class="starChartTab">

--- a/style.css
+++ b/style.css
@@ -821,6 +821,14 @@ body {
     padding: 5px;
 }
 
+.upgradesTab {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    background-color: #5c5c5c;
+    padding: 5px;
+}
+
 /* Joker container and tiles */
 .joker-wrapper {
     max-width: 90px;
@@ -921,6 +929,37 @@ body {
 
 .upgrade-item.unaffordable {
     opacity: 0.5;
+}
+
+.bar-upgrades {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    margin-top: 4px;
+}
+.bar-upgrade {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+.bar {
+    width: 100%;
+    height: 8px;
+    background: #444;
+    border-radius: 4px;
+    overflow: hidden;
+}
+.bar-fill {
+    height: 100%;
+    width: 0%;
+    background: #4caf50;
+}
+.bar-info {
+    font-size: 0.6rem;
+}
+.bar-invest-btn {
+    width: 60px;
+    font-size: 0.6rem;
 }
 
 .restart-overlay {


### PR DESCRIPTION
## Summary
- add a new **Upgrades** tab and remove upgrades from the main panel
- implement simple bar upgrades powered by new Upgrade Power resource
- persist bar upgrade state across saves
- allocate Upgrade Power on enemy and boss defeats
- style UI for new upgrade bars

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684df7b3257c8326b0eaddfdbffdc4a6