### PR TITLE
Fix deck tab display and add mini card view

### DIFF
--- a/style.css
+++ b/style.css
@@ -918,6 +918,31 @@ body {
     white-space: nowrap;
 }
 
+.mini-card-wrapper {
+    width: 40px;
+    display: inline-flex;
+    justify-content: center;
+}
+
+.mini-card {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    align-items: center;
+    width: 100%;
+    aspect-ratio: 3 / 4;
+    border: 1px solid grey;
+    border-radius: 4px;
+    background: white;
+    padding: 2px;
+    box-sizing: border-box;
+    font-size: 0.6rem;
+}
+
+.mini-card-level {
+    font-size: 0.6rem;
+}
+
 .job-entry {
     display: flex;
     align-items: center;


### PR DESCRIPTION
## Summary
- update deck view toggling so only the selected sub-tab is visible
- add miniature card rendering for decks
- ensure deck tab defaults to deck list view

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685387c98b1c8326af1b0c37bc271681