### PR TITLE
Implement deck mastery and new deck tab UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -134,25 +134,16 @@
     <!-- close mainTab -->
     <!--------------deck tab----------------->
     <div class="deckTab">
-      <div class="vignette open">
-        <button class="vignette-toggle">Basic Deck</button>
-        <div class="vignette-content">
-          <div class="deckTabContainer">
-            <!-- <div id="deckDisplay"> Deck: 0</div> -->
-          </div>
-        </div>
+      <div class="deckSidePanel casino-section">
+        <button class="deckViewBtn">Decks</button>
+        <button class="jokerViewBtn">Jokers</button>
+        <button class="jobsViewBtn">Jobs</button>
       </div>
-      <div class="vignette">
-        <button class="vignette-toggle">Jokers</button>
-        <div class="vignette-content">
-          <div class="jokerContainer"></div>
-        </div>
-      </div>
-      <div class="vignette">
-        <button class="vignette-toggle">Jobs</button>
-        <div class="vignette-content">
-          <div class="deckJobsContainer"></div>
-        </div>
+      <div class="deckMainContainer casino-section">
+        <div class="deckListContainer"></div>
+        <div class="deckTabContainer" style="display:none;"></div>
+        <div class="jokerViewContainer" style="display:none;"></div>
+        <div class="deckJobsContainer" style="display:none;"></div>
       </div>
     </div>
     <div class="upgradesTab casino-section">

--- a/style.css
+++ b/style.css
@@ -810,10 +810,25 @@ body {
 /*============= deck tab panel============== */
 .deckTab {
     display: flex;
-    flex-direction: column;
     gap: 10px;
     background-color: #67a16c;
     padding: 5px;
+    height: 100vh;
+}
+
+.deckSidePanel {
+    flex: 1 1 33%;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.deckMainContainer {
+    flex: 1 1 67%;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
 }
 
 .deckTabContainer {
@@ -826,6 +841,49 @@ body {
     display: flex;
     flex-direction: column;
     gap: 4px;
+}
+
+.deckListContainer, .deckTabContainer, .jokerViewContainer {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+}
+
+.deck-row {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    height: 30px;
+}
+
+.deck-art {
+    width: 24px;
+    height: 32px;
+    object-fit: contain;
+}
+
+.deckMasteryBar {
+    position: relative;
+    flex: 1;
+    height: 8px;
+    background: rgba(0, 0, 0, 0.8);
+    border: 1px solid #d4af37;
+    border-radius: 4px;
+    overflow: hidden;
+}
+
+.deckMasteryFill {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: 0;
+    background: #d4af37;
+}
+
+.deck-req {
+    font-size: 0.7rem;
+    white-space: nowrap;
 }
 
 .job-entry {


### PR DESCRIPTION
## Summary
- add mastery tracking utilities in `deck.js`
- create new deck tab layout with side panel buttons
- implement deck view switching with progress bars for mastery levels
- update styles for deck tab rows and mastery bars

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850978cee48832682905efd233e3edf