### PR TITLE
Refactor upgrade system

### DIFF
--- a/index.html
+++ b/index.html
@@ -147,6 +147,7 @@
     </div>
     <div class="upgradesTab">
       <div id="upgradePowerDisplay">Upgrade Power: 0</div>
+      <button id="buyUpgradePowerBtn">Buy Upgrade Point ($50)</button>
       <div class="bar-upgrades"></div>
       <div class="card-upgrades">
         <h3>Card Upgrades</h3>

--- a/style.css
+++ b/style.css
@@ -823,7 +823,7 @@ body {
 
 .upgradesTab {
     display: flex;
-    flex-direction: column;
+    flex-direction: row;
     gap: 10px;
     background-color: #5c5c5c;
     padding: 5px;
@@ -936,6 +936,7 @@ body {
     flex-direction: column;
     gap: 4px;
     margin-top: 4px;
+    flex: 1;
 }
 .bar-upgrade {
     display: flex;
@@ -957,9 +958,37 @@ body {
 .bar-info {
     font-size: 0.6rem;
 }
-.bar-invest-btn {
-    width: 60px;
-    font-size: 0.6rem;
+
+.card-upgrades {
+    flex: 1;
+}
+
+.bar-controls {
+    display: flex;
+    gap: 4px;
+    align-items: center;
+}
+
+.bar-controls button {
+    width: 20px;
+    height: 20px;
+    padding: 0;
+    font-size: 0.7rem;
+}
+
+.bar-points {
+    min-width: 20px;
+    text-align: center;
+    font-size: 0.7rem;
+}
+
+.upgrade-card {
+    background: #333;
+    padding: 4px;
+    margin-bottom: 4px;
+    color: #fff;
+    font-size: 0.7rem;
+    border-radius: 4px;
 }
 
 .restart-overlay {


### PR DESCRIPTION
## Summary
- allow buying upgrade points with cash using a new button
- allocate points to damage and HP bars with +/- controls
- bars now passively fill based on allocated points
- display card upgrade list and arrange upgrade tab horizontally
- persist upgrade point purchases in save data

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e03f3ddb083268ed150fabe0c7ce5