### PR TITLE
Fix upgrade layouts and card upgrade purchase

### DIFF
--- a/cardUpgrades.js
+++ b/cardUpgrades.js
@@ -194,6 +194,7 @@ export function renderCardUpgrades(container, options = {}) {
     const cost = getCardUpgradeCost(id, stats);
     const wrapper = document.createElement('div');
     wrapper.classList.add('card-wrapper');
+    wrapper.dataset.id = id;
     const card = document.createElement('div');
     card.classList.add('card', 'upgrade-card');
     card.innerHTML = `

--- a/script.js
+++ b/script.js
@@ -451,6 +451,18 @@ function updateUpgradeButtons() {
     row.classList.toggle("affordable", affordable);
     row.classList.toggle("unaffordable", !affordable);
   });
+  updateCardUpgradeButtons();
+}
+
+function updateCardUpgradeButtons() {
+  document.querySelectorAll('.card-upgrade-list .card-wrapper').forEach(wrap => {
+    const btn = wrap.querySelector('button');
+    const id = wrap.dataset.id;
+    if (!btn || !id) return;
+    const cost = getCardUpgradeCost(id, stats);
+    btn.disabled = cash < cost;
+    btn.textContent = `Buy $${cost}`;
+  });
 }
 
 // Deduct cash and apply the effects of the chosen upgrade
@@ -567,16 +579,19 @@ function renderBarUpgrades() {
     const row = document.createElement('div');
     row.classList.add('bar-upgrade');
     row.dataset.key = key;
+    const header = document.createElement('div');
+    header.classList.add('bar-header');
     const label = document.createElement('div');
     label.classList.add('bar-label');
     label.textContent = key === 'damage' ? 'Damage' : 'Max HP';
+    const info = document.createElement('div');
+    info.classList.add('bar-info');
+    header.append(label, info);
     const barEl = document.createElement('div');
     barEl.classList.add('bar');
     const fill = document.createElement('div');
     fill.classList.add('bar-fill');
     barEl.appendChild(fill);
-    const info = document.createElement('div');
-    info.classList.add('bar-info');
     const controls = document.createElement('div');
     controls.classList.add('bar-controls');
     const minus = document.createElement('button');
@@ -589,7 +604,7 @@ function renderBarUpgrades() {
     plus.textContent = '+';
     plus.addEventListener('click', () => allocateBarPoint(key));
     controls.append(minus, pts, plus);
-    row.append(label, barEl, info, controls);
+    row.append(header, barEl, controls);
     container.appendChild(row);
     updateBarUI(key);
   });

--- a/style.css
+++ b/style.css
@@ -961,8 +961,14 @@ body {
 }
 .bar-upgrade {
     display: flex;
-    align-items: center;
-    gap: 6px;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.bar-header {
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.6rem;
 }
 .bar {
     width: 100%;
@@ -993,16 +999,16 @@ body {
 
 .bar-controls {
     display: flex;
-    gap: 4px;
+    gap: 2px;
     align-items: center;
     margin-left: auto;
 }
 
 .bar-controls button {
-    width: 20px;
-    height: 20px;
+    width: 16px;
+    height: 16px;
     padding: 0;
-    font-size: 0.7rem;
+    font-size: 0.6rem;
 }
 
 .bar-points {
@@ -1012,11 +1018,11 @@ body {
 }
 
 .upgrade-card {
-    background: #333;
+    background: #fff;
     padding: 4px;
     margin-bottom: 4px;
-    color: #fff;
-    font-size: 0.7rem;
+    color: #000;
+    font-size: 0.6rem;
     border-radius: 4px;
     display: flex;
     flex-direction: column;
@@ -1026,11 +1032,12 @@ body {
 .upgrade-card button {
     width: 100%;
     padding: 2px 4px;
-    font-size: 0.7rem;
+    font-size: 0.6rem;
     background: linear-gradient(135deg, #e8ffe8, #c8facc);
     border: 1px solid #4caf50;
     border-radius: 4px;
     cursor: pointer;
+    color: #000;
 }
 
 .upgrade-popup {


### PR DESCRIPTION
## Summary
- refactor bar upgrade layout so labels and info sit above progress bars
- shrink bar control buttons
- restyle upgrade cards with white background and smaller text
- store upgrade id on card elements and update buttons when cash changes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ee3e78b948326bbd243ac79aada55