### PR TITLE
Add canvas-based job carousel

### DIFF
--- a/style.css
+++ b/style.css
@@ -1338,6 +1338,13 @@ body {
     width: 100%;
 }
 
+.job-carousel-canvas {
+    width: 100%;
+    height: 220px;
+    touch-action: pan-y;
+    outline: none;
+}
+
 .job-carousel-wrapper {
     display: flex;
     align-items: center;


### PR DESCRIPTION
## Summary
- use a canvas element for Jobs display with smooth animation
- support navigation via keyboard arrows or swipes
- style the canvas element

## Testing
- `npm test` *(fails: mocha not found)*
- `npm install` *(fails to download puppeteer)*

------
https://chatgpt.com/codex/tasks/task_e_6850cbf691f8832685e2a909b3ce7a8a