### PR TITLE
Refactor upgrade UI and core visuals

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,8 +45,7 @@
       <button class="deckTabButton">deck</button>
       <button class="starChartTabButton">star chart</button>
       <button class="playerStatsTabButton">stats</button>
-      <button class="upgradesTabButton">upgrades</button>
-      <button class="cardUpgradesTabButton">card upgrades</button>
+      <!-- upgrades tabs removed -->
       <button class="worldTabButton">worlds</button>
       <button class="playerTabButton">player</button>
     </div>
@@ -119,6 +118,7 @@
           </div>
           <button id="clickalipse" title="Draw">🃏</button>
           <button id="redrawBtn" title="Re-draw">🔄</button>
+          <div id="redrawCostDisplay" class="redraw-cost"></div>
           <button id="nextStageBtn" disabled title="Next Stage">🚀</button>
           <button id="fightBossBtn" style="display:none;" title="Fight Boss">👑</button>
         </div>
@@ -148,6 +148,7 @@
         <button class="jokerViewBtn">Jokers</button>
         <button class="jobsViewBtn">Card Jobs</button>
         <button class="jobsCarouselBtn">Jobs</button>
+        <button class="deckUpgradesViewBtn">Upgrades</button>
       </div>
       <div class="deckMainContainer casino-section">
         <div class="deckListContainer"></div>
@@ -155,28 +156,10 @@
         <div class="jokerViewContainer" style="display:none;"></div>
         <div class="deckJobsContainer" style="display:none;"></div>
         <div class="jobCarouselContainer" style="display:none;"></div>
-      </div>
-    </div>
-    <div class="upgradesTab casino-section">
-      <div class="upgrade-subtabs">
-        <button class="barSubTabButton">Bar Upgrades</button>
-        <button class="cardSubTabButton" style="display:none;">Card Upgrades</button>
-      </div>
-      <div class="bar-upgrades-panel">
-        <div class="bar-upgrades-container casino-section">
-          <div id="upgradePowerDisplay">Upgrade Power: 0</div>
-          <button id="buyUpgradePowerBtn">Buy Upgrade Point ($50)</button>
-          <div class="bar-upgrades"></div>
+        <div class="deckUpgradesContainer" style="display:none;">
+          <h3>Purchased Upgrades</h3>
+          <div class="purchased-upgrade-list"></div>
         </div>
-      </div>
-    </div>
-    <div class="cardUpgradesTab">
-      <div class="card-upgrades-container casino-section">
-        <h3>Available Upgrades</h3>
-        <div class="card-upgrade-list"></div>
-        <h3>Purchased Upgrades</h3>
-        <div class="purchased-upgrade-list"></div>
-        <div class="active-effects casino-section"></div>
       </div>
     </div>
     <div class="starChartTab">
@@ -191,8 +174,8 @@
     </div>
     <div class="playerTab">
       <div class="playerSidePanel casino-section">
-        <button class="playerLifeSubTabButton active">Life</button>
         <button class="playerCoreSubTabButton">Core</button>
+        <button class="playerLifeSubTabButton active">Life</button>
       </div>
       <div class="playerMainContainer">
         <div class="player-life-panel">

--- a/script.js
+++ b/script.js
@@ -290,26 +290,21 @@ let deckTabButton;
 let starChartTabButton;
 let playerStatsTabButton;
 let worldTabButton;
-let upgradesTabButton;
-let cardUpgradesTabButton;
 let playerTabButton;
 let mainTab;
 let deckTab;
 let starChartTab;
 let playerStatsTab;
 let worldsTab;
-let upgradesTab;
-let cardUpgradesTab;
 let playerTab;
-let barSubTabButton;
-let cardSubTabButton;
-let barUpgradesPanel;
-let cardUpgradesPanel;
 let purchasedUpgradeList;
 let activeEffectsContainer;
 let tooltip;
 let deckViewBtn;
 let jokerViewBtn;
+let deckUpgradesViewBtn;
+let deckUpgradesContainer;
+let redrawCostDisplay;
 let playerLifeSubTabButton;
 let playerCoreSubTabButton;
 let playerLifePanel;
@@ -347,8 +342,6 @@ function hideTab() {
   if (starChartTab) starChartTab.style.display = "none";
   if (playerStatsTab) playerStatsTab.style.display = "none";
   if (worldsTab) worldsTab.style.display = "none";
-  if (upgradesTab) upgradesTab.style.display = "none";
-  if (cardUpgradesTab) cardUpgradesTab.style.display = "none";
   if (playerTab) playerTab.style.display = "none";
 }
 
@@ -358,29 +351,9 @@ function showTab(tab) {
   if (tab) tab.style.display = "";
 }
 
-function hideUpgradePanels() {
-  if (barUpgradesPanel) barUpgradesPanel.style.display = "none";
-  if (cardUpgradesPanel) cardUpgradesPanel.style.display = "none";
-}
-
-function showBarUpgradesPanel() {
-  hideUpgradePanels();
-  if (barUpgradesPanel) barUpgradesPanel.style.display = "block";
-  renderBarUpgrades();
-}
-
-function showCardUpgradesPanel() {
-  hideUpgradePanels();
-  if (cardUpgradesPanel) cardUpgradesPanel.style.display = "block";
-  renderCardUpgrades(document.querySelector('.card-upgrade-list'), {
-    stats,
-    stageData,
-    cash,
-    onPurchase: purchaseCardUpgrade
-  });
-  renderPurchasedUpgrades();
-  updateActiveEffects();
-}
+function hideUpgradePanels() {}
+function showBarUpgradesPanel() {}
+function showCardUpgradesPanel() {}
 
 function initTabs() {
   if (typeof document === 'undefined') return;
@@ -390,26 +363,21 @@ function initTabs() {
   starChartTabButton = document.querySelector('.starChartTabButton');
   playerStatsTabButton = document.querySelector('.playerStatsTabButton');
   worldTabButton = document.querySelector('.worldTabButton');
-  upgradesTabButton = document.querySelector('.upgradesTabButton');
-  cardUpgradesTabButton = document.querySelector('.cardUpgradesTabButton');
   playerTabButton = document.querySelector('.playerTabButton');
   mainTab = document.querySelector('.mainTab');
   deckTab = document.querySelector('.deckTab');
   starChartTab = document.querySelector('.starChartTab');
   playerStatsTab = document.querySelector('.playerStatsTab');
   worldsTab = document.querySelector('.worldsTab');
-  upgradesTab = document.querySelector('.upgradesTab');
-  cardUpgradesTab = document.querySelector('.cardUpgradesTab');
   playerTab = document.querySelector('.playerTab');
-  barSubTabButton = document.querySelector('.barSubTabButton');
-  cardSubTabButton = document.querySelector('.cardSubTabButton');
-  barUpgradesPanel = document.querySelector('.bar-upgrades-panel');
-  cardUpgradesPanel = document.querySelector('.card-upgrades-panel');
   purchasedUpgradeList = document.querySelector('.purchased-upgrade-list');
   activeEffectsContainer = document.querySelector('.active-effects');
   tooltip = document.getElementById('tooltip');
   deckViewBtn = document.querySelector('.deckViewBtn');
   jokerViewBtn = document.querySelector('.jokerViewBtn');
+  deckUpgradesViewBtn = document.querySelector('.deckUpgradesViewBtn');
+  deckUpgradesContainer = document.querySelector('.deckUpgradesContainer');
+  redrawCostDisplay = document.getElementById('redrawCostDisplay');
   jobsViewBtn = document.querySelector('.jobsViewBtn');
   jobsCarouselBtn = document.querySelector('.jobsCarouselBtn');
   playerLifeSubTabButton = document.querySelector(".playerLifeSubTabButton");
@@ -477,33 +445,14 @@ function initTabs() {
       showDeckCardsView(e.detail.id);
     });
 
-  if (upgradesTabButton) {
-    upgradesTabButton.addEventListener("click", () => {
-      showTab(upgradesTab);
-      showBarUpgradesPanel();
-      setActiveTabButton(upgradesTabButton);
+  if (deckUpgradesViewBtn)
+    deckUpgradesViewBtn.addEventListener('click', () => {
+      hideDeckViews();
+      if (deckUpgradesContainer) {
+        renderPurchasedUpgrades();
+        deckUpgradesContainer.style.display = 'flex';
+      }
     });
-  }
-
-  if (cardUpgradesTabButton) {
-    cardUpgradesTabButton.addEventListener('click', () => {
-      showTab(cardUpgradesTab);
-      renderCardUpgrades(document.querySelector('.card-upgrade-list'), {
-        stats,
-        stageData,
-        cash,
-        onPurchase: purchaseCardUpgrade
-      });
-      renderPurchasedUpgrades();
-      updateActiveEffects();
-      setActiveTabButton(cardUpgradesTabButton);
-    });
-  }
-
-  if (barSubTabButton)
-    barSubTabButton.addEventListener("click", showBarUpgradesPanel);
-  if (cardSubTabButton)
-    cardSubTabButton.addEventListener("click", showCardUpgradesPanel);
   if (playerLifeSubTabButton)
     playerLifeSubTabButton.addEventListener("click", () => {
       if (playerLifePanel) playerLifePanel.style.display = "flex";
@@ -604,7 +553,6 @@ function checkUpgradeUnlocks() {
     }
   });
   if (changed) {
-    renderUpgrades();
     updateUpgradeButtons();
   }
 }
@@ -618,7 +566,6 @@ function purchaseUpgrade(key) {
   cashRateTracker.record(cash);
   up.level += 1;
   up.effect({ stats, pDeck, stageData, systems });
-  renderUpgrades();
   updateDrawButton();
   renderPlayerStats(stats);
 }
@@ -882,6 +829,7 @@ function hideDeckViews() {
   if (jokerViewContainer) jokerViewContainer.style.display = 'none';
   if (deckJobsContainer) deckJobsContainer.style.display = 'none';
   if (jobCarouselContainer) jobCarouselContainer.style.display = 'none';
+  if (deckUpgradesContainer) deckUpgradesContainer.style.display = 'none';
 }
 
 function showDeckListView() {
@@ -934,18 +882,7 @@ document.addEventListener("DOMContentLoaded", () => {
   });
   showDeckListView();
   Object.values(upgrades).forEach(u => u.effect({ stats, pDeck, stageData, systems }));
-  renderUpgrades();
-  renderBarUpgrades();
-  updateUpgradePowerDisplay();
-  updateUpgradePowerCost();
-  renderCardUpgrades(document.querySelector('.card-upgrade-list'), {
-    stats,
-    stageData,
-    cash,
-    onPurchase: purchaseCardUpgrade
-  });
   renderPurchasedUpgrades();
-  updateActiveEffects();
   // Start or resume the game after loading
   spawnPlayer();
   respawnDealerStage();
@@ -956,14 +893,7 @@ document.addEventListener("DOMContentLoaded", () => {
   renderWorldsMenu();
   renderJobAssignments(deckJobsContainer, pDeck);
   rollNewCardUpgrades();
-  renderCardUpgrades(document.querySelector('.card-upgrade-list'), {
-    stats,
-    stageData,
-    cash,
-    onPurchase: purchaseCardUpgrade
-  });
   renderPurchasedUpgrades();
-  updateActiveEffects();
   shuffleArray(deck);
   checkUpgradeUnlocks();
 
@@ -993,20 +923,6 @@ document.addEventListener("DOMContentLoaded", () => {
     enemyAttackFill = renderEnemyAttackBar();
     dealerDeathAnimation();
   });
-  const buyBtn = document.getElementById('buyUpgradePowerBtn');
-  if (buyBtn) {
-    buyBtn.addEventListener('click', () => {
-      const cost = upgradePowerCost();
-      if (cash < cost) return;
-      cash -= cost;
-      cashDisplay.textContent = `Cash: $${formatNumber(cash)}`;
-      cashRateTracker.record(cash);
-      stats.upgradePower += 1;
-      upgradePowerPurchased += 1;
-      updateUpgradePowerDisplay();
-      updateUpgradePowerCost();
-    });
-  }
   renderJokers();
   const buttons = document.querySelector('.buttonsContainer');
   playerAttackFill = renderPlayerAttackBar(buttons);
@@ -1540,16 +1456,8 @@ function onBossDefeat(boss) {
 
   healCardsOnKill();
   stats.upgradePower += 5;
-  updateUpgradePowerDisplay();
   rollNewCardUpgrades();
-  renderCardUpgrades(document.querySelector('.card-upgrade-list'), {
-    stats,
-    stageData,
-    cash,
-    onPurchase: purchaseCardUpgrade
-  });
   renderPurchasedUpgrades();
-  updateActiveEffects();
   shuffleArray(deck);
   // Unlock the next world but require the player to travel manually
   updateWorldTabNotification();
@@ -1737,7 +1645,9 @@ function updateDrawButton() {
 
 function updateRedrawButton() {
   if (!redrawBtn) return;
-  redrawBtn.textContent = `🔄 ($${redrawCost})`;
+  redrawBtn.textContent = `🔄`;
+  if (redrawCostDisplay)
+    redrawCostDisplay.textContent = `Cost: $${redrawCost}`;
   redrawBtn.disabled = cash < redrawCost;
 }
 
@@ -2387,9 +2297,6 @@ Object.values(upgrades).forEach(u => u.effect({ stats, pDeck, stageData, systems
 cashDisplay.textContent = `Cash: $${formatNumber(cash)}`;
 cardPointsDisplay.textContent = `Card Points: ${formatNumber(cardPoints)}`;
 
-  renderUpgrades();
-  renderBarUpgrades();
-  updateUpgradePowerDisplay();
   renderJokers();
 updateUpgradeButtons();
   renderPlayerStats(stats);
@@ -2409,7 +2316,6 @@ updateUpgradeButtons();
   checkUpgradeUnlocks();
   updateUpgradePowerCost();
   renderPurchasedUpgrades();
-  updateActiveEffects();
   applyWorldTheme();
   updateRedrawButton();
 

--- a/style.css
+++ b/style.css
@@ -274,6 +274,7 @@ body {
 
 /* dealer container */
 .dealerContainer {
+    position: relative;
     display: flex;
     flex-direction: column;
     justify-content: space-between;
@@ -346,13 +347,20 @@ body {
 
 /* Card container */
 .dCardContainer {
-    margin-top: 5px;
+    position: absolute;
+    inset: 0;
     display: flex;
     justify-content: center;
-    gap: 10px;
-    flex-grow: 1;
     align-items: center;
+    gap: 10px;
     width: 100%;
+    height: 100%;
+    pointer-events: none;
+    z-index: 5;
+}
+.dCardContainer .card-wrapper {
+    pointer-events: auto;
+    box-shadow: 0 0 10px rgba(0,0,0,0.6);
 }
 
 /* Dealer card base */
@@ -569,6 +577,13 @@ body {
     transform: translateY(-2px);
     box-shadow: 0 4px 12px rgba(0, 128, 0, 0.6);
     background: linear-gradient(135deg, #fafafa, #f0f0f0);
+}
+
+.redraw-cost {
+    font-size: 0.8rem;
+    color: #fff;
+    width: 100%;
+    text-align: center;
 }
 
 /* hand container */
@@ -1421,9 +1436,9 @@ body {
 
 .player-actions button {
     padding: 6px;
-    border: 2px solid #d4af37;
-    background: rgba(0, 0, 0, 0.4);
-    color: #d4af37;
+    border: 2px solid #b76eff;
+    background: rgba(70, 0, 100, 0.4);
+    color: #e0d0ff;
     border-radius: 6px;
     cursor: pointer;
     font-size: 0.8rem;
@@ -1499,16 +1514,16 @@ body {
 }
 .player-subtabs button {
     width: 100%;
-    background: rgba(0, 0, 0, 0.4);
-    color: #d4af37;
-    border: 2px solid #d4af37;
+    background: rgba(70, 0, 100, 0.4);
+    color: #e0d0ff;
+    border: 2px solid #b76eff;
     padding: 6px 10px;
     border-radius: 6px;
     font-size: 0.8rem;
     font-weight: bold;
 }
 .player-subtabs button.active {
-    background: #d4af37;
+    background: #b76eff;
     color: #220000;
 }
 .player-life-panel {
@@ -1520,6 +1535,7 @@ body {
     display: flex;
     flex-direction: column;
     align-items: center;
+    justify-content: center;
     gap: 6px;
     flex: 1;
 }
@@ -1527,10 +1543,12 @@ body {
     display: flex;
     flex-direction: column;
     align-items: center;
+    justify-content: center;
     gap: 6px;
 }
 #coreTabContent svg {
-    max-width: 300px;
+    max-width: 360px;
+    transform: scale(1.2);
 }
 .core-level-text {
     margin-top: 4px;


### PR DESCRIPTION
## Summary
- remove standalone upgrade shop tabs
- add new upgrades subview inside deck tab
- overlay card upgrade choices above enemy area
- style player tab buttons violet and center larger core diagram
- show redraw cost under button

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_68535b841ee08326aaf780e5fdbfea56