### PR TITLE
Move upgrade definitions

### DIFF
--- a/cardUpgrades.js
+++ b/cardUpgrades.js
@@ -104,6 +104,95 @@ export const cardUpgradeDefinitions = {
   }
 };
 
+export const upgrades = {
+  // Unlocked from start
+  globalDamage: {
+    name: 'Global Damage Multiplier',
+    level: 0,
+    baseValue: 1.0,
+    unlocked: true,
+    costFormula: level => 100 * level ** 1.2,
+    effect: ({ stats }) => {
+      stats.upgradeDamageMultiplier =
+        upgrades.globalDamage.baseValue + 0.15 * upgrades.globalDamage.level;
+    }
+  },
+  cardHpPerKill: {
+    name: 'Card HP per Kill',
+    level: 0,
+    baseValue: 1,
+    unlocked: true,
+    costFormula: level => 150 * level ** 2,
+    effect: ({ stats, pDeck }) => {
+      stats.hpPerKill =
+        upgrades.cardHpPerKill.baseValue + upgrades.cardHpPerKill.level;
+      if (pDeck) pDeck.forEach(card => (card.hpPerKill = stats.hpPerKill));
+    }
+  },
+  baseCardHp: {
+    name: 'Base Card HP Boost',
+    level: 0,
+    baseValue: 0,
+    unlocked: true,
+    costFormula: level => 100 * level ** 1.2,
+    effect: ({ stats, pDeck }) => {
+      const prev = stats.baseCardHpBoost || 0;
+      const newBoost = 3 * upgrades.baseCardHp.level;
+      const diff = newBoost - prev;
+      stats.baseCardHpBoost = newBoost;
+      if (pDeck) {
+        pDeck.forEach(card => {
+          card.baseHpBoost = (card.baseHpBoost || 0) + diff;
+          card.maxHp = Math.round(card.maxHp + diff);
+          card.currentHp = Math.round(card.currentHp + diff);
+        });
+      }
+    }
+  },
+
+  // Locked at start
+  autoAttackSpeed: {
+    name: 'Auto-Attack Speed',
+    level: 0,
+    baseValue: 5000,
+    unlocked: false,
+    unlockCondition: ({ stageData }) => stageData.stage >= 10,
+    costFormula: level => Math.floor(300 * level ** 2),
+    effect: ({ stats }) => {
+      const lvl = upgrades.autoAttackSpeed.level;
+      const base = upgrades.autoAttackSpeed.baseValue;
+      const fastReduction = 500 * Math.min(lvl, 4);
+      const diminishing = 250 * Math.max(lvl - 4, 0);
+      stats.attackSpeed = Math.max(2000, base - fastReduction - diminishing);
+    }
+  },
+  /* maxMana and manaRegen upgrades were previously implemented as card
+     upgrades. Removing duplicates to avoid conflicting behavior. */
+  abilityCooldownReduction: {
+    name: 'Ability Cooldown Reduction',
+    level: 0,
+    baseValue: 0,
+    unlocked: false,
+    unlockCondition: ({ stageData }) => stageData.stage >= 10,
+    costFormula: level => 200 * level ** 2,
+    effect: ({ stats }) => {
+      stats.abilityCooldownReduction = upgrades.abilityCooldownReduction.level * 0.05;
+    }
+  },
+  jokerCooldownReduction: {
+    name: 'Joker Cooldown Reduction',
+    level: 0,
+    baseValue: 0,
+    unlocked: false,
+    unlockCondition: ({ stageData }) => stageData.stage >= 12,
+    costFormula: level => 200 * level ** 2,
+    effect: ({ stats }) => {
+      stats.jokerCooldownReduction = upgrades.jokerCooldownReduction.level * 0.05;
+    }
+  },
+  // redrawCooldownReduction upgrade handled via card upgrades
+}; 
+
 const rarityCostMultiplier = {
   common: 1,
   uncommon: 1.5,

--- a/simulation.js
+++ b/simulation.js
@@ -2,7 +2,7 @@
 import generateDeck from "./card.js";
 import { Enemy } from "./enemy.js"; // assume this works without DOM
 import { Boss } from "./boss.js";
-import { upgrades as allUpgrades } from "./script.js"; // if needed, or copy upgrade logic
+import { upgrades as allUpgrades } from "./cardUpgrades.js";
 import { saveCSV } from "./utils/logger.cjs";
 
 export class GameSimulator {
@@ -40,7 +40,7 @@ export class GameSimulator {
       if (this.stats.cash >= cost) {
         this.stats.cash -= cost;
         up.level += 1;
-        up.effect(this.stats);
+        up.effect({ stats: this.stats });
         this.logs.push(`Bought ${up.name} to level ${up.level}`);
       }
     };


### PR DESCRIPTION
## Summary
- centralize upgrade definitions in `cardUpgrades.js`
- import upgrades constant from `cardUpgrades.js`
- update upgrade usage to pass context
- adjust simulation to use new export
- remove duplicate upgrades to avoid conflicts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684f59412ca883268df382fb567768ab