### PR TITLE
Improve hand card layout on desktops

### DIFF
--- a/style.css
+++ b/style.css
@@ -584,6 +584,16 @@ body {
     max-height: 120px;
 }
 
+@media (min-width: 1024px) {
+    .card-wrapper {
+        max-width: 140px;
+        max-height: none;
+    }
+    .handContainer {
+        grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    }
+}
+
 .card {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
## Summary
- allow more card space on wider screens
- tweak hand grid to use larger cards

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f2d25ca888326a106ba2d48364ec3