### PR TITLE
Add job assignment UI inside Deck tab

### DIFF
--- a/classes.js
+++ b/classes.js
@@ -1,0 +1,53 @@
+export const Jobs = {
+  warrior: {
+    id: 'warrior',
+    name: 'Warrior',
+    attribute: 'Strength',
+    description: 'High HP, taunt abilities'
+  },
+  rogue: {
+    id: 'rogue',
+    name: 'Rogue',
+    attribute: 'Dexterity',
+    description: 'Increased critical hits and speed'
+  },
+  mage: {
+    id: 'mage',
+    name: 'Mage',
+    attribute: 'Mind',
+    description: 'Powerful magical attacks'
+  },
+  trickster: {
+    id: 'trickster',
+    name: 'Trickster',
+    attribute: 'Chaos',
+    description: 'Unpredictable burst damage'
+  },
+  priest: {
+    id: 'priest',
+    name: 'Priest',
+    attribute: 'Holy',
+    description: 'Healing and support abilities'
+  }
+};
+
+export function getJob(id) {
+  return Jobs[id] || null;
+}
+
+export function assignJob(card, jobId) {
+  if (!Jobs[jobId]) return false;
+  card.job = jobId;
+  // Placeholder: apply job bonuses here in the future
+  return true;
+}
+
+export function getAvailableJobs(card) {
+  const mapping = {
+    Spades: ['warrior'],
+    Diamonds: ['rogue'],
+    Clubs: ['mage'],
+    Hearts: ['priest']
+  };
+  return mapping[card.suit] || [];
+}

--- a/index.html
+++ b/index.html
@@ -148,6 +148,12 @@
           <div class="jokerContainer"></div>
         </div>
       </div>
+      <div class="vignette">
+        <button class="vignette-toggle">Jobs</button>
+        <div class="vignette-content">
+          <div class="deckJobsContainer"></div>
+        </div>
+      </div>
     </div>
     <div class="upgradesTab casino-section">
       <div class="upgrade-subtabs">

--- a/script.js
+++ b/script.js
@@ -18,6 +18,7 @@ import {
 import {
   initStarChart
 } from "./starChart.js"; // optional star chart tab
+import { Jobs, assignJob, getAvailableJobs } from "./classes.js"; // job definitions
 import RateTracker from "./utils/rateTracker.js";
 import {
   rollNewCardUpgrades,
@@ -233,6 +234,7 @@ const killsDisplay = document.getElementById("kills");
 const cashPerSecDisplay = document.getElementById("cashPerSecDisplay");
 const worldProgressPerSecDisplay = document.getElementById("worldProgressPerSecDisplay");
 const deckTabContainer = document.getElementsByClassName("deckTabContainer")[0];
+const deckJobsContainer = document.getElementsByClassName("deckJobsContainer")[0];
 const dCardContainer = document.getElementsByClassName("dCardContainer")[0];
 const jokerContainers = document.querySelectorAll(".jokerContainer");
 const manaBar = document.getElementById("manaBar");
@@ -391,6 +393,7 @@ function initTabs() {
       setActiveTabButton(playerStatsTabButton);
     });
   }
+
 
   if (worldTabButton) {
     worldTabButton.addEventListener("click", () => {
@@ -750,6 +753,7 @@ function updateDeckDisplay() {
       card.hpDisplay.textContent = `HP: ${Math.round(card.currentHp)}/${Math.round(card.maxHp)}`;
     }
   });
+  renderJobAssignments();
 }
 
 
@@ -779,6 +783,7 @@ document.addEventListener("DOMContentLoaded", () => {
   renderStageInfo();
   nextStageChecker();
   renderWorldsMenu();
+  renderJobAssignments();
   rollNewCardUpgrades();
   renderCardUpgrades(document.querySelector('.card-upgrade-list'), {
     stats,
@@ -1185,6 +1190,44 @@ function updateWorldTabNotification() {
   const newWorldAvailable = highestUnlocked > stageData.world;
   const shouldGlow = rewardAvailable || newWorldAvailable;
   worldTabButton.classList.toggle("glow-notify", shouldGlow);
+}
+
+// Show cards eligible for job assignment in the Deck tab
+function renderJobAssignments() {
+  const container = deckJobsContainer;
+  if (!container) return;
+  container.innerHTML = '';
+  pDeck.forEach(card => {
+    if (card.currentLevel >= 20 && !card.job) {
+      const row = document.createElement('div');
+      row.classList.add('job-entry');
+      row.textContent = `${card.value}${card.symbol} (Lv. ${card.currentLevel})`;
+
+      const select = document.createElement('select');
+      getAvailableJobs(card).forEach(id => {
+        const j = Jobs[id];
+        const opt = document.createElement('option');
+        opt.value = id;
+        opt.textContent = j.name;
+        select.appendChild(opt);
+      });
+
+      const btn = document.createElement('button');
+      btn.textContent = 'Assign';
+      btn.addEventListener('click', () => {
+        const id = select.value;
+        if (assignJob(card, id)) {
+          renderJobAssignments();
+        }
+      });
+
+      row.append(' ', select, btn);
+      container.appendChild(row);
+    }
+  });
+  if (!container.firstChild) {
+    container.textContent = 'No eligible cards.';
+  }
 }
 
 // ===== Stage and world management =====

--- a/style.css
+++ b/style.css
@@ -822,6 +822,21 @@ body {
     border: 2px solid grey;
 }
 
+.deckJobsContainer {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.job-entry {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    background: rgba(0, 0, 0, 0.3);
+    padding: 4px;
+    border-radius: 4px;
+}
+
 /* Star chart tab */
 .starChartTab {
     width: 100%;


### PR DESCRIPTION
## Summary
- integrate Jobs module with deck UI
- show eligible cards for job assignment once they reach level 20
- drop dedicated Jobs tab and embed jobs panel inside the Deck tab

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6850717beff483269c46827aaaf49ab5