### PR TITLE
Implement redraw cost and card upgrade overhaul

### DIFF
--- a/card.js
+++ b/card.js
@@ -122,7 +122,8 @@ export function recalcCardHp(card, stats = {}, barUpgrades = {}) {
   const suitMult =
     card.suit === 'Hearts' ? stats.heartHpMultiplier || 1 : 1;
   const maxHpMult = barUpgrades.maxHp?.multiplier || 1;
-  const hp = Math.round(baseHp * maxHpMult * suitMult);
+  const globalMult = stats.hpMultiplier || 1;
+  const hp = Math.round(baseHp * maxHpMult * suitMult * globalMult);
   const ratio = card.maxHp > 0 ? card.currentHp / card.maxHp : 1;
   card.maxHp = hp;
   card.currentHp = Math.round(Math.min(hp, ratio * hp));

--- a/cardUpgrades.js
+++ b/cardUpgrades.js
@@ -40,6 +40,23 @@ export const cardUpgradeDefinitions = {
       stats.cardSlots += 1;
     }
   },
+  hpMultiplier: {
+    id: 'hpMultiplier',
+    name: 'HP Multiplier x1.1',
+    rarity: 'common',
+    effect: ({ stats, updateAllCardHp }) => {
+      stats.hpMultiplier = (stats.hpMultiplier || 1) * 1.1;
+      if (typeof updateAllCardHp === 'function') updateAllCardHp();
+    }
+  },
+  damageMultiplier: {
+    id: 'damageMultiplier',
+    name: 'Damage Multiplier x1.1',
+    rarity: 'common',
+    effect: ({ stats }) => {
+      stats.extraDamageMultiplier = (stats.extraDamageMultiplier || 1) * 1.1;
+    }
+  },
   // Prestige unlocked upgrades
   maxMana: {
     id: 'maxMana',
@@ -255,13 +272,14 @@ export function createUpgradeCard(id) {
   return { upgradeId: id };
 }
 
-export function getCardUpgradeCost(id, stats) {
+export function getCardUpgradeCost(id, stats = {}, stageData = {}) {
   const def = cardUpgradeDefinitions[id];
   if (!def) return 0;
   const rarityMult = rarityCostMultiplier[def.rarity] || 1;
-  const handPoints = stats.points || 30;
-  const payout = Math.floor(handPoints * (1 + Math.sqrt(9)) * (stats.cashMulti || 1));
-  return Math.floor(payout * 100 * rarityMult);
+  const kills = Math.floor(Math.random() * 6) + 10; // 10-15 kills
+  const points = stats.points || 30;
+  const baseReward = Math.floor(points * (1 + Math.sqrt(stageData.stage || 1)));
+  return Math.floor(baseReward * kills * rarityMult);
 }
 
 export function addActiveUpgradeCardsToDeck(deck) {
@@ -279,13 +297,13 @@ export function applyCardUpgrade(id, context) {
 
 export function renderCardUpgrades(container, options = {}) {
   if (!container) return;
-  const { stats = {}, cash = 0, onPurchase = null } = options;
+  const { stats = {}, stageData = {}, cash = 0, onPurchase = null } = options;
   container.innerHTML = '';
   const ids = new Set([...activeCardUpgrades, ...Object.keys(upgradeLevels)]);
   ids.forEach(id => {
     const def = cardUpgradeDefinitions[id];
     const level = upgradeLevels[id] || 0;
-    const cost = getCardUpgradeCost(id, stats);
+    const cost = getCardUpgradeCost(id, stats, stageData);
     const wrapper = document.createElement('div');
     wrapper.classList.add('card-wrapper');
     wrapper.dataset.id = id;

--- a/index.html
+++ b/index.html
@@ -46,6 +46,7 @@
       <button class="starChartTabButton">star chart</button>
       <button class="playerStatsTabButton">stats</button>
       <button class="upgradesTabButton">upgrades</button>
+      <button class="cardUpgradesTabButton">card upgrades</button>
       <button class="worldTabButton">worlds</button>
       <button class="playerTabButton">player</button>
     </div>
@@ -84,6 +85,9 @@
               </div>
               <div id="cardPointsDisplay">
                 Card Points: 0
+              </div>
+              <div id="drawPointsDisplay">
+                DP: 0
               </div>
               <div id="hpPerKillDisplay">
                 HP per Kill: 1
@@ -156,7 +160,7 @@
     <div class="upgradesTab casino-section">
       <div class="upgrade-subtabs">
         <button class="barSubTabButton">Bar Upgrades</button>
-        <button class="cardSubTabButton">Card Upgrades</button>
+        <button class="cardSubTabButton" style="display:none;">Card Upgrades</button>
       </div>
       <div class="bar-upgrades-panel">
         <div class="bar-upgrades-container casino-section">
@@ -165,14 +169,14 @@
           <div class="bar-upgrades"></div>
         </div>
       </div>
-      <div class="card-upgrades-panel">
-        <div class="card-upgrades-container casino-section">
-          <h3>Available Upgrades</h3>
-          <div class="card-upgrade-list"></div>
-          <h3>Purchased Upgrades</h3>
-          <div class="purchased-upgrade-list"></div>
-          <div class="active-effects casino-section"></div>
-        </div>
+    </div>
+    <div class="cardUpgradesTab">
+      <div class="card-upgrades-container casino-section">
+        <h3>Available Upgrades</h3>
+        <div class="card-upgrade-list"></div>
+        <h3>Purchased Upgrades</h3>
+        <div class="purchased-upgrade-list"></div>
+        <div class="active-effects casino-section"></div>
       </div>
     </div>
     <div class="starChartTab">


### PR DESCRIPTION
## Summary
- add global HP multiplier to card HP calculation
- introduce new card upgrades for damage and HP multipliers
- show draw points and new card upgrade tab in the UI
- implement redraw cost escalation with deck upgrade options
- allow purchased upgrades to apply immediately and track levels

## Testing
- `npm test --silent` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_68534e1276d48326ba193953d3086104