### PR TITLE
Fix XP bar text

### DIFF
--- a/style.css
+++ b/style.css
@@ -709,12 +709,14 @@ body {
 .xpBarLabel {
     position: absolute;
     top: 0;
-    left: 50%;
-    transform: translateX(-50%);
+    left: 0;
+    width: 100%;
     line-height: 1em;
     font-size: 0.6em;
     color: white;
     pointer-events: none; /* clicks pass through */
+    text-align: center;
+    white-space: nowrap;
 }
 
 @keyframes card-heal {


### PR DESCRIPTION
## Summary
- center XP text labels and keep them on a single line

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f5fd949e88326b2781e51047aee33