### PR TITLE
Add life card UI

### DIFF
--- a/playerLife.js
+++ b/playerLife.js
@@ -18,6 +18,7 @@ const skills = {
   preparedness: { xp: 0 }
 };
 
+const ACTION_DURATION = 10; // seconds per resource tick
 const actions = [
   {
     id: 'meditate',
@@ -26,6 +27,7 @@ const actions = [
     resource: 'focus',
     xpGain: 1,
     resGain: 1,
+    duration: ACTION_DURATION,
     unlockSkill: null,
     unlockXp: 0
   },
@@ -36,6 +38,7 @@ const actions = [
     resource: 'cleanliness',
     xpGain: 1,
     resGain: 1,
+    duration: ACTION_DURATION,
     unlockSkill: 'focus',
     unlockXp: 5
   },
@@ -46,6 +49,7 @@ const actions = [
     resource: 'knowledge',
     xpGain: 1,
     resGain: 1,
+    duration: ACTION_DURATION,
     unlockSkill: 'cleanliness',
     unlockXp: 5
   },
@@ -56,6 +60,7 @@ const actions = [
     resource: 'mentalHealth',
     xpGain: 1,
     resGain: 1,
+    duration: ACTION_DURATION,
     unlockSkill: 'knowledge',
     unlockXp: 5
   },
@@ -66,6 +71,7 @@ const actions = [
     resource: 'preparedness',
     xpGain: 1,
     resGain: 1,
+    duration: ACTION_DURATION,
     unlockSkill: 'mentalHealth',
     unlockXp: 5
   }
@@ -75,17 +81,60 @@ let getGameCash = () => 0;
 let spendGameCash = () => 0;
 let actionsContainer;
 let resourcesContainer;
+const unlockedActions = new Set();
+const actionStates = {};
+let tickTimer;
 
 function addResource(key, amt) {
   const cap = key === 'cash' ? CASH_CAP : RESOURCE_CAP;
   lifeResources[key] = Math.min(cap, lifeResources[key] + amt);
 }
 
-function performAction(action) {
-  addResource(action.resource, action.resGain);
-  skills[action.skill].xp += action.xpGain;
-  renderResources();
+function startAction(action) {
+  const state = actionStates[action.id] || { active: false, elapsed: 0 };
+  if (state.active) return;
+  state.active = true;
+  state.elapsed = 0;
+  actionStates[action.id] = state;
   renderActions();
+}
+
+function cancelAction(id) {
+  const state = actionStates[id];
+  if (state) state.active = false;
+  renderActions();
+}
+
+function tickActions(delta) {
+  let refreshed = false;
+  Object.entries(actionStates).forEach(([id, state]) => {
+    if (!state.active) return;
+    state.elapsed += delta;
+    const action = actions.find(a => a.id === id);
+    if (!action) return;
+    if (state.elapsed >= action.duration) {
+      state.elapsed -= action.duration;
+      addResource(action.resource, action.resGain);
+      skills[action.skill].xp += action.xpGain;
+      refreshed = true;
+    }
+  });
+  if (refreshed) {
+    renderResources();
+    checkUnlocks();
+  }
+  renderActions();
+}
+
+function checkUnlocks() {
+  let changed = false;
+  actions.forEach(a => {
+    if (!unlockedActions.has(a.id) && isActionUnlocked(a)) {
+      unlockedActions.add(a.id);
+      changed = true;
+    }
+  });
+  if (changed) renderActions();
 }
 
 function isActionUnlocked(action) {
@@ -98,10 +147,55 @@ function renderActions() {
   actionsContainer.innerHTML = '';
   actions.forEach(act => {
     if (!isActionUnlocked(act)) return;
-    const btn = document.createElement('button');
-    btn.textContent = act.label;
-    btn.addEventListener('click', () => performAction(act));
-    actionsContainer.appendChild(btn);
+    const state = actionStates[act.id] || { active: false, elapsed: 0 };
+    if (!unlockedActions.has(act.id)) {
+      unlockedActions.add(act.id);
+      state.fadeIn = true;
+    }
+    actionStates[act.id] = state;
+
+    const card = document.createElement('div');
+    card.classList.add('life-card');
+    if (state.fadeIn) {
+      card.classList.add('fade-in');
+      state.fadeIn = false;
+    }
+    if (state.active) card.classList.add('active');
+
+    const header = document.createElement('div');
+    header.classList.add('life-card-title');
+    header.textContent = act.label;
+
+    const desc = document.createElement('div');
+    desc.classList.add('life-card-desc');
+    desc.textContent = `+${act.resGain} ${act.resource} every ${act.duration}s`;
+
+    const actionBar = document.createElement('div');
+    actionBar.classList.add('life-card-action');
+    if (state.active) {
+      const timer = document.createElement('div');
+      timer.classList.add('life-card-timer');
+      timer.textContent = `${Math.ceil(act.duration - state.elapsed)}s`; 
+      const cancelBtn = document.createElement('button');
+      cancelBtn.textContent = 'Cancel';
+      cancelBtn.addEventListener('click', () => cancelAction(act.id));
+      actionBar.append(timer, cancelBtn);
+    } else {
+      const startBtn = document.createElement('button');
+      startBtn.textContent = 'Start';
+      startBtn.addEventListener('click', () => startAction(act));
+      actionBar.appendChild(startBtn);
+    }
+
+    const xp = skills[act.skill].xp;
+    const level = Math.floor(xp / 10) + 1;
+    const progress = xp % 10;
+    const progressEl = document.createElement('div');
+    progressEl.classList.add('life-card-progress');
+    progressEl.textContent = `Level ${level} - XP: ${progress}/10`;
+
+    card.append(header, desc, actionBar, progressEl);
+    actionsContainer.appendChild(card);
   });
   const transfer = document.createElement('button');
   transfer.textContent = 'Transfer Cash';
@@ -136,6 +230,9 @@ export function initPlayerLife(opts = {}) {
   resourcesContainer = document.querySelector('.player-resources');
   renderActions();
   renderResources();
+  if (!tickTimer) {
+    tickTimer = setInterval(() => tickActions(1), 1000);
+  }
 }
 
 export function refreshPlayerLife() {

--- a/style.css
+++ b/style.css
@@ -1429,3 +1429,53 @@ body {
     display: flex;
     justify-content: space-between;
 }
+
+/* life cards */
+.life-card {
+    border: 2px solid #d4af37;
+    border-radius: 8px;
+    background: rgba(0, 0, 0, 0.4);
+    color: #d4af37;
+    padding: 6px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
+}
+
+.life-card.fade-in {
+    animation: life-fade-in 0.4s ease-out;
+}
+
+.life-card.active {
+    animation: glow-pulse 1s infinite alternate;
+}
+
+.life-card-title {
+    font-weight: bold;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.life-card-desc {
+    font-size: 0.8rem;
+}
+
+.life-card-action {
+    text-align: center;
+}
+
+.life-card-progress {
+    font-size: 0.7rem;
+    text-align: center;
+}
+
+.life-card-timer {
+    margin-bottom: 4px;
+}
+
+@keyframes life-fade-in {
+    from { opacity: 0; transform: translateY(10px); }
+    to { opacity: 1; transform: translateY(0); }
+}


### PR DESCRIPTION
## Summary
- add timed life card actions with levels
- fade in new unlocked actions and show progress
- style life cards with gold borders and glow on activation

## Testing
- `npm test`
- `npm run lint` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68522a3592048326ad540a95e3ac7412