### PR TITLE
Add SVG fill progress for core

### DIFF
--- a/core.js
+++ b/core.js
@@ -9,14 +9,51 @@ export const coreState = {
 let container;
 let meditateBtn;
 let levelDisplay;
+let progressText;
 let soulTimer;
 
 export function initCore() {
   container = document.getElementById('coreTabContent');
   if (!container) return;
-  container.innerHTML = `\n    <svg id="coreDiagram" viewBox="0 0 400 400" width="100%" height="100%">\n      <path d="M200 140\n               C185 140, 180 120, 200 120\n               C220 120, 215 140, 200 140\n               M190 140\n               C170 160, 170 190, 185 200\n               C170 210, 170 240, 200 240\n               C230 240, 230 210, 215 200\n               C230 190, 230 160, 210 140\n               Z"\n            fill="rgba(0,0,0,0.5)" stroke="#888" stroke-width="2" />\n\n      <circle id="mindOrb" cx="200" cy="60" r="20" fill="rgba(100,150,255,0.3)" stroke="#88aaff" stroke-width="2" />\n      <text id="mindText" x="200" y="95" text-anchor="middle" class="orb-text"></text>\n      <circle id="bodyOrb" cx="120" cy="220" r="20" fill="rgba(255,100,100,0.3)" stroke="#ff8888" stroke-width="2" />\n      <text id="bodyText" x="120" y="255" text-anchor="middle" class="orb-text"></text>\n      <circle id="soulOrb" cx="280" cy="220" r="20" fill="rgba(180,100,255,0.3)" stroke="#cc88ff" stroke-width="2" />\n      <text id="soulText" x="280" y="255" text-anchor="middle" class="orb-text"></text>\n    </svg>\n    <button id="meditateCoreBtn" disabled>Meditate Core</button>\n    <div id="coreLevelText" class="core-level-text"></div>\n  `;
-  meditateBtn = container.querySelector('#meditateCoreBtn');
+const bodyPath = `M200 140
+               C185 140, 180 120, 200 120
+               C220 120, 215 140, 200 140
+               M190 140
+               C170 160, 170 190, 185 200
+               C170 210, 170 240, 200 240
+               C230 240, 230 210, 215 200
+               C230 190, 230 160, 210 140
+               Z`;
+  container.innerHTML = `
+    <svg id="coreDiagram" viewBox="0 0 400 400" width="100%" height="100%">
+      <defs>
+        <clipPath id="bodyShapeClip"><path d="${bodyPath}" /></clipPath>
+        <clipPath id="mindClip"><circle cx="200" cy="60" r="20" /></clipPath>
+        <clipPath id="bodyOrbClip"><circle cx="120" cy="220" r="20" /></clipPath>
+        <clipPath id="soulClip"><circle cx="280" cy="220" r="20" /></clipPath>
+      </defs>
+      <path d="${bodyPath}" fill="rgba(0,0,0,0.3)" stroke="#888" stroke-width="2" />
+      <rect id="bodyFill" x="170" y="240" width="60" height="0" fill="rgba(255,255,255,0.4)" clip-path="url(#bodyShapeClip)" />
+      <circle cx="200" cy="60" r="20" fill="rgba(100,150,255,0.3)" />
+      <rect id="mindFill" x="180" y="80" width="40" height="0" fill="rgba(100,150,255,0.6)" clip-path="url(#mindClip)" />
+      <circle id="mindOrb" cx="200" cy="60" r="20" fill="none" stroke="#88aaff" stroke-width="2" />
+      <text id="mindText" x="200" y="95" text-anchor="middle" class="orb-text"></text>
+      <circle cx="120" cy="220" r="20" fill="rgba(255,100,100,0.3)" />
+      <rect id="bodyOrbFill" x="100" y="240" width="40" height="0" fill="rgba(255,100,100,0.6)" clip-path="url(#bodyOrbClip)" />
+      <circle id="bodyOrb" cx="120" cy="220" r="20" fill="none" stroke="#ff8888" stroke-width="2" />
+      <text id="bodyText" x="120" y="255" text-anchor="middle" class="orb-text"></text>
+      <circle cx="280" cy="220" r="20" fill="rgba(180,100,255,0.3)" />
+      <rect id="soulFill" x="260" y="240" width="40" height="0" fill="rgba(180,100,255,0.6)" clip-path="url(#soulClip)" />
+      <circle id="soulOrb" cx="280" cy="220" r="20" fill="none" stroke="#cc88ff" stroke-width="2" />
+      <text id="soulText" x="280" y="255" text-anchor="middle" class="orb-text"></text>
+      <text id="coreProgressText" x="200" y="260" text-anchor="middle" class="orb-text"></text>
+    </svg>
+    <button id="meditateCoreBtn" disabled>Meditate Core</button>
+    <div id="coreLevelText" class="core-level-text"></div>
+  `;
+  meditateBtn = container.querySelector("#meditateCoreBtn");
   levelDisplay = container.querySelector('#coreLevelText');
+  progressText = container.querySelector("#coreProgressText");
   const mindOrb = container.querySelector('#mindOrb');
   mindOrb.addEventListener('click', onMindOrbClick);
   meditateBtn.addEventListener('click', startMeditation);
@@ -73,21 +110,40 @@ function renderCore() {
   const mindFill = Math.min(1, coreState.mind.xp / coreState.mind.maxXP);
   const bodyFill = Math.min(1, coreState.body.xp / coreState.body.maxXP);
   const soulFill = Math.min(1, coreState.soul.xp / coreState.soul.maxXP);
+
+  const totalXP = coreState.mind.xp + coreState.body.xp + coreState.soul.xp;
+  const totalMax = coreState.mind.maxXP + coreState.body.maxXP + coreState.soul.maxXP;
+  const coreFill = Math.min(1, totalXP / totalMax);
+
+  const updateRect = (id, cx, cy, r, fill) => {
+    const rect = container.querySelector(id);
+    if (!rect) return;
+    const size = r * 2;
+    const h = size * fill;
+    rect.setAttribute('y', cy + r - h);
+    rect.setAttribute('height', h);
+  };
+
+  updateRect('#mindFill', 200, 60, 20, mindFill);
+  updateRect('#bodyOrbFill', 120, 220, 20, bodyFill);
+  updateRect('#soulFill', 280, 220, 20, soulFill);
+  updateRect('#bodyFill', 200, 180, 30, coreFill);
+
   const mindOrb = container.querySelector('#mindOrb');
-  mindOrb.setAttribute('fill', `rgba(100,150,255,${0.3 + 0.7 * mindFill})`);
-  mindOrb.setAttribute('stroke', mindFill >= 1 ? '#ffffaa' : '#88aaff');
+  if (mindOrb) mindOrb.setAttribute('stroke', mindFill >= 1 ? '#ffffaa' : '#88aaff');
+  const bodyOrb = container.querySelector('#bodyOrb');
+  if (bodyOrb) bodyOrb.setAttribute('stroke', bodyFill >= 1 ? '#ffcccc' : '#ff8888');
+  const soulOrb = container.querySelector('#soulOrb');
+  if (soulOrb) soulOrb.setAttribute('stroke', soulFill >= 1 ? '#ddaaff' : '#cc88ff');
+
   const mindText = container.querySelector('#mindText');
   if (mindText) mindText.textContent = `${Math.floor(coreState.mind.xp)}/${coreState.mind.maxXP}`;
-  container
-    .querySelector('#bodyOrb')
-    .setAttribute('fill', `rgba(255,100,100,${0.3 + 0.7 * bodyFill})`);
   const bodyText = container.querySelector('#bodyText');
   if (bodyText) bodyText.textContent = `${Math.floor(coreState.body.xp)}/${coreState.body.maxXP}`;
-  container
-    .querySelector('#soulOrb')
-    .setAttribute('fill', `rgba(180,100,255,${0.3 + 0.7 * soulFill})`);
   const soulText = container.querySelector('#soulText');
   if (soulText) soulText.textContent = `${Math.floor(coreState.soul.xp)}/${coreState.soul.maxXP}`;
+  const progressText = container.querySelector('#coreProgressText');
+  if (progressText) progressText.textContent = `${Math.floor(totalXP)}/${totalMax}`;
   levelDisplay.textContent = `Core Level: ${coreState.coreLevel}`;
   const ready = mindFill >= 1 && bodyFill >= 1 && soulFill >= 1 && !coreState.meditating;
   meditateBtn.disabled = !ready;


### PR DESCRIPTION
## Summary
- implement bodyPath clip and progress rectangles
- update renderCore to fill orbs and body from bottom-up
- show overall XP progress below core diagram

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_68533f76945883268212d9936b6fede6