### PR TITLE
Fix deck tab persistence and mastery bar points

### DIFF
--- a/deck.js
+++ b/deck.js
@@ -7,7 +7,8 @@ import { formatNumber } from './utils/numberFormat.js';
 
 // Required levels to reach each mastery tier
 export const masteryRequirements = [
-  10000,
+  // first tier is intentionally low for testing purposes
+  10,
   100000,
   1000000,
   10000000,

--- a/script.js
+++ b/script.js
@@ -804,7 +804,7 @@ function updateMasteryBars() {
 }
 
 function hideDeckViews() {
-  if (deckListContainer) deckListContainer.style.display = 'none';
+  // keep the deck list visible so mastery progress remains on screen
   if (deckTabContainer) deckTabContainer.style.display = 'none';
   if (jokerViewContainer) jokerViewContainer.style.display = 'none';
   if (deckJobsContainer) deckJobsContainer.style.display = 'none';


### PR DESCRIPTION
## Summary
- keep deck list visible when viewing other deck sub-panels
- reduce the first mastery tier requirement to 10 for testing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68517cabafa483269b4d5c0c8382f631