### PR TITLE
Upgrade tab layout overhaul and purchasable card upgrades

### DIFF
--- a/index.html
+++ b/index.html
@@ -145,11 +145,13 @@
         </div>
       </div>
     </div>
-    <div class="upgradesTab">
-      <div id="upgradePowerDisplay">Upgrade Power: 0</div>
-      <button id="buyUpgradePowerBtn">Buy Upgrade Point ($50)</button>
-      <div class="bar-upgrades"></div>
-      <div class="card-upgrades">
+    <div class="upgradesTab casino-section">
+      <div class="bar-upgrades-container casino-section">
+        <div id="upgradePowerDisplay">Upgrade Power: 0</div>
+        <button id="buyUpgradePowerBtn">Buy Upgrade Point ($50)</button>
+        <div class="bar-upgrades"></div>
+      </div>
+      <div class="card-upgrades-container casino-section">
         <h3>Card Upgrades</h3>
         <div class="card-upgrade-list"></div>
       </div>

--- a/style.css
+++ b/style.css
@@ -823,11 +823,24 @@ body {
 
 .upgradesTab {
     display: flex;
-    flex-direction: column; /* stack upgrade UI vertically */
-    gap: 6px;
+    gap: 10px;
     background-color: #5c5c5c;
     padding: 5px;
-    align-items: flex-start;
+}
+
+.bar-upgrades-container {
+    width: 33%;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.card-upgrades-container {
+    width: 67%;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    overflow-y: auto;
 }
 
 /* Reduce button padding so bars remain visible */
@@ -948,8 +961,8 @@ body {
 }
 .bar-upgrade {
     display: flex;
-    flex-direction: column;
-    gap: 2px;
+    align-items: center;
+    gap: 6px;
 }
 .bar {
     width: 100%;
@@ -957,6 +970,11 @@ body {
     background: #444;
     border-radius: 4px;
     overflow: hidden;
+}
+
+.bar-label {
+    width: 60px;
+    font-size: 0.7rem;
 }
 .bar-fill {
     height: 100%;
@@ -967,14 +985,17 @@ body {
     font-size: 0.6rem;
 }
 
-.card-upgrades {
-    flex: 1;
+.card-upgrade-list {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(90px, 1fr));
+    gap: 8px;
 }
 
 .bar-controls {
     display: flex;
     gap: 4px;
     align-items: center;
+    margin-left: auto;
 }
 
 .bar-controls button {
@@ -997,6 +1018,28 @@ body {
     color: #fff;
     font-size: 0.7rem;
     border-radius: 4px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 4px;
+}
+.upgrade-card button {
+    width: 100%;
+    padding: 2px 4px;
+    font-size: 0.7rem;
+    background: linear-gradient(135deg, #e8ffe8, #c8facc);
+    border: 1px solid #4caf50;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+.upgrade-popup {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    z-index: 2000;
+    pointer-events: none;
 }
 
 .restart-overlay {


### PR DESCRIPTION
## Summary
- refactor upgrades tab into side-by-side bar and card sections
- style upgrades tab with casino theme and adjust bar controls
- implement purchasable card upgrades rendered as cards
- show upgrade card popup when drawn
- compute costs based on stage 9 payout and rarity

## Testing
- `npm test` *(fails: mocha not found)*
- `npx eslint .` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_684e7356752483268e1e16744b84d436