### PR TITLE
Refactor game logic modules

### DIFF
--- a/cardManagement.js
+++ b/cardManagement.js
@@ -1,0 +1,71 @@
+export function drawCard(state) {
+  const {
+    deck,
+    drawnCards,
+    handContainer,
+    renderCard,
+    updateDeckDisplay,
+    stats,
+    showUpgradePopup,
+    applyCardUpgrade,
+    renderCardUpgrades,
+    purchaseCardUpgrade,
+    cash,
+    renderPurchasedUpgrades,
+    updateActiveEffects,
+    pDeck
+  } = state;
+
+  if (deck.length === 0) return null;
+
+  const card = deck.shift();
+
+  if (card.upgradeId) {
+    showUpgradePopup(card.upgradeId);
+    applyCardUpgrade(card.upgradeId, { stats, pDeck });
+    renderCardUpgrades(document.querySelector('.card-upgrade-list'), {
+      stats,
+      cash,
+      onPurchase: purchaseCardUpgrade
+    });
+    renderPurchasedUpgrades();
+    updateActiveEffects();
+    return null;
+  }
+
+  drawnCards.push(card);
+  renderCard(card, handContainer);
+  updateDeckDisplay();
+  return card;
+}
+
+export function redrawHand(state) {
+  const {
+    deck,
+    drawnCards,
+    handContainer,
+    shuffleArray,
+    stats,
+    drawCard,
+    updateDrawButton,
+    updateDeckDisplay,
+    updatePlayerStats,
+    pDeck
+  } = state;
+
+  deck.push(...drawnCards);
+  drawnCards.length = 0;
+  handContainer.innerHTML = '';
+  shuffleArray(deck);
+  if (stats.healOnRedraw > 0) {
+    pDeck.forEach(c => {
+      c.currentHp = Math.min(c.maxHp, c.currentHp + stats.healOnRedraw);
+    });
+  }
+  while (drawnCards.length < stats.cardSlots && deck.length > 0) {
+    drawCard(state);
+  }
+  updateDrawButton();
+  updateDeckDisplay();
+  updatePlayerStats(stats);
+}

--- a/enemySpawning.js
+++ b/enemySpawning.js
@@ -1,0 +1,60 @@
+import Enemy from './enemy.js';
+import { Boss, BossTemplates } from './boss.js';
+import { AbilityRegistry } from './dealerabilities.js';
+
+export function calculateEnemyHp(stage, world, isBoss = false) {
+  const baseHp = 10 + stage;
+  const effectiveStage = stage + 10 * (world - 1);
+  let hp = baseHp * Math.pow(effectiveStage, 1.1);
+  if (isBoss) hp *= 5;
+  return Math.floor(hp);
+}
+
+export function calculateEnemyBasicDamage(stage, world) {
+  let baseDamage;
+  if (stage === 10) {
+    baseDamage = stage * 2;
+  } else if (stage <= 10) {
+    baseDamage = stage;
+  } else {
+    baseDamage = Math.floor(0.1 * stage * stage);
+  }
+  const scaledDamage = baseDamage * world ** 2;
+  const maxDamage = Math.max(scaledDamage, 1);
+  const minDamage = Math.floor(0.5 * maxDamage) + 1;
+  return { minDamage, maxDamage };
+}
+
+export function spawnDealer(stageData, enemyAttackProgress, onAttack, onDefeat) {
+  const stage = stageData.stage;
+  const world = stageData.world;
+  const enemy = new Enemy(stage, world, {
+    maxHp: calculateEnemyHp(stage, world),
+    onAttack,
+    onDefeat
+  });
+  enemy.attackTimer = enemy.attackInterval * enemyAttackProgress;
+  return enemy;
+}
+
+export function spawnBoss(stageData, enemyAttackProgress, onAttack, onDefeat) {
+  const stage = stageData.stage;
+  const world = stageData.world;
+  const template = BossTemplates[world];
+  const abilities = template.abilityKeys.map(key => {
+    const [group, fn] = key.split('.');
+    return AbilityRegistry[group][fn]();
+  });
+  const boss = new Boss(stage, world, {
+    maxHp: calculateEnemyHp(stage, world, true),
+    name: template.name,
+    icon: template.icon,
+    iconColor: template.iconColor,
+    xp: Math.pow(stage, 1.5) * world,
+    abilities,
+    onAttack,
+    onDefeat
+  });
+  boss.attackTimer = boss.attackInterval * enemyAttackProgress;
+  return boss;
+}

