### PR TITLE
Detach orb XP from combat events

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Auto-Attack: Activate automated attacks with adjustable speeds, influenced by ca
 
 Prestige System: Reset progress for long-term benefits, including deck reshuffling, HP refill, and stage resets.
 
+Core Meditation: Mind, Body and Soul orbs fill from Life tab activities. They no longer gain XP from mana, healing or defeats during combat.
+
 
 Resource Management:
 

--- a/cardManagement.js
+++ b/cardManagement.js
@@ -1,4 +1,3 @@
-import { addCoreXP } from "./core.js";
 
 export function drawCard(state) {
   const {
@@ -63,10 +62,7 @@ export function redrawHand(state) {
   shuffleArray(deck);
   if (stats.healOnRedraw > 0) {
     pDeck.forEach(c => {
-      const before = c.currentHp;
       c.currentHp = Math.min(c.maxHp, c.currentHp + stats.healOnRedraw);
-      const gained = c.currentHp - before;
-      if (gained > 0) addCoreXP('physical', gained);
     });
   }
   while (drawnCards.length < stats.cardSlots && deck.length > 0) {

--- a/core.js
+++ b/core.js
@@ -11,7 +11,6 @@ let container;
 let meditateBtn;
 let levelDisplay;
 let progressText;
-let soulTimer;
 let meditationTimer;
 
 export function initCore() {
@@ -62,9 +61,6 @@ const bodyPath = `M200 140
   const mindOrb = container.querySelector('#mindOrb');
   mindOrb.addEventListener('click', onMindOrbClick);
   meditateBtn.addEventListener('click', startMeditation);
-  if (!soulTimer) {
-    soulTimer = setInterval(() => addCoreXP('soul', 0.5), 1000);
-  }
   renderCore();
 }
 

--- a/script.js
+++ b/script.js
@@ -24,7 +24,7 @@ import { initPlayerLife, refreshPlayerLife } from "./playerLife.js";
 import { Jobs, assignJob, getAvailableJobs, renderJobAssignments, renderJobCarousel } from "./jobs.js"; // job definitions
 import RateTracker from "./utils/rateTracker.js";
 import { formatNumber } from "./utils/numberFormat.js";
-import { initCore, refreshCore, addCoreXP } from './core.js';
+import { initCore, refreshCore } from './core.js';
 import {
   rollNewCardUpgrades,
   applyCardUpgrade,
@@ -1704,12 +1704,9 @@ function heartHeal() {
 
   drawnCards.forEach(card => {
     if (card.suit === "Hearts") {
-      const before = target.currentHp;
       target.currentHp = Math.round(
         Math.min(target.currentHp + card.currentLevel, target.maxHp)
       );
-      const gained = target.currentHp - before;
-      if (gained > 0) addCoreXP('physical', gained);
       animateCardHeal(target);
     }
   });
@@ -1839,10 +1836,7 @@ function animateCardDeath(card, callback) {
 function healCardsOnKill() {
   drawnCards.forEach(card => {
     if (!card) return;
-    const before = card.currentHp;
     card.healFromKill();
-    const gained = card.currentHp - before;
-    if (gained > 0) addCoreXP('physical', gained);
   });
   updateHandDisplay();
   updateDeckDisplay();
@@ -1920,14 +1914,9 @@ function useJoker(joker) {
       const healAmt = joker.getScaledPower();
       drawnCards.forEach(card => {
         if (!card) return;
-        const before = card.currentHp;
         card.currentHp = Math.round(Math.min(card.maxHp, card.currentHp + healAmt));
-        const gained = card.currentHp - before;
-        if (gained > 0) {
-          addCoreXP('physical', gained);
-          card.hpDisplay.textContent = `HP: ${formatNumber(Math.round(card.currentHp))}/${formatNumber(Math.round(card.maxHp))}`;
-          animateCardHeal(card);
-        }
+        card.hpDisplay.textContent = `HP: ${formatNumber(Math.round(card.currentHp))}/${formatNumber(Math.round(card.maxHp))}`;
+        animateCardHeal(card);
       });
       addLog(`Healed ${healAmt} HP`,
         "heal");
@@ -2461,8 +2450,7 @@ stats.mana = Math.min(
 stats.maxMana,
 stats.mana + (stats.manaRegen * deltaTime) / 1000
 );
-updateManaBar();
- addCoreXP('mental', (stats.manaRegen * deltaTime) / 1000);
+ updateManaBar();
 }
 
   // passive progress for bar upgrades


### PR DESCRIPTION
## Summary
- prevent core orbs from gaining XP through combat
- remove soul orb idle timer
- document core meditation progression in README

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_68549bd99af083268733f40c0f674e9b