### PR TITLE
Update skill list with progress bars

### DIFF
--- a/playerLife.js
+++ b/playerLife.js
@@ -57,8 +57,20 @@ function renderSkillsList(container) {
     const progress = data.xp % 10;
     const row = document.createElement('div');
     row.classList.add('skill-entry');
+
+    const nameEl = document.createElement('div');
     const name = key.replace(/([A-Z])/g, ' $1');
-    row.textContent = `${name.charAt(0).toUpperCase()+name.slice(1)}: Lv ${level} (${progress}/10)`;
+    nameEl.textContent = `${name.charAt(0).toUpperCase()+name.slice(1)}: Lv ${level} (${progress}/10)`;
+    row.appendChild(nameEl);
+
+    const bar = document.createElement('div');
+    bar.classList.add('skill-progress');
+    const fill = document.createElement('div');
+    fill.classList.add('skill-progress-fill');
+    fill.style.width = `${(progress / 10) * 100}%`;
+    bar.appendChild(fill);
+    row.appendChild(bar);
+
     container.appendChild(row);
   });
 }

--- a/style.css
+++ b/style.css
@@ -1599,14 +1599,34 @@ body {
 
 .skills-list {
     display: flex;
-    flex-direction: column;
-    gap: 4px;
+    flex-wrap: wrap;
+    gap: 8px;
     font-size: 0.8rem;
 }
 
 .skill-entry {
     display: flex;
-    justify-content: space-between;
+    flex-direction: column;
+    flex: 0 0 calc(33.333% - 8px);
+}
+
+.skill-progress {
+    width: 100%;
+    height: 6px;
+    background: #090b09;
+    border: 1px solid grey;
+    border-radius: 4px;
+    position: relative;
+    overflow: hidden;
+}
+
+.skill-progress-fill {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: 0;
+    background: #d4af37;
 }
 .player-core-panel {
     display: flex;


### PR DESCRIPTION
## Summary
- show skill progress as a bar below each skill entry
- arrange skills horizontally in thirds of the container

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68547060394c83268109f6fda20d995f