### PR TITLE
Fix cash rewards

### DIFF
--- a/script.js
+++ b/script.js
@@ -1937,18 +1937,15 @@ renderDealerLifeBarFill();
 
 // Convert points earned this stage into spendable cash
 function cashOut() {
-  // Only convert points earned since the last cash out
-  const newPoints = Math.max(0, stats.points - lastCashOutPoints);
-  if (newPoints === 0) return cash;
-
-  cash = Math.floor(
-    cash +
-    newPoints *
+  // Reward cash based on current card points and stage multiplier
+  const reward = Math.floor(
+    stats.points *
     (1 + Math.pow(stageData.stage, 0.5)) *
     stats.cashMulti
   );
+  if (reward <= 0) return cash;
 
-  lastCashOutPoints = stats.points;
+  cash += reward;
   cashDisplay.textContent = `Cash: $${cash}`;
   cashRateTracker.record(cash);
   updateUpgradeButtons();


### PR DESCRIPTION
## Summary
- simplify `cashOut()` so each kill grants cash

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e6678fbe48326a6360b65dbe82307