### PR TITLE
Implement Player Life tab

### DIFF
--- a/.codex/tasks.md
+++ b/.codex/tasks.md
@@ -23,6 +23,7 @@
 
 ## 🚧 Upcoming Goals
 - Fix dev tools: spawn boss does not update stage stats properly
+- Add Alternate Progression System (Player Life Tab)
 
 ## fixes
 

--- a/index.html
+++ b/index.html
@@ -43,6 +43,7 @@
       <button class="playerStatsTabButton">stats</button>
       <button class="upgradesTabButton">upgrades</button>
       <button class="worldTabButton">worlds</button>
+      <button class="playerTabButton">player</button>
     </div>
 
     <!--------------main tab panel----------------->
@@ -179,6 +180,10 @@
     <div class="worldsTab">
       <span id="worldProgressPerSecDisplay">Avg World Progress/sec: 0%</span>
       <div class="worldsContainer casino-section"></div>
+    </div>
+    <div class="playerTab">
+      <div class="player-actions"></div>
+      <div class="player-resources casino-section"></div>
     </div>
     <div id="tooltip"></div>
     <script type="module" src="script.js"></script>

--- a/playerLife.js
+++ b/playerLife.js
@@ -1,0 +1,144 @@
+export const lifeResources = {
+  focus: 0,
+  cleanliness: 0,
+  knowledge: 0,
+  mentalHealth: 0,
+  preparedness: 0,
+  cash: 0
+};
+
+const RESOURCE_CAP = 100;
+const CASH_CAP = 9999;
+
+const skills = {
+  focus: { xp: 0 },
+  cleanliness: { xp: 0 },
+  knowledge: { xp: 0 },
+  mentalHealth: { xp: 0 },
+  preparedness: { xp: 0 }
+};
+
+const actions = [
+  {
+    id: 'meditate',
+    label: 'Meditate',
+    skill: 'focus',
+    resource: 'focus',
+    xpGain: 1,
+    resGain: 1,
+    unlockSkill: null,
+    unlockXp: 0
+  },
+  {
+    id: 'cleanRoom',
+    label: 'Clean Room',
+    skill: 'cleanliness',
+    resource: 'cleanliness',
+    xpGain: 1,
+    resGain: 1,
+    unlockSkill: 'focus',
+    unlockXp: 5
+  },
+  {
+    id: 'readBook',
+    label: 'Read Book',
+    skill: 'knowledge',
+    resource: 'knowledge',
+    xpGain: 1,
+    resGain: 1,
+    unlockSkill: 'cleanliness',
+    unlockXp: 5
+  },
+  {
+    id: 'writeJournal',
+    label: 'Write Journal',
+    skill: 'mentalHealth',
+    resource: 'mentalHealth',
+    xpGain: 1,
+    resGain: 1,
+    unlockSkill: 'knowledge',
+    unlockXp: 5
+  },
+  {
+    id: 'jobSearch',
+    label: 'Job Search',
+    skill: 'preparedness',
+    resource: 'preparedness',
+    xpGain: 1,
+    resGain: 1,
+    unlockSkill: 'mentalHealth',
+    unlockXp: 5
+  }
+];
+
+let getGameCash = () => 0;
+let spendGameCash = () => 0;
+let actionsContainer;
+let resourcesContainer;
+
+function addResource(key, amt) {
+  const cap = key === 'cash' ? CASH_CAP : RESOURCE_CAP;
+  lifeResources[key] = Math.min(cap, lifeResources[key] + amt);
+}
+
+function performAction(action) {
+  addResource(action.resource, action.resGain);
+  skills[action.skill].xp += action.xpGain;
+  renderResources();
+  renderActions();
+}
+
+function isActionUnlocked(action) {
+  if (!action.unlockSkill) return true;
+  return skills[action.unlockSkill].xp >= action.unlockXp;
+}
+
+function renderActions() {
+  if (!actionsContainer) return;
+  actionsContainer.innerHTML = '';
+  actions.forEach(act => {
+    if (!isActionUnlocked(act)) return;
+    const btn = document.createElement('button');
+    btn.textContent = act.label;
+    btn.addEventListener('click', () => performAction(act));
+    actionsContainer.appendChild(btn);
+  });
+  const transfer = document.createElement('button');
+  transfer.textContent = 'Transfer Cash';
+  transfer.addEventListener('click', transferCashFromGame);
+  actionsContainer.appendChild(transfer);
+}
+
+function renderResources() {
+  if (!resourcesContainer) return;
+  resourcesContainer.innerHTML = '';
+  ['focus','cleanliness','knowledge','mentalHealth','preparedness','cash']
+    .forEach(k => {
+      const row = document.createElement('div');
+      row.classList.add('resource-entry');
+      row.textContent = `${k.charAt(0).toUpperCase()+k.slice(1)}: ${lifeResources[k]}`;
+      resourcesContainer.appendChild(row);
+    });
+}
+
+export function transferCashFromGame() {
+  const available = Math.min(getGameCash(), CASH_CAP - lifeResources.cash);
+  if (available <= 0) return;
+  spendGameCash(available);
+  addResource('cash', available);
+  renderResources();
+}
+
+export function initPlayerLife(opts = {}) {
+  getGameCash = opts.getGameCash || getGameCash;
+  spendGameCash = opts.spendGameCash || spendGameCash;
+  actionsContainer = document.querySelector('.player-actions');
+  resourcesContainer = document.querySelector('.player-resources');
+  renderActions();
+  renderResources();
+}
+
+export function refreshPlayerLife() {
+  renderActions();
+  renderResources();
+}

