### PR TITLE
Hide removed skills on player tab

### DIFF
--- a/playerLife.js
+++ b/playerLife.js
@@ -53,6 +53,7 @@ function renderSkillsList(container) {
   if (!container) return;
   container.innerHTML = '';
   Object.entries(skills).forEach(([key, data]) => {
+    if (["strength", "dexterity", "focus"].includes(key)) return;
     const level = Math.floor(data.xp / 10) + 1;
     const progress = data.xp % 10;
     const row = document.createElement('div');


### PR DESCRIPTION
## Summary
- skip strength, dexterity, and focus when rendering skill list

## Testing
- `npx mocha` *(fails: needs to install mocha)*

------
https://chatgpt.com/codex/tasks/task_e_68547c4277848326826b54cf2b06f381