--- a/rendering.js
+++ b/rendering.js
@@ -1,0 +1,71 @@
+export function renderDealerLifeBar(dealerLifeDisplay, currentEnemy) {
+  if (document.querySelector('.dealerLifeContainer')) return;
+  const container = document.createElement('div');
+  const fill = document.createElement('div');
+  container.classList.add('dealerLifeContainer');
+  fill.id = 'dealerBarFill';
+  container.appendChild(fill);
+  dealerLifeDisplay.insertAdjacentElement('afterend', container);
+  dealerLifeDisplay.textContent = `Life: ${currentEnemy.maxHp}`;
+  return fill;
+}
+
+export function renderEnemyAttackBar() {
+  const existing = document.querySelector('.enemyAttackBar');
+  if (existing) existing.remove();
+  const bar = document.createElement('div');
+  const fill = document.createElement('div');
+  bar.classList.add('enemyAttackBar');
+  fill.classList.add('enemyAttackFill');
+  bar.appendChild(fill);
+  const lifeContainer = document.querySelector('.dealerLifeContainer');
+  if (lifeContainer) lifeContainer.insertAdjacentElement('afterend', bar);
+  return fill;
+}
+
+export function renderPlayerAttackBar(container) {
+  if (!container) return null;
+  const bar = document.getElementById('playerAttackBar');
+  if (!bar) return null;
+  return bar.querySelector('.playerAttackFill');
+}
+
+export function renderDealerLifeBarFill(currentEnemy) {
+  const dealerBarFill = document.getElementById('dealerBarFill');
+  if (!dealerBarFill) return;
+  dealerBarFill.style.width = `${(currentEnemy.currentHp / currentEnemy.maxHp) * 100}%`;
+}
+
+export function renderCard(card, handContainer) {
+  const wrapper = document.createElement('div');
+  wrapper.classList.add('card-wrapper');
+  const cardPane = document.createElement('div');
+  cardPane.classList.add('card');
+  cardPane.innerHTML = `\n  <div class="card-value" style="color: ${card.color}">${card.value}</div>\n  <div class="card-suit" style="color: ${card.color}">${card.symbol}</div>\n  <div class="card-hp">HP: ${Math.round(card.currentHp)}/${Math.round(card.maxHp)}</div>\n  `;
+  const xpBar = document.createElement('div');
+  const xpBarFill = document.createElement('div');
+  const xpLabel = document.createElement('div');
+  xpBar.classList.add('xpBar');
+  xpBarFill.classList.add('xpBarFill');
+  xpLabel.classList.add('xpBarLabel');
+  xpLabel.textContent = `LV: ${card.currentLevel}`;
+  xpBar.append(xpBarFill, xpLabel);
+  wrapper.append(cardPane, xpBar);
+  handContainer.appendChild(wrapper);
+  card.wrapperElement = wrapper;
+  card.cardElement = cardPane;
+  card.hpDisplay = cardPane.querySelector('.card-hp');
+  card.xpBar = xpBar;
+  card.xpBarFill = xpBarFill;
+  card.xpLabel = xpLabel;
+}
+
+export function renderDiscardCard(card, discardContainer, backImages) {
+  discardContainer.innerHTML = '';
+  const img = document.createElement('img');
+  img.alt = 'Card Back';
+  img.src = backImages[card.backType] || backImages['basic-red'];
+  img.classList.add('card-back', card.backType);
+  discardContainer.appendChild(img);
+  card.discardElement = img;
+}

--- a/script.js
+++ b/script.js
@@ -30,6 +30,21 @@ import {
   upgradeLevels as cardUpgradeLevels,
   removeActiveUpgrade
 } from "./cardUpgrades.js";
+import {
+  calculateEnemyHp,
+  calculateEnemyBasicDamage,
+  spawnDealer,
+  spawnBoss
+} from "./enemySpawning.js";
+import {
+  renderCard,
+  renderDiscardCard,
+  renderDealerLifeBar,
+  renderEnemyAttackBar,
+  renderPlayerAttackBar,
+  renderDealerLifeBarFill
+} from "./rendering.js";
+import { drawCard, redrawHand } from "./cardManagement.js";
 
 
 // --- Game State ---
@@ -291,6 +306,29 @@ function getDealerIconStyle(stage) {
 let pDeck = generateDeck();
 let deck = [...pDeck];
 
+function getCardState() {
+  return {
+    deck,
+    drawnCards,
+    handContainer,
+    renderCard: card => renderCard(card, handContainer),
+    updateDeckDisplay,
+    stats,
+    showUpgradePopup,
+    applyCardUpgrade,
+    renderCardUpgrades,
+    purchaseCardUpgrade,
+    cash,
+    renderPurchasedUpgrades,
+    updateActiveEffects,
+    pDeck,
+    shuffleArray,
+    updateDrawButton,
+    updatePlayerStats,
+    drawCard, // will be replaced after definition
+  };
+}
+
 const btn = document.getElementById("clickalipse");
 const redrawBtn = document.getElementById("redrawBtn");
 const nextStageBtn = document.getElementById("nextStageBtn");
@@ -536,7 +574,7 @@ function purchaseUpgrade(key) {
   up.effect(stats);
   if (key === "cardSlots") {
     while (drawnCards.length < stats.cardSlots && deck.length > 0) {
-      drawCard();
+      drawCard(getCardState());
     }
   }
   renderUpgrades();
@@ -814,47 +852,7 @@ document.addEventListener("DOMContentLoaded", () => {
   requestAnimationFrame(gameLoop);
 });
 
-// life
-function renderDealerLifeBar() {
-  if (document.querySelector(".dealerLifeContainer")) return;
-  const dealerContainerLife = document.createElement("div");
-  const dealerBarFill = document.createElement("div");
-
-  dealerContainerLife.classList.add("dealerLifeContainer");
-  dealerBarFill.id = "dealerBarFill";
-
-  dealerContainerLife.appendChild(dealerBarFill);
-  dealerLifeDisplay.insertAdjacentElement("afterend", dealerContainerLife);
-  dealerLifeDisplay.textContent = `Life: ${currentEnemy.maxHp}`;
-}
-
-function renderEnemyAttackBar() {
-  const existing = document.querySelector(".enemyAttackBar");
-  if (existing) existing.remove();
-  const bar = document.createElement("div");
-  const fill = document.createElement("div");
-  bar.classList.add("enemyAttackBar");
-  fill.classList.add("enemyAttackFill");
-  bar.appendChild(fill);
-  enemyAttackFill = fill;
-  const lifeContainer = document.querySelector(".dealerLifeContainer");
-  if (lifeContainer) lifeContainer.insertAdjacentElement("afterend", bar);
-}
-
-function renderPlayerAttackBar() {
-  const container = document.querySelector(".buttonsContainer");
-  if (!container) return;
-  const bar = document.getElementById("playerAttackBar");
-  if (!bar) return;
-  playerAttackFill = bar.querySelector(".playerAttackFill");
-}
-
-function renderDealerLifeBarFill() {
-  const dealerBarFill = document.getElementById("dealerBarFill");
-  dealerBarFill.style.width = `${
-  (currentEnemy.currentHp / currentEnemy.maxHp) * 100
-  }%`;
-} //red fill gauge render
+// life rendering moved to rendering.js
 
 function updateManaBar() {
   if (!manaBar) return;
@@ -1226,38 +1224,7 @@ function nextStageChecker() {
 
 //dealer
 
-// Spawn a regular enemy for the current stage
-function spawnDealer() {
-  const stage = stageData.stage;
-  const world = stageData.world;
-  const maxHp = calculateEnemyHp(stage, world);
-
-  currentEnemy = new Enemy(stage, world, {
-    maxHp,
-    onAttack: Enemy => {
-      const {
-        minDamage, maxDamage
-      } = calculateEnemyBasicDamage(
-        stage,
-        world
-      );
-      const damage =
-      Math.floor(Math.random() * (maxDamage - minDamage + 1)) +
-      minDamage;
-      cDealerDamage(damage, null, Enemy.name);
-    },
-    onDefeat: () => {
-      onDealerDefeat();
-    }
-  });
-
-  // carry over any attack progress from the last enemy
-  currentEnemy.attackTimer = currentEnemy.attackInterval * enemyAttackProgress;
-
-  updateDealerLifeDisplay();
-  renderEnemyAttackBar();
-  dealerDeathAnimation();
-}
+// Spawn logic moved to enemySpawning.js
 
 // Adjust the width of the dealer's HP bar
 function updateDealerLifeBar(enemy) {
@@ -1281,10 +1248,31 @@ function removeDealerLifeBar() {
 function respawnDealerStage() {
   removeDealerLifeBar();
   if (stageData.stage === 10) {
-    spawnBoss();
+    currentEnemy = spawnBoss(
+      stageData,
+      enemyAttackProgress,
+      boss => {
+        const { minDamage, maxDamage } = calculateEnemyBasicDamage(stageData.stage, stageData.world);
+        const dmg = Math.floor(Math.random() * (maxDamage - minDamage + 1)) + minDamage;
+        cDealerDamage(dmg, null, boss.name);
+      },
+      () => onBossDefeat(currentEnemy)
+    );
   } else {
-    spawnDealer();
+    currentEnemy = spawnDealer(
+      stageData,
+      enemyAttackProgress,
+      Enemy => {
+        const { minDamage, maxDamage } = calculateEnemyBasicDamage(stageData.stage, stageData.world);
+        const dmg = Math.floor(Math.random() * (maxDamage - minDamage + 1)) + minDamage;
+        cDealerDamage(dmg, null, Enemy.name);
+      },
+      onDealerDefeat
+    );
   }
+  updateDealerLifeDisplay();
+  enemyAttackFill = renderEnemyAttackBar();
+  dealerDeathAnimation();
 }
 
 // What happens after defeating a regular dealer
@@ -1341,85 +1329,17 @@ function onBossDefeat(boss) {
 }
 
 // Spawn the boss that appears every 10 stages
-function spawnBoss() {
-  const stage = stageData.stage;
-  const world = stageData.world;
-  const template = BossTemplates[world];
-
-  const abilities = template.abilityKeys.map(key => {
-    const [group, fn] = key.split(".");
-    return AbilityRegistry[group][fn]();
-  });
-
-  currentEnemy = new Boss(stage, world, {
-    maxHp: calculateEnemyHp(stage, world, true), // true for boss
-    name: template.name,
-    icon: template.icon,
-    iconColor: template.iconColor,
-    xp: Math.pow(stage, 1.5) * world,
-    abilities,
-    onAttack: boss => {
-      const {
-        minDamage, maxDamage
-      } = calculateEnemyBasicDamage(
-        stage,
-        world
-      );
-      const damage =
-      Math.floor(Math.random() * (maxDamage - minDamage + 1)) +
-      minDamage;
-      cDealerDamage(damage, null, boss.name);
-    },
-    onDefeat: () => {
-      onBossDefeat(currentEnemy);
-    }
-  });
-
-  // carry over any attack progress from the last enemy
-  currentEnemy.attackTimer = currentEnemy.attackInterval * enemyAttackProgress;
-
-  updateDealerLifeDisplay();
-  renderEnemyAttackBar();
-  dealerDeathAnimation();
-}
+// Spawn logic moved to enemySpawning.js
 
 // Update text and bar UI for the current enemy's health
 function updateDealerLifeDisplay() {
   dealerLifeDisplay.textContent = `Life: ${currentEnemy.currentHp}/${currentEnemy.maxHp}`;
-  renderDealerLifeBar();
-  renderDealerLifeBarFill();
+  renderDealerLifeBar(dealerLifeDisplay, currentEnemy);
+  renderDealerLifeBarFill(currentEnemy);
 }
 
 // Determine how much health an enemy or boss should have
-function calculateEnemyHp(stage, world, isBoss = false) {
-  const baseHp = 10 + stage;
-  const effectiveStage = stage + 10 * (world - 1);
-  let hp = baseHp * Math.pow(effectiveStage, 1.1);
-  if (isBoss) hp *= 5;
-  return Math.floor(hp);
-}
-
-// Base damage output scaled by stage and world
-function calculateEnemyBasicDamage(stage, world) {
-  let baseDamage;
-
-  if (stage === 10) {
-    baseDamage = stage * 2;
-  } else if (stage <= 10) {
-    baseDamage = stage;
-  } else {
-    baseDamage = Math.floor(0.1 * stage * stage);
-  }
-
-  const scaledDamage = baseDamage * world ** 2;
-  const maxDamage = Math.max(scaledDamage, 1);
-  const minDamage = Math.floor(0.5 * maxDamage) + 1;
-
-  return {
-    minDamage,
-    maxDamage
-  };
-}
+// enemy scaling moved to enemySpawning.js
 
 // Apply damage from the enemy to the first card in the player's hand
 function cDealerDamage(damageAmount = null, ability = null, source = "dealer") {
@@ -1552,41 +1472,7 @@ function cardXp(xpAmount) {
 * Returns the drawn card, or null if the deck was empty.
 */
 // Draw the next card from the deck into the player's hand
-function drawCard() {
-  // 1) Nothing to draw?
-  if (deck.length === 0) return null;
-
-  // 2) Take the *same* object out of deck…
-  const card = deck.shift();
-
-  // Upgrade cards apply immediately and are not kept in hand
-  if (card.upgradeId) {
-    showUpgradePopup(card.upgradeId);
-    applyCardUpgrade(card.upgradeId, { stats, pDeck });
-    renderCardUpgrades(document.querySelector('.card-upgrade-list'), {
-      stats,
-      cash,
-      onPurchase: purchaseCardUpgrade
-    });
-    renderPurchasedUpgrades();
-    updateActiveEffects();
-    updatePlayerStats(stats);
-    return null;
-  }
-
-  // 3) …put it into your hand…
-  drawnCards.push(card);
-
-  // 4) render just that one card in the hand…
-  renderCard(card);
-
-  // 5) refresh any other UI that shows the deck
-  updateDeckDisplay();
-
-  // 6) return the drawn card
-
-  return card;
-}
+// drawing logic moved to cardManagement.js
 
 // Enable or disable the draw button depending on hand size
 function updateDrawButton() {
@@ -1610,56 +1496,7 @@ function updateHandDisplay() {
 }
 
 // Create DOM elements for a card in the player's hand
-function renderCard(card) {
-  // 1) Wrapper
-  const wrapper = document.createElement("div");
-  wrapper.classList.add("card-wrapper");
-
-  // 2) Card pane (value / suite / HP)
-  const cardPane = document.createElement("div");
-  cardPane.classList.add("card");
-  cardPane.innerHTML = `
-  <div class="card-value" style="color: ${card.color}">${card.value}</div>
-  <div class="card-suit" style="color: ${card.color}">${card.symbol}</div>
-  <div class="card-hp">HP: ${Math.round(card.currentHp)}/${Math.round(card.maxHp)}</div>
-  `;
-
-  // 3) XP bar
-  const xpBar = document.createElement("div");
-  const xpBarFill = document.createElement("div");
-  const xpLabel = document.createElement("div");
-  xpBar.classList.add("xpBar");
-  xpBarFill.classList.add("xpBarFill");
-  xpLabel.classList.add("xpBarLabel");
-  xpLabel.textContent = `LV: ${card.currentLevel}`;
-  xpBar.append(xpBarFill,
-    xpLabel);
-
-  // 4) Nest and append
-  wrapper.append(cardPane,
-    xpBar);
-  handContainer.appendChild(wrapper);
-
-  // 5) Save references for later updates
-  card.wrapperElement = wrapper;
-  card.cardElement = cardPane;
-  card.hpDisplay = cardPane.querySelector(".card-hp");
-  card.xpBar = xpBar;
-  card.xpBarFill = xpBarFill;
-  card.xpLabel = xpLabel;
-}
-
-// Display the top of the discard pile
-function renderDiscardCard(card) {
-  discardContainer.innerHTML = "";
-  const img = document.createElement("img");
-  img.alt = "Card Back";
-  img.src = cardBackImages[card.backType] || cardBackImages["basic-red"];
-  img.classList.add("card-back",
-    card.backType);
-  discardContainer.appendChild(img);
-  card.discardElement = img;
-}
+// card rendering moved to rendering.js
 
 // Move a card to the discard pile and update the UI
 function discardCard(card) {
@@ -1907,7 +1744,7 @@ const awardJokerCard = () => awardJokerCardByWorld(stageData.world);
 
 function spawnPlayer() {
   while (drawnCards.length < stats.cardSlots && deck.length > 0) {
-    drawCard();
+    drawCard(getCardState());
   }
 }
 
@@ -1998,23 +1835,7 @@ location.reload();
 }
 
 // Shuffle all current cards back into the deck and draw a new hand
-function redrawHand() {
-deck.push(...drawnCards);
-drawnCards = [];
-handContainer.innerHTML = "";
-shuffleArray(deck);
- if (stats.healOnRedraw > 0) {
-   pDeck.forEach(c => {
-     c.currentHp = Math.min(c.maxHp, c.currentHp + stats.healOnRedraw);
-   });
- }
- while (drawnCards.length < stats.cardSlots && deck.length > 0) {
-   drawCard();
- }
-updateDrawButton();
-updateDeckDisplay();
-updatePlayerStats(stats);
-}
+// redraw logic moved to cardManagement.js
 
 // Player auto-attack; deals combined damage to the current enemy
 function attack() {
@@ -2284,7 +2105,7 @@ e);
 // Spawn the player's cards before the enemy so the initial
 // first strike doesn't trigger a full respawn
 spawnPlayer();
-spawnDealer();
+respawnDealerStage();
 resetStageCashStats();
 renderStageInfo();
 nextStageChecker();
@@ -2300,15 +2121,27 @@ updateActiveEffects();
 shuffleArray(deck);
 checkUpgradeUnlocks();
 
-btn.addEventListener("click", drawCard);
-redrawBtn.addEventListener("click", redrawHand);
+btn.addEventListener("click", () => drawCard(getCardState()));
+redrawBtn.addEventListener("click", () => redrawHand(getCardState()));
 nextStageBtn.addEventListener("click", nextStage);
 fightBossBtn.addEventListener("click", () => {
   fightBossBtn.style.display = "none";
   stageData.stage = 10;
   stageData.kills = playerStats.stageKills[stageData.stage] || 0;
   renderStageInfo();
-  spawnBoss();
+  currentEnemy = spawnBoss(
+    stageData,
+    enemyAttackProgress,
+    boss => {
+      const { minDamage, maxDamage } = calculateEnemyBasicDamage(stageData.stage, stageData.world);
+      const dmg = Math.floor(Math.random() * (maxDamage - minDamage + 1)) + minDamage;
+      cDealerDamage(dmg, null, boss.name);
+    },
+    () => onBossDefeat(currentEnemy)
+  );
+  updateDealerLifeDisplay();
+  enemyAttackFill = renderEnemyAttackBar();
+  dealerDeathAnimation();
 });
 
 /*function retry() {

--- a/test/enemy.scaling.test.cjs
+++ b/test/enemy.scaling.test.cjs
@@ -1,16 +1,11 @@
 const { expect } = require('chai');
-const fs = require('fs');
-const vm = require('vm');
-const path = require('path');
-
-// Extract the functions from script.js without executing the entire file
-const script = fs.readFileSync(path.resolve(__dirname, '../script.js'), 'utf8');
-const hpCode = script.match(/function calculateEnemyHp\([\s\S]*?\n\}/)[0];
-const dmgCode = script.match(/function calculateEnemyBasicDamage\([\s\S]*?\n\}/)[0];
-const context = {};
-vm.createContext(context);
-vm.runInContext(`${hpCode}\n${dmgCode}`, context);
-const { calculateEnemyHp, calculateEnemyBasicDamage } = context;
+let calculateEnemyHp;
+let calculateEnemyBasicDamage;
+before(async () => {
+  const mod = await import('../enemySpawning.js');
+  calculateEnemyHp = mod.calculateEnemyHp;
+  calculateEnemyBasicDamage = mod.calculateEnemyBasicDamage;
+});
 
 describe('🧮 Enemy Scaling Functions', () => {
   describe('calculateEnemyHp', () => {


### PR DESCRIPTION
## Summary
- split enemy spawning utilities into `enemySpawning.js`
- move rendering helpers to `rendering.js`
- move card drawing logic to `cardManagement.js`
- trim `script.js` and use new modules
- update enemy scaling tests to import from new module

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f2f26cf848326b8090783b6e3bda5