### PR TITLE
Add deck stats and new upgrades

### DIFF
--- a/cardUpgrades.js
+++ b/cardUpgrades.js
@@ -57,6 +57,33 @@ export const cardUpgradeDefinitions = {
       stats.extraDamageMultiplier = (stats.extraDamageMultiplier || 1) * 1.1;
     }
   },
+  drawPointsIncrease: {
+    id: 'drawPointsIncrease',
+    name: 'Draw Points +10%',
+    rarity: 'common',
+    effect: ({ stats }) => {
+      stats.drawPointsMult = (stats.drawPointsMult || 1) * 1.1;
+    }
+  },
+  damageBuff30s: {
+    id: 'damageBuff30s',
+    name: 'Damage Buff 30s',
+    rarity: 'uncommon',
+    noLevel: true,
+    effect: ({ stats, updateActiveEffects }) => {
+      const now = Date.now();
+      const expiry = now + 30000;
+      stats.damageBuffMultiplier = 1.3;
+      stats.damageBuffExpiration = Math.max(stats.damageBuffExpiration || 0, expiry);
+      updateActiveEffects?.();
+      setTimeout(() => {
+        if (Date.now() >= stats.damageBuffExpiration) {
+          stats.damageBuffMultiplier = 1;
+          updateActiveEffects?.();
+        }
+      }, expiry - now);
+    }
+  },
   // Prestige unlocked upgrades
   maxMana: {
     id: 'maxMana',
@@ -230,7 +257,9 @@ export const unlockedCardUpgrades = [
   'hpPerKill',
   'attackSpeedReduction',
   'redrawCooldownReduction',
-  'extraCardSlot'
+  'extraCardSlot',
+  'drawPointsIncrease',
+  'damageBuff30s'
 ];
 
 export const upgradeLevels = {};
@@ -289,9 +318,12 @@ export function addActiveUpgradeCardsToDeck(deck) {
 }
 
 export function applyCardUpgrade(id, context) {
-  if (!upgradeLevels[id]) upgradeLevels[id] = 0;
-  upgradeLevels[id] += 1;
   const def = cardUpgradeDefinitions[id];
+  if (!def) return;
+  if (!def.noLevel) {
+    if (!upgradeLevels[id]) upgradeLevels[id] = 0;
+    upgradeLevels[id] += 1;
+  }
   def.effect(context);
 }
 

--- a/deck.js
+++ b/deck.js
@@ -4,6 +4,7 @@
 export const deckMastery = {};
 
 import { formatNumber } from './utils/numberFormat.js';
+import { cardUpgradeDefinitions } from './cardUpgrades.js';
 
 // Required levels to reach each mastery tier
 export const masteryRequirements = [
@@ -20,7 +21,17 @@ export const deckConfigs = {
     id: 'basic',
     name: 'Basic Deck',
     description: 'Starter deck',
-    cards: []
+    cards: [],
+    deckSize: 52,
+    maxJokers: 2,
+    hpMultiplier: 1,
+    damageMultiplier: 1,
+    upgrades: [
+      'hpPerKill',
+      'healOnRedraw',
+      'damageBuff30s',
+      'drawPointsIncrease'
+    ]
   }
 };
 
@@ -76,7 +87,29 @@ export function renderDeckList(container) {
     bottom.classList.add('deck-bottom-row');
     bottom.append(art, bar, reqSpan);
 
-    row.append(name, bottom);
+    const caps = document.createElement('div');
+    caps.classList.add('deck-capacities');
+    caps.innerHTML = `
+      <span>Size: ${cfg.deckSize || cfg.cards.length}</span>
+      <span>Jokers: ${cfg.maxJokers}</span>
+      <span>HP ×${cfg.hpMultiplier}</span>
+      <span>DMG ×${cfg.damageMultiplier}</span>
+    `;
+
+    const details = document.createElement('details');
+    const summary = document.createElement('summary');
+    summary.textContent = 'Upgrades';
+    details.appendChild(summary);
+    const upList = document.createElement('ul');
+    upList.classList.add('deck-upgrade-list');
+    (cfg.upgrades || []).forEach(u => {
+      const li = document.createElement('li');
+      li.textContent = cardUpgradeDefinitions[u]?.name || u;
+      upList.appendChild(li);
+    });
+    details.appendChild(upList);
+
+    row.append(name, bottom, caps, details);
     row.addEventListener('click', () => {
       selectedDeck = id;
       const event = new CustomEvent('deck-selected', { detail: { id } });

--- a/script.js
+++ b/script.js
@@ -127,7 +127,10 @@ const stats = {
   redrawCooldownReduction: 0,
   hpMultiplier: 1,
   extraDamageMultiplier: 1,
-  drawPoints: 0
+  drawPoints: 0,
+  drawPointsMult: 1,
+  damageBuffMultiplier: 1,
+  damageBuffExpiration: 0
 };
 
 const systems = {
@@ -618,6 +621,12 @@ function updateActiveEffects() {
       activeEffectsContainer.appendChild(div);
     }
   });
+  if (stats.damageBuffMultiplier > 1 && stats.damageBuffExpiration) {
+    const remain = Math.max(0, Math.ceil((stats.damageBuffExpiration - Date.now()) / 1000));
+    const div = document.createElement('div');
+    div.textContent = `Damage Buff x${stats.damageBuffMultiplier.toFixed(1)} (${remain}s)`;
+    activeEffectsContainer.appendChild(div);
+  }
 }
 
 function updateUpgradePowerDisplay() {
@@ -1715,8 +1724,8 @@ let redrawCost = 10;
 function handleRedraw() {
   if (cash < redrawCost) return;
   spendCash(redrawCost);
-  stats.drawPoints = (stats.drawPoints || 0) + 1;
-  redrawCost = Math.floor(redrawCost * 1.2 + 1);
+  stats.drawPoints = (stats.drawPoints || 0) + stats.drawPointsMult;
+  redrawCost = redrawCost * 2;
   redrawHand(getCardState());
   updateRedrawButton();
   renderPlayerStats(stats);
@@ -2163,6 +2172,10 @@ function updatePlayerStats() {
   stats.cashMulti = 1;
   stats.points = 0;
 
+  if (stats.damageBuffExpiration && Date.now() > stats.damageBuffExpiration) {
+    stats.damageBuffMultiplier = 1;
+  }
+
   for (const card of drawnCards) {
     if (!card) continue;
     recalcCardHp(card, stats, barUpgrades);
@@ -2178,7 +2191,7 @@ stats.pDamage += card.damage;
 stats.points += card.value;
 }
 
-stats.pDamage *= stats.damageMultiplier;
+stats.pDamage *= stats.damageMultiplier * stats.damageBuffMultiplier;
 renderPlayerStats(stats);
 }
 

--- a/style.css
+++ b/style.css
@@ -929,6 +929,21 @@ body {
     white-space: nowrap;
 }
 
+.deck-capacities {
+    display: flex;
+    gap: 6px;
+    font-size: 0.75rem;
+}
+
+.deck-upgrade-list {
+    margin-left: 12px;
+    font-size: 0.75rem;
+}
+
+.deck-row summary {
+    cursor: pointer;
+}
+
 .mini-card-wrapper {
     width: 40px;
     display: inline-flex;


### PR DESCRIPTION
## Summary
- display deck capacities and upgrade pool in Deck tab
- implement Draw Points booster and temporary Damage Buff upgrades
- double redraw cost after each use
- show active damage buff in effects list

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853ac14d5c08326a84407fb9a9d10bf