### PR TITLE
Fix enemy card initialization on load

### DIFF
--- a/script.js
+++ b/script.js
@@ -840,7 +840,6 @@ document.addEventListener("DOMContentLoaded", () => {
   // now the DOM is in, and lucide.js has run, so window.lucide is defined
   initTabs();
   loadGame();
-  renderDealerCard();
   initVignetteToggles();
   Object.values(upgrades).forEach(u => u.effect(stats));
   renderUpgrades();
@@ -857,6 +856,7 @@ document.addEventListener("DOMContentLoaded", () => {
   // Start or resume the game after loading
   spawnPlayer();
   respawnDealerStage();
+  renderDealerCard();
   resetStageCashStats();
   renderStageInfo();
   nextStageChecker();


### PR DESCRIPTION
## Summary
- ensure enemy card renders only after enemy is spawned

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f596659708326a373de51ff24f828