### PR TITLE
Add nested upgrade tabs and card effects

### DIFF
--- a/cardUpgrades.js
+++ b/cardUpgrades.js
@@ -130,6 +130,10 @@ export const upgradeLevels = {};
 
 let activeCardUpgrades = [];
 
+export function removeActiveUpgrade(id) {
+  activeCardUpgrades = activeCardUpgrades.filter(a => a !== id);
+}
+
 export function unlockCardUpgrade(id) {
   if (!unlockedCardUpgrades.includes(id)) {
     unlockedCardUpgrades.push(id);

--- a/index.html
+++ b/index.html
@@ -115,6 +115,7 @@
 
         <div class="handContainer casino-section">
         </div>
+        <div class="active-effects casino-section"></div>
         <div class="jokerContainer casino-section">
         </div>
         <div class="manaBar" id="manaBar" style="display:none;">
@@ -146,14 +147,24 @@
       </div>
     </div>
     <div class="upgradesTab casino-section">
-      <div class="bar-upgrades-container casino-section">
-        <div id="upgradePowerDisplay">Upgrade Power: 0</div>
-        <button id="buyUpgradePowerBtn">Buy Upgrade Point ($50)</button>
-        <div class="bar-upgrades"></div>
+      <div class="upgrade-subtabs">
+        <button class="barSubTabButton">Bar Upgrades</button>
+        <button class="cardSubTabButton">Card Upgrades</button>
       </div>
-      <div class="card-upgrades-container casino-section">
-        <h3>Card Upgrades</h3>
-        <div class="card-upgrade-list"></div>
+      <div class="bar-upgrades-panel">
+        <div class="bar-upgrades-container casino-section">
+          <div id="upgradePowerDisplay">Upgrade Power: 0</div>
+          <button id="buyUpgradePowerBtn">Buy Upgrade Point ($50)</button>
+          <div class="bar-upgrades"></div>
+        </div>
+      </div>
+      <div class="card-upgrades-panel">
+        <div class="card-upgrades-container casino-section">
+          <h3>Available Upgrades</h3>
+          <div class="card-upgrade-list"></div>
+          <h3>Purchased Upgrades</h3>
+          <div class="purchased-upgrade-list"></div>
+        </div>
       </div>
     </div>
     <div class="starChartTab">

--- a/script.js
+++ b/script.js
@@ -26,7 +26,9 @@ import {
   unlockCardUpgrade,
   createUpgradeCard,
   getCardUpgradeCost,
-  cardUpgradeDefinitions
+  cardUpgradeDefinitions,
+  upgradeLevels as cardUpgradeLevels,
+  removeActiveUpgrade
 } from "./cardUpgrades.js";
 
 
@@ -344,6 +346,12 @@ const starChartTab = document.querySelector(".starChartTab");
 const playerStatsTab = document.querySelector(".playerStatsTab");
 const worldsTab = document.querySelector(".worldsTab");
 const upgradesTab = document.querySelector(".upgradesTab");
+const barSubTabButton = document.querySelector('.barSubTabButton');
+const cardSubTabButton = document.querySelector('.cardSubTabButton');
+const barUpgradesPanel = document.querySelector('.bar-upgrades-panel');
+const cardUpgradesPanel = document.querySelector('.card-upgrades-panel');
+const purchasedUpgradeList = document.querySelector('.purchased-upgrade-list');
+const activeEffectsContainer = document.querySelector('.active-effects');
 const tooltip = document.getElementById("tooltip");
 
 function hideTab() {
@@ -359,6 +367,28 @@ function showTab(tab) {
   hideTab();
   // Reset display so CSS controls layout
   tab.style.display = "";
+}
+
+function hideUpgradePanels() {
+  if (barUpgradesPanel) barUpgradesPanel.style.display = "none";
+  if (cardUpgradesPanel) cardUpgradesPanel.style.display = "none";
+}
+
+function showBarUpgradesPanel() {
+  hideUpgradePanels();
+  if (barUpgradesPanel) barUpgradesPanel.style.display = "";
+  renderBarUpgrades();
+}
+
+function showCardUpgradesPanel() {
+  hideUpgradePanels();
+  if (cardUpgradesPanel) cardUpgradesPanel.style.display = "";
+  renderCardUpgrades(document.querySelector('.card-upgrade-list'), {
+    stats,
+    cash,
+    onPurchase: purchaseCardUpgrade
+  });
+  renderPurchasedUpgrades();
 }
 
 mainTabButton.addEventListener("click", () => {
@@ -389,10 +419,13 @@ if (worldTabButton) {
 }
 if (upgradesTabButton) {
   upgradesTabButton.addEventListener("click", () => {
-    renderBarUpgrades();
     showTab(upgradesTab);
+    showBarUpgradesPanel();
   });
 }
+
+if (barSubTabButton) barSubTabButton.addEventListener('click', showBarUpgradesPanel);
+if (cardSubTabButton) cardSubTabButton.addEventListener('click', showCardUpgradesPanel);
 
 showTab(mainTab); // Start with main tab visible
 
@@ -507,12 +540,44 @@ function purchaseCardUpgrade(id, cost) {
   cashDisplay.textContent = `Cash: $${cash}`;
   cashRateTracker.record(cash);
   deck.push(createUpgradeCard(id));
+  removeActiveUpgrade(id);
   renderCardUpgrades(document.querySelector('.card-upgrade-list'), {
     stats,
     cash,
     onPurchase: purchaseCardUpgrade
   });
+  renderPurchasedUpgrades();
   updateUpgradeButtons();
+}
+
+function renderPurchasedUpgrades() {
+  if (!purchasedUpgradeList) return;
+  purchasedUpgradeList.innerHTML = '';
+  deck.forEach(c => {
+    if (!c.upgradeId) return;
+    const wrap = document.createElement('div');
+    wrap.classList.add('card-wrapper');
+    const cardEl = document.createElement('div');
+    cardEl.classList.add('card', 'upgrade-card');
+    const def = cardUpgradeDefinitions[c.upgradeId];
+    cardEl.innerHTML = `<div class="card-suit"><i data-lucide="sword"></i></div><div class="card-desc">${def.name}</div>`;
+    wrap.appendChild(cardEl);
+    purchasedUpgradeList.appendChild(wrap);
+  });
+  lucide.createIcons();
+}
+
+function updateActiveEffects() {
+  if (!activeEffectsContainer) return;
+  activeEffectsContainer.innerHTML = '';
+  Object.entries(cardUpgradeLevels).forEach(([id, lvl]) => {
+    if (lvl > 0) {
+      const def = cardUpgradeDefinitions[id];
+      const div = document.createElement('div');
+      div.textContent = `${def.name} (Lv. ${lvl})`;
+      activeEffectsContainer.appendChild(div);
+    }
+  });
 }
 
 function updateUpgradePowerDisplay() {
@@ -717,6 +782,8 @@ document.addEventListener("DOMContentLoaded", () => {
     cash,
     onPurchase: purchaseCardUpgrade
   });
+  renderPurchasedUpgrades();
+  updateActiveEffects();
   const buyBtn = document.getElementById('buyUpgradePowerBtn');
   if (buyBtn) {
     buyBtn.addEventListener('click', () => {
@@ -1253,6 +1320,8 @@ function onBossDefeat(boss) {
     cash,
     onPurchase: purchaseCardUpgrade
   });
+  renderPurchasedUpgrades();
+  updateActiveEffects();
   shuffleArray(deck);
   nextWorld();
   renderWorldsMenu();
@@ -1488,6 +1557,8 @@ function drawCard() {
       cash,
       onPurchase: purchaseCardUpgrade
     });
+    renderPurchasedUpgrades();
+    updateActiveEffects();
     updatePlayerStats(stats);
     return null;
   }
@@ -2182,6 +2253,8 @@ updateUpgradeButtons();
 
   checkUpgradeUnlocks();
   updateUpgradePowerCost();
+  renderPurchasedUpgrades();
+  updateActiveEffects();
 
 addLog("Game loaded!",
 "info");
@@ -2207,6 +2280,8 @@ renderCardUpgrades(document.querySelector('.card-upgrade-list'), {
   cash,
   onPurchase: purchaseCardUpgrade
 });
+renderPurchasedUpgrades();
+updateActiveEffects();
 shuffleArray(deck);
 checkUpgradeUnlocks();
 

--- a/style.css
+++ b/style.css
@@ -41,23 +41,23 @@ body {
     display: flex;
     gap: 12px;
     padding: 10px;
-    background: rgba(10, 10, 30, 0.8);
-    box-shadow: 0 0 12px #222;
-    border-bottom: 2px solid #00ffee;
+    background: radial-gradient(circle, #3b1a1a 0%, #1a0000 100%);
+    box-shadow: 0 0 20px #d4af37;
+    border-bottom: 3px solid #d4af37;
 }
 
 .tabsContainer button {
-    background: #111;
-    color: #00ffee;
-    border: 1px solid #00ffee;
+    background: #220000;
+    color: #d4af37;
+    border: 1px solid #d4af37;
     padding: 8px 14px;
     border-radius: 8px;
     font-weight: bold;
     transition: all 0.2s;
 }
 .tabsContainer button:hover {
-    background: #00ffee;
-    color: #000;
+    background: #d4af37;
+    color: #220000;
 }
 
 /* tabs container */
@@ -823,20 +823,29 @@ body {
 
 .upgradesTab {
     display: flex;
-    gap: 10px;
+    flex-direction: column;
+    gap: 8px;
     background-color: #5c5c5c;
     padding: 5px;
 }
 
-.bar-upgrades-container {
-    width: 33%;
+.upgrade-subtabs {
     display: flex;
-    flex-direction: column;
     gap: 6px;
 }
 
+.upgrade-subtabs button {
+    flex: 1;
+}
+
+.bar-upgrades-panel,
+.card-upgrades-panel {
+    display: none;
+}
+
+.bar-upgrades-container,
 .card-upgrades-container {
-    width: 67%;
+    width: 100%;
     display: flex;
     flex-direction: column;
     gap: 6px;
@@ -997,6 +1006,12 @@ body {
     gap: 8px;
 }
 
+.purchased-upgrade-list {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(90px, 1fr));
+    gap: 8px;
+}
+
 .bar-controls {
     display: flex;
     gap: 2px;
@@ -1028,6 +1043,7 @@ body {
     flex-direction: column;
     align-items: center;
     gap: 4px;
+    transform: rotate(5deg);
 }
 .upgrade-card button {
     width: 100%;
@@ -1047,6 +1063,14 @@ body {
     transform: translate(-50%, -50%);
     z-index: 2000;
     pointer-events: none;
+}
+
+.active-effects {
+    font-size: 0.6rem;
+    padding: 4px;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
 }
 
 .restart-overlay {


### PR DESCRIPTION
## Summary
- restyle main tabs with casino theme
- show purchased upgrade cards separately
- add nested tabs within upgrades panel
- tilt upgrade cards and display drawn upgrade effects
- support removing purchased upgrade options

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ef308f0f0832695efe762f7ac1c05