### PR TITLE
Fix boss respawn and bar colors

### DIFF
--- a/script.js
+++ b/script.js
@@ -1345,7 +1345,26 @@ function onBossDefeat(boss) {
   updateWorldTabNotification();
   renderWorldsMenu();
   fightBossBtn.style.display = "none";
-  respawnDealerStage();
+  dealerDeathAnimation();
+  dealerBarDeathAnimation(() => {
+    nextStageChecker();
+    currentEnemy = spawnDealer(
+      stageData,
+      enemyAttackProgress,
+      Enemy => {
+        const { minDamage, maxDamage } = calculateEnemyBasicDamage(
+          stageData.stage,
+          stageData.world
+        );
+        const dmg = Math.floor(Math.random() * (maxDamage - minDamage + 1)) +
+          minDamage;
+        cDealerDamage(dmg, null, Enemy.name);
+      },
+      onDealerDefeat
+    );
+    updateDealerLifeDisplay();
+    enemyAttackFill = renderEnemyAttackBar();
+  });
 }
 
 // Spawn the boss that appears every 10 stages

--- a/style.css
+++ b/style.css
@@ -172,7 +172,8 @@ body {
     display: flex;
     justify-content: center;
     align-items: center;
-    height: 20px;
+    height: 30px;
+    width: 80%;
 }
 
 .manaBarInner {
@@ -180,8 +181,8 @@ body {
     width: 100%;
     height: 100%;
     background: rgba(0, 0, 0, 0.8);
-    border: 1px solid #d4af37;
-    box-shadow: inset 0 0 6px #d4af37;
+    border: 1px solid #3498db;
+    box-shadow: inset 0 0 6px #3498db;
 }
 
 .manaFill {
@@ -190,7 +191,7 @@ body {
     left: 0;
     height: 100%;
     width: 0%;
-    background: #d4af37;
+    background: #3498db;
 }
 
 .manaText {
@@ -301,9 +302,9 @@ body {
 #dealerBarFill {
     height: 30px;
     width: 100%;
-    background: #d4af37;
-    border: 2px solid #d4af37;
-    box-shadow: inset 0 0 6px #d4af37;
+    background: #e74c3c;
+    border: 2px solid #e74c3c;
+    box-shadow: inset 0 0 6px #e74c3c;
     transition: width 0.3s;
 }
 
@@ -312,10 +313,10 @@ body {
     width: 80%;
     justify-self: center;
     background: rgba(0, 0, 0, 0.8);
-    border: 1px solid #d4af37;
+    border: 1px solid #e74c3c;
     border-radius: 8px;
     overflow: hidden;
-    box-shadow: inset 0 0 6px #d4af37;
+    box-shadow: inset 0 0 6px #e74c3c;
 }
 
 .dealerLifeContainer.bar-dead {


### PR DESCRIPTION
## Summary
- restore blue mana bar and red enemy life bar
- make mana bar same size as enemy life bar
- replace defeated boss with a standard enemy

## Testing
- `npm test --silent` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f86546338832694befed5a6893d1e