### PR TITLE
Implement core orb progress and healing XP

### DIFF
--- a/cardManagement.js
+++ b/cardManagement.js
@@ -1,3 +1,5 @@
+import { addCoreXP } from "./core.js";
+
 export function drawCard(state) {
   const {
     deck,
@@ -61,7 +63,10 @@ export function redrawHand(state) {
   shuffleArray(deck);
   if (stats.healOnRedraw > 0) {
     pDeck.forEach(c => {
+      const before = c.currentHp;
       c.currentHp = Math.min(c.maxHp, c.currentHp + stats.healOnRedraw);
+      const gained = c.currentHp - before;
+      if (gained > 0) addCoreXP('physical', gained);
     });
   }
   while (drawnCards.length < stats.cardSlots && deck.length > 0) {

--- a/core.js
+++ b/core.js
@@ -9,16 +9,20 @@ export const coreState = {
 let container;
 let meditateBtn;
 let levelDisplay;
+let soulTimer;
 
 export function initCore() {
   container = document.getElementById('coreTabContent');
   if (!container) return;
-  container.innerHTML = `\n    <svg id="coreDiagram" viewBox="0 0 400 400" width="100%" height="100%">\n      <path d="M200 140\n               C185 140, 180 120, 200 120\n               C220 120, 215 140, 200 140\n               M190 140\n               C170 160, 170 190, 185 200\n               C170 210, 170 240, 200 240\n               C230 240, 230 210, 215 200\n               C230 190, 230 160, 210 140\n               Z"\n            fill="rgba(0,0,0,0.5)" stroke="#888" stroke-width="2" />\n\n      <circle id="mindOrb" cx="200" cy="60" r="20" fill="rgba(100,150,255,0.3)" stroke="#88aaff" stroke-width="2" />\n      <circle id="bodyOrb" cx="120" cy="220" r="20" fill="rgba(255,100,100,0.3)" stroke="#ff8888" stroke-width="2" />\n      <circle id="soulOrb" cx="280" cy="220" r="20" fill="rgba(180,100,255,0.3)" stroke="#cc88ff" stroke-width="2" />\n    </svg>\n    <button id="meditateCoreBtn" disabled>Meditate Core</button>\n    <div id="coreLevelText" class="core-level-text"></div>\n  `;
+  container.innerHTML = `\n    <svg id="coreDiagram" viewBox="0 0 400 400" width="100%" height="100%">\n      <path d="M200 140\n               C185 140, 180 120, 200 120\n               C220 120, 215 140, 200 140\n               M190 140\n               C170 160, 170 190, 185 200\n               C170 210, 170 240, 200 240\n               C230 240, 230 210, 215 200\n               C230 190, 230 160, 210 140\n               Z"\n            fill="rgba(0,0,0,0.5)" stroke="#888" stroke-width="2" />\n\n      <circle id="mindOrb" cx="200" cy="60" r="20" fill="rgba(100,150,255,0.3)" stroke="#88aaff" stroke-width="2" />\n      <text id="mindText" x="200" y="95" text-anchor="middle" class="orb-text"></text>\n      <circle id="bodyOrb" cx="120" cy="220" r="20" fill="rgba(255,100,100,0.3)" stroke="#ff8888" stroke-width="2" />\n      <text id="bodyText" x="120" y="255" text-anchor="middle" class="orb-text"></text>\n      <circle id="soulOrb" cx="280" cy="220" r="20" fill="rgba(180,100,255,0.3)" stroke="#cc88ff" stroke-width="2" />\n      <text id="soulText" x="280" y="255" text-anchor="middle" class="orb-text"></text>\n    </svg>\n    <button id="meditateCoreBtn" disabled>Meditate Core</button>\n    <div id="coreLevelText" class="core-level-text"></div>\n  `;
   meditateBtn = container.querySelector('#meditateCoreBtn');
   levelDisplay = container.querySelector('#coreLevelText');
   const mindOrb = container.querySelector('#mindOrb');
   mindOrb.addEventListener('click', onMindOrbClick);
   meditateBtn.addEventListener('click', startMeditation);
+  if (!soulTimer) {
+    soulTimer = setInterval(() => addCoreXP('soul', 0.5), 1000);
+  }
   renderCore();
 }
 
@@ -72,12 +76,18 @@ function renderCore() {
   const mindOrb = container.querySelector('#mindOrb');
   mindOrb.setAttribute('fill', `rgba(100,150,255,${0.3 + 0.7 * mindFill})`);
   mindOrb.setAttribute('stroke', mindFill >= 1 ? '#ffffaa' : '#88aaff');
+  const mindText = container.querySelector('#mindText');
+  if (mindText) mindText.textContent = `${Math.floor(coreState.mind.xp)}/${coreState.mind.maxXP}`;
   container
     .querySelector('#bodyOrb')
     .setAttribute('fill', `rgba(255,100,100,${0.3 + 0.7 * bodyFill})`);
+  const bodyText = container.querySelector('#bodyText');
+  if (bodyText) bodyText.textContent = `${Math.floor(coreState.body.xp)}/${coreState.body.maxXP}`;
   container
     .querySelector('#soulOrb')
     .setAttribute('fill', `rgba(180,100,255,${0.3 + 0.7 * soulFill})`);
+  const soulText = container.querySelector('#soulText');
+  if (soulText) soulText.textContent = `${Math.floor(coreState.soul.xp)}/${coreState.soul.maxXP}`;
   levelDisplay.textContent = `Core Level: ${coreState.coreLevel}`;
   const ready = mindFill >= 1 && bodyFill >= 1 && soulFill >= 1 && !coreState.meditating;
   meditateBtn.disabled = !ready;

--- a/index.html
+++ b/index.html
@@ -21,6 +21,10 @@
       <label>Damage Mult: <input id="debugDamageMult" type="number" value="1" step="0.1" style="width: 50px;"></label>
       <button onclick="devTools.setDamageMult()">Set</button>
       <button onclick="devTools.toggleFastMode()">Fast Mode</button>
+      <br>
+
+      <label>Mana Regen + <input id="debugManaRegen" type="number" value="0.1" step="0.1" style="width: 50px;"></label>
+      <button onclick="devTools.addManaRegen()">Add</button>
       <br><br>
 
       <button onclick="devTools.spawnBoss()">Spawn Boss</button>

--- a/script.js
+++ b/script.js
@@ -1728,9 +1728,12 @@ function heartHeal() {
 
   drawnCards.forEach(card => {
     if (card.suit === "Hearts") {
+      const before = target.currentHp;
       target.currentHp = Math.round(
         Math.min(target.currentHp + card.currentLevel, target.maxHp)
       );
+      const gained = target.currentHp - before;
+      if (gained > 0) addCoreXP('physical', gained);
       animateCardHeal(target);
     }
   });
@@ -1805,7 +1808,10 @@ function animateCardDeath(card, callback) {
 function healCardsOnKill() {
   drawnCards.forEach(card => {
     if (!card) return;
+    const before = card.currentHp;
     card.healFromKill();
+    const gained = card.currentHp - before;
+    if (gained > 0) addCoreXP('physical', gained);
   });
   updateHandDisplay();
   updateDeckDisplay();
@@ -1885,7 +1891,9 @@ function useJoker(joker) {
         if (!card) return;
         const before = card.currentHp;
         card.currentHp = Math.round(Math.min(card.maxHp, card.currentHp + healAmt));
-        if (card.currentHp > before) {
+        const gained = card.currentHp - before;
+        if (gained > 0) {
+          addCoreXP('physical', gained);
           card.hpDisplay.textContent = `HP: ${formatNumber(Math.round(card.currentHp))}/${formatNumber(Math.round(card.maxHp))}`;
           animateCardHeal(card);
         }
@@ -2488,6 +2496,11 @@ if (!isNaN(mult)) {
 stats.damageMultiplier = mult;
 renderPlayerStats(stats);
 }
+},
+addManaRegen: () => {
+const amt = parseFloat(document.getElementById("debugManaRegen").value) || 0;
+stats.manaRegen += amt;
+renderPlayerStats(stats);
 },
 toggleFastMode: () => {
 timeScale = timeScale === 1 ? FAST_MODE_SCALE: 1;

--- a/style.css
+++ b/style.css
@@ -1535,3 +1535,9 @@ body {
 .core-level-text {
     margin-top: 4px;
 }
+
+.orb-text {
+    font-size: 0.8rem;
+    fill: #d4af37;
+    pointer-events: none;
+}


### PR DESCRIPTION
## Summary
- show progress values under each core orb
- animate body XP gain from card heals
- tick soul orb automatically over time
- add a debug control to increase mana regen

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_68533bd083fc8326acfd3127180e42ce