### PR TITLE
Implement mind orb progression and update player core layout

### DIFF
--- a/core.js
+++ b/core.js
@@ -1,6 +1,6 @@
 export const coreState = {
   coreLevel: 1,
-  mind: { level: 1, xp: 0, maxXP: 10 },
+  mind: { level: 1, xp: 0, maxXP: 1000 },
   body: { level: 1, xp: 0, maxXP: 10 },
   soul: { level: 1, xp: 0, maxXP: 10 },
   meditating: false
@@ -16,6 +16,8 @@ export function initCore() {
   container.innerHTML = `\n    <svg id="coreDiagram" viewBox="0 0 400 400" width="100%" height="100%">\n      <path d="M200 140\n               C185 140, 180 120, 200 120\n               C220 120, 215 140, 200 140\n               M190 140\n               C170 160, 170 190, 185 200\n               C170 210, 170 240, 200 240\n               C230 240, 230 210, 215 200\n               C230 190, 230 160, 210 140\n               Z"\n            fill="rgba(0,0,0,0.5)" stroke="#888" stroke-width="2" />\n\n      <circle id="mindOrb" cx="200" cy="60" r="20" fill="rgba(100,150,255,0.3)" stroke="#88aaff" stroke-width="2" />\n      <circle id="bodyOrb" cx="120" cy="220" r="20" fill="rgba(255,100,100,0.3)" stroke="#ff8888" stroke-width="2" />\n      <circle id="soulOrb" cx="280" cy="220" r="20" fill="rgba(180,100,255,0.3)" stroke="#cc88ff" stroke-width="2" />\n    </svg>\n    <button id="meditateCoreBtn" disabled>Meditate Core</button>\n    <div id="coreLevelText" class="core-level-text"></div>\n  `;
   meditateBtn = container.querySelector('#meditateCoreBtn');
   levelDisplay = container.querySelector('#coreLevelText');
+  const mindOrb = container.querySelector('#mindOrb');
+  mindOrb.addEventListener('click', onMindOrbClick);
   meditateBtn.addEventListener('click', startMeditation);
   renderCore();
 }
@@ -31,6 +33,15 @@ export function addCoreXP(type, amt = 1) {
     type === 'soul' ? coreState.soul : null;
   if (!orb) return;
   orb.xp = Math.min(orb.maxXP, orb.xp + amt);
+  renderCore();
+}
+
+function onMindOrbClick() {
+  if (coreState.mind.xp < coreState.mind.maxXP) return;
+  coreState.mind.level += 1;
+  coreState.mind.xp = 0;
+  coreState.mind.maxXP = Math.floor(coreState.mind.maxXP * 1.5);
+  window.dispatchEvent(new CustomEvent('core-mind-upgrade'));
   renderCore();
 }
 
@@ -58,9 +69,15 @@ function renderCore() {
   const mindFill = Math.min(1, coreState.mind.xp / coreState.mind.maxXP);
   const bodyFill = Math.min(1, coreState.body.xp / coreState.body.maxXP);
   const soulFill = Math.min(1, coreState.soul.xp / coreState.soul.maxXP);
-  container.querySelector('#mindOrb').setAttribute('fill', `rgba(100,150,255,${0.3 + 0.7 * mindFill})`);
-  container.querySelector('#bodyOrb').setAttribute('fill', `rgba(255,100,100,${0.3 + 0.7 * bodyFill})`);
-  container.querySelector('#soulOrb').setAttribute('fill', `rgba(180,100,255,${0.3 + 0.7 * soulFill})`);
+  const mindOrb = container.querySelector('#mindOrb');
+  mindOrb.setAttribute('fill', `rgba(100,150,255,${0.3 + 0.7 * mindFill})`);
+  mindOrb.setAttribute('stroke', mindFill >= 1 ? '#ffffaa' : '#88aaff');
+  container
+    .querySelector('#bodyOrb')
+    .setAttribute('fill', `rgba(255,100,100,${0.3 + 0.7 * bodyFill})`);
+  container
+    .querySelector('#soulOrb')
+    .setAttribute('fill', `rgba(180,100,255,${0.3 + 0.7 * soulFill})`);
   levelDisplay.textContent = `Core Level: ${coreState.coreLevel}`;
   const ready = mindFill >= 1 && bodyFill >= 1 && soulFill >= 1 && !coreState.meditating;
   meditateBtn.disabled = !ready;

--- a/index.html
+++ b/index.html
@@ -182,16 +182,18 @@
       <div class="worldsContainer casino-section"></div>
     </div>
     <div class="playerTab">
-      <div class="player-subtabs">
+      <div class="playerSidePanel casino-section">
         <button class="playerLifeSubTabButton active">Life</button>
         <button class="playerCoreSubTabButton">Core</button>
       </div>
-      <div class="player-life-panel">
-        <div class="player-actions"></div>
-        <div class="player-resources casino-section"></div>
-      </div>
-      <div class="player-core-panel" style="display:none;">
-        <div id="coreTabContent" class="casino-section"></div>
+      <div class="playerMainContainer">
+        <div class="player-life-panel">
+          <div class="player-actions"></div>
+          <div class="player-resources casino-section"></div>
+        </div>
+        <div class="player-core-panel" style="display:none;">
+          <div id="coreTabContent"></div>
+        </div>
       </div>
     </div>
     <div id="tooltip"></div>

--- a/script.js
+++ b/script.js
@@ -24,7 +24,7 @@ import { initPlayerLife, refreshPlayerLife } from "./playerLife.js";
 import { Jobs, assignJob, getAvailableJobs, renderJobAssignments, renderJobCarousel } from "./jobs.js"; // job definitions
 import RateTracker from "./utils/rateTracker.js";
 import { formatNumber } from "./utils/numberFormat.js";
-import { initCore, refreshCore } from './core.js';
+import { initCore, refreshCore, addCoreXP } from './core.js';
 import {
   rollNewCardUpgrades,
   applyCardUpgrade,
@@ -902,6 +902,10 @@ document.addEventListener("DOMContentLoaded", () => {
   initVignetteToggles();
   initPlayerLife({ getGameCash: () => cash, spendGameCash: spendCash });
   initCore();
+  window.addEventListener('core-mind-upgrade', () => {
+    stats.maxMana += 10;
+    updateManaBar();
+  });
   showDeckListView();
   Object.values(upgrades).forEach(u => u.effect({ stats, pDeck, stageData, systems }));
   renderUpgrades();
@@ -2411,6 +2415,7 @@ stats.maxMana,
 stats.mana + (stats.manaRegen * deltaTime) / 1000
 );
 updateManaBar();
+ addCoreXP('mental', (stats.manaRegen * deltaTime) / 1000);
 }
 
   // passive progress for bar upgrades

--- a/style.css
+++ b/style.css
@@ -1399,6 +1399,18 @@ body {
     padding: 5px;
     height: 100vh;
 }
+.playerSidePanel {
+    flex: 1 1 20%;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+.playerMainContainer {
+    flex: 1 1 80%;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
 
 .player-actions {
     flex: 1 1 70%;
@@ -1482,11 +1494,11 @@ body {
 
 .player-subtabs {
     display: flex;
+    flex-direction: column;
     gap: 6px;
-    margin-bottom: 6px;
 }
 .player-subtabs button {
-    flex: 1;
+    width: 100%;
     background: rgba(0, 0, 0, 0.4);
     color: #d4af37;
     border: 2px solid #d4af37;
@@ -1510,6 +1522,12 @@ body {
     align-items: center;
     gap: 6px;
     flex: 1;
+}
+#coreTabContent {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 6px;
 }
 #coreTabContent svg {
     max-width: 300px;


### PR DESCRIPTION
## Summary
- move player Life/Core buttons to a vertical side panel
- remove casino-section styling around the core SVG
- track mind orb progress from mana regeneration
- allow clicking the filled mind orb to boost max mana
- adjust styles for new player core layout

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853387ada708326a1a256aead6fdd1e