### PR TITLE
Add world 2 casino theme

### DIFF
--- a/script.js
+++ b/script.js
@@ -354,6 +354,24 @@ const purchasedUpgradeList = document.querySelector('.purchased-upgrade-list');
 const activeEffectsContainer = document.querySelector('.active-effects');
 const tooltip = document.getElementById("tooltip");
 
+function applyWorldTheme() {
+  if (mainTab) {
+    mainTab.classList.toggle("world-2-theme", stageData.world === 2);
+  }
+}
+
+function selectWorld(id) {
+  const w = parseInt(id);
+  if (!isNaN(w)) {
+    stageData.world = w;
+    stageData.stage = 1;
+    applyWorldTheme();
+    renderStageInfo();
+    respawnDealerStage();
+    showTab(mainTab);
+  }
+}
+
 function hideTab() {
   mainTab.style.display = "none";
   deckTab.style.display = "none";
@@ -1132,6 +1150,11 @@ function renderWorldsMenu() {
     const entry = document.createElement("div");
     entry.classList.add("world-entry");
     entry.innerHTML = `<div>World ${id}</div>`;
+    entry.addEventListener("click", e => {
+      if (e.target.tagName !== "BUTTON") {
+        selectWorld(id);
+      }
+    });
     const progressText = document.createElement("span");
     progressText.classList.add("world-progress-text");
     progressText.dataset.world = id;
@@ -1184,6 +1207,7 @@ function nextWorld() {
   stageData.world += 1;
   stageData.stage = 1;
   stageData.kills = playerStats.stageKills[stageData.stage] || 0;
+  applyWorldTheme();
   resetStageCashStats();
   worldProgressTimer = 0;
   worldProgressRateTracker.reset(computeWorldProgress(stageData.world) * 100);
@@ -2260,6 +2284,7 @@ updateUpgradeButtons();
   updateUpgradePowerCost();
   renderPurchasedUpgrades();
   updateActiveEffects();
+  applyWorldTheme();
 
 addLog("Game loaded!",
 "info");

--- a/style.css
+++ b/style.css
@@ -116,6 +116,10 @@ body {
     gap: 10px;
 }
 
+.mainTab.world-2-theme {
+    background: radial-gradient(circle, #3b1a1a 0%, #1a0000 100%);
+}
+
 .dealerContainer {
     grid-area: dealer;
 }


### PR DESCRIPTION
## Summary
- add `world-2-theme` class styles for main tab
- toggle the theme when selecting world 2
- ensure theme updates after loading and changing worlds

## Testing
- `npm test` *(fails: mocha not found)*
- `npm run lint` *(fails: cannot find '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68501eef74f48326b38d8ac8a1805736