### PR TITLE
Fix dealer card placement and upgrade overlay

### DIFF
--- a/script.js
+++ b/script.js
@@ -259,6 +259,7 @@ const jokerViewContainer = document.querySelector('.jokerViewContainer');
 const deckJobsContainer = document.querySelector('.deckJobsContainer');
 const jobCarouselContainer = document.querySelector('.jobCarouselContainer');
 const dCardContainer = document.getElementsByClassName("dCardContainer")[0];
+const dealerContainer = document.querySelector('.dealerContainer');
 const jokerContainers = document.querySelectorAll(".jokerContainer");
 const manaBar = document.getElementById("manaBar");
 const manaFill = document.getElementById("manaFill");
@@ -1708,6 +1709,7 @@ function heartHeal() {
 
 let gamePaused = false;
 let upgradeSelectionOpen = false;
+let upgradeOverlay = null;
 let redrawCost = 10;
 
 function handleRedraw() {
@@ -1726,6 +1728,9 @@ function openCardUpgradeSelection() {
   upgradeSelectionOpen = true;
   gamePaused = true;
   dCardContainer.innerHTML = '';
+  upgradeOverlay = document.createElement('div');
+  upgradeOverlay.classList.add('upgrade-selection-overlay');
+  dealerContainer.appendChild(upgradeOverlay);
   const ids = rollNewCardUpgrades(3);
   ids.forEach(id => {
     const def = cardUpgradeDefinitions[id];
@@ -1740,7 +1745,7 @@ function openCardUpgradeSelection() {
       purchaseCardUpgrade(id, cost);
       closeCardUpgradeSelection();
     });
-    dCardContainer.appendChild(wrap);
+    upgradeOverlay.appendChild(wrap);
   });
   lucide.createIcons();
 }
@@ -1749,6 +1754,10 @@ function closeCardUpgradeSelection() {
   if (!upgradeSelectionOpen) return;
   upgradeSelectionOpen = false;
   dCardContainer.innerHTML = '';
+  if (upgradeOverlay) {
+    upgradeOverlay.remove();
+    upgradeOverlay = null;
+  }
   renderDealerCard();
   gamePaused = false;
 }

--- a/style.css
+++ b/style.css
@@ -277,8 +277,9 @@ body {
     position: relative;
     display: flex;
     flex-direction: column;
-    justify-content: space-between;
+    justify-content: flex-start;
     align-items: center;
+    gap: 4px;
     height: 100%;
 }
 
@@ -347,20 +348,30 @@ body {
 
 /* Card container */
 .dCardContainer {
-    position: absolute;
-    inset: 0;
     display: flex;
     justify-content: center;
     align-items: center;
     gap: 10px;
     width: 100%;
-    height: 100%;
     pointer-events: none;
     z-index: 5;
 }
 .dCardContainer .card-wrapper {
     pointer-events: auto;
     box-shadow: 0 0 10px rgba(0,0,0,0.6);
+}
+
+/* Overlay shown when selecting card upgrades */
+.upgrade-selection-overlay {
+    position: absolute;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.8);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 10px;
+    z-index: 10;
+    padding: 10px;
 }
 
 /* Dealer card base */


### PR DESCRIPTION
## Summary
- keep dealer card area static so it sits below the life bar
- add overlay for selecting card upgrades
- show upgrade options in that overlay

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_68538b8e43ac8326ac066e27e1d9650f