--- a/script.js
+++ b/script.js
@@ -20,6 +20,7 @@ import {
 import {
   initStarChart
 } from "./starChart.js"; // optional star chart tab
+import { initPlayerLife, refreshPlayerLife } from "./playerLife.js";
 import { Jobs, assignJob, getAvailableJobs, renderJobAssignments, renderJobCarousel } from "./jobs.js"; // job definitions
 import RateTracker from "./utils/rateTracker.js";
 import { formatNumber } from "./utils/numberFormat.js";
@@ -79,6 +80,15 @@ let cardPoints = 0;
 // Track how many card points have already been converted to cash
 let lastCashOutPoints = 0;
 let currentEnemy = null;
+
+function spendCash(amount) {
+  const amt = Math.min(amount, cash);
+  cash -= amt;
+  if (cashDisplay) cashDisplay.textContent = `Cash: $${formatNumber(cash)}`;
+  cashRateTracker.record(cash);
+  updateUpgradeButtons();
+  return amt;
+}
 
 // track how many upgrade power points have been bought total
 let upgradePowerPurchased = 0;
@@ -277,12 +287,14 @@ let starChartTabButton;
 let playerStatsTabButton;
 let worldTabButton;
 let upgradesTabButton;
+let playerTabButton;
 let mainTab;
 let deckTab;
 let starChartTab;
 let playerStatsTab;
 let worldsTab;
 let upgradesTab;
+let playerTab;
 let barSubTabButton;
 let cardSubTabButton;
 let barUpgradesPanel;
@@ -326,6 +338,7 @@ function hideTab() {
   if (playerStatsTab) playerStatsTab.style.display = "none";
   if (worldsTab) worldsTab.style.display = "none";
   if (upgradesTab) upgradesTab.style.display = "none";
+  if (playerTab) playerTab.style.display = "none";
 }
 
 function showTab(tab) {
@@ -366,12 +379,14 @@ function initTabs() {
   playerStatsTabButton = document.querySelector('.playerStatsTabButton');
   worldTabButton = document.querySelector('.worldTabButton');
   upgradesTabButton = document.querySelector('.upgradesTabButton');
+  playerTabButton = document.querySelector('.playerTabButton');
   mainTab = document.querySelector('.mainTab');
   deckTab = document.querySelector('.deckTab');
   starChartTab = document.querySelector('.starChartTab');
   playerStatsTab = document.querySelector('.playerStatsTab');
   worldsTab = document.querySelector('.worldsTab');
   upgradesTab = document.querySelector('.upgradesTab');
+  playerTab = document.querySelector('.playerTab');
   barSubTabButton = document.querySelector('.barSubTabButton');
   cardSubTabButton = document.querySelector('.cardSubTabButton');
   barUpgradesPanel = document.querySelector('.bar-upgrades-panel');
@@ -417,6 +432,14 @@ function initTabs() {
       renderWorldsMenu();
       showTab(worldsTab);
       setActiveTabButton(worldTabButton);
+    });
+  }
+
+  if (playerTabButton) {
+    playerTabButton.addEventListener('click', () => {
+      refreshPlayerLife();
+      showTab(playerTab);
+      setActiveTabButton(playerTabButton);
     });
   }
 
@@ -853,6 +876,7 @@ document.addEventListener("DOMContentLoaded", () => {
   initTabs();
   loadGame();
   initVignetteToggles();
+  initPlayerLife({ getGameCash: () => cash, spendGameCash: spendCash });
   showDeckListView();
   Object.values(upgrades).forEach(u => u.effect({ stats, pDeck, stageData, systems }));
   renderUpgrades();

--- a/style.css
+++ b/style.css
@@ -1390,3 +1390,42 @@ body {
 .job-info {
     text-align: center;
 }
+
+/* Player life tab */
+.playerTab {
+    display: flex;
+    gap: 10px;
+    background-color: #556b7a;
+    padding: 5px;
+    height: 100vh;
+}
+
+.player-actions {
+    flex: 1 1 70%;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.player-actions button {
+    padding: 6px;
+    border: 2px solid #d4af37;
+    background: rgba(0, 0, 0, 0.4);
+    color: #d4af37;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 0.8rem;
+}
+
+.player-resources {
+    flex: 0 0 180px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    font-size: 0.8rem;
+}
+
+.player-resources .resource-entry {
+    display: flex;
+    justify-content: space-between;
+}


### PR DESCRIPTION
## Summary
- track roadmap item to add alternate progression system
- add Player tab markup and styling
- implement a basic life-simulation system in `playerLife.js`
- wire the Player tab into tab controls and cash logic

## Testing
- `npm test --silent` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_685223b7c83083269655a3e8d3ed0750