### PR TITLE
Improve upgrade visuals

### DIFF
--- a/style.css
+++ b/style.css
@@ -179,8 +179,9 @@ body {
     position: relative;
     width: 100%;
     height: 100%;
-    background: black;
-    border: 1px solid #333;
+    background: rgba(0, 0, 0, 0.8);
+    border: 1px solid #d4af37;
+    box-shadow: inset 0 0 6px #d4af37;
 }
 
 .manaFill {
@@ -189,7 +190,7 @@ body {
     left: 0;
     height: 100%;
     width: 0%;
-    background: #351691;
+    background: #d4af37;
 }
 
 .manaText {
@@ -300,8 +301,9 @@ body {
 #dealerBarFill {
     height: 30px;
     width: 100%;
-    background: red;
-    border: 2px solid grey;
+    background: #d4af37;
+    border: 2px solid #d4af37;
+    box-shadow: inset 0 0 6px #d4af37;
     transition: width 0.3s;
 }
 
@@ -309,9 +311,11 @@ body {
     height: 30px;
     width: 80%;
     justify-self: center;
-    background: #090b09;
+    background: rgba(0, 0, 0, 0.8);
+    border: 1px solid #d4af37;
     border-radius: 8px;
     overflow: hidden;
+    box-shadow: inset 0 0 6px #d4af37;
 }
 
 .dealerLifeContainer.bar-dead {
@@ -512,13 +516,14 @@ body {
 .playerAttackBar {
     width: 50%;
     height: 4px;
-    background: #090b09;
-    border: 1px solid grey;
+    background: rgba(0, 0, 0, 0.8);
+    border: 1px solid #d4af37;
     border-radius: 8px;
     overflow: hidden;
     margin: 0 auto 4px; /* center above the buttons */
     position: relative;
     flex-basis: 100%; /* occupy its own row within the flex wrapper */
+    box-shadow: inset 0 0 6px #d4af37;
 }
 
 .playerAttackFill {
@@ -527,18 +532,19 @@ body {
     left: 0;
     height: 100%;
     width: 0;
-    background: grey;
+    background: #d4af37;
 }
 
 .enemyAttackBar {
     width: 50%;
     height: 4px;
-    background: #090b09;
-    border: 1px solid grey;
+    background: rgba(0, 0, 0, 0.8);
+    border: 1px solid #d4af37;
     border-radius: 8px;
     overflow: hidden;
     margin: 4px auto 0;
     position: relative;
+    box-shadow: inset 0 0 6px #d4af37;
 }
 
 .enemyAttackFill {
@@ -547,7 +553,7 @@ body {
     left: 0;
     height: 100%;
     width: 0;
-    background: grey;
+    background: #d4af37;
 }
 
 .buttonsContainer > button:hover {
@@ -839,6 +845,24 @@ body {
 
 .upgrade-subtabs button {
     flex: 1;
+    background: rgba(0, 0, 0, 0.4);
+    color: #d4af37;
+    border: 3px solid #d4af37;
+    padding: 8px 14px;
+    border-radius: 8px;
+    font-weight: bold;
+    text-shadow: 0 0 6px #000;
+    box-shadow: 0 0 8px rgba(212, 175, 55, 0.5);
+    transition: all 0.2s;
+}
+.upgrade-subtabs button:hover {
+    box-shadow: 0 0 12px rgba(212, 175, 55, 0.8);
+    color: #fff4b3;
+}
+.upgrade-subtabs button.active {
+    background: #d4af37;
+    color: #220000;
+    box-shadow: inset 0 0 8px #fff8c6, 0 0 12px #d4af37;
 }
 
 .upgradesTab h3 {
@@ -1003,19 +1027,22 @@ body {
 .bar {
     width: 100%;
     height: 8px;
-    background: #444;
+    background: rgba(0, 0, 0, 0.8);
     border-radius: 4px;
+    border: 1px solid #d4af37;
+    box-shadow: inset 0 0 6px #d4af37;
     overflow: hidden;
 }
 
 .bar-label {
     width: 60px;
     font-size: 0.7rem;
+    color: #d4af37;
 }
 .bar-fill {
     height: 100%;
     width: 0%;
-    background: #4caf50;
+    background: #d4af37;
 }
 .bar-info {
     font-size: 0.6rem;
@@ -1054,7 +1081,7 @@ body {
 }
 
 .upgrade-card {
-    background: radial-gradient(circle, #08340f 0%, #021106 100%);
+    background: #000;
     padding: 4px;
     margin-bottom: 4px;
     color: #fff;


### PR DESCRIPTION
## Summary
- darken upgrade card background
- style upgrade subtabs like main tabs
- theme bars with casino colors

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f79651e8483268c06ab221f9a74e3