### PR TITLE
Add manual world travel and worlds tab glow

### DIFF
--- a/style.css
+++ b/style.css
@@ -1141,3 +1141,12 @@ body {
 .card-upgrade-entry.active {
     font-weight: bold;
 }
+
+@keyframes glow-pulse {
+    from { box-shadow: 0 0 5px 2px gold; }
+    to { box-shadow: 0 0 12px 4px gold; }
+}
+
+.glow-notify {
+    animation: glow-pulse 1s infinite alternate;
+}


### PR DESCRIPTION
## Summary
- add button to travel to specific world from Worlds tab
- highlight Worlds tab when reward is claimable or a new world is unlocked
- add glow animation style
- keep next world locked until player selects it

## Testing
- `npm test` *(fails: mocha not found)*
- `npm install` *(fails: download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684f5f8bf08c83269950f58c7d30753b