### PR TITLE
Add speaker narrative and restructure tabs

### DIFF
--- a/core.js
+++ b/core.js
@@ -2,7 +2,7 @@ export const coreState = {
   coreLevel: 1,
   mind: { level: 1, xp: 0, maxXP: 1000 },
   body: { level: 1, xp: 0, maxXP: 10 },
-  soul: { level: 1, xp: 0, maxXP: 10 },
+  will: { level: 1, xp: 0, maxXP: 10 },
   meditationProgress: 0,
   meditating: false
 };
@@ -35,7 +35,7 @@ const bodyPath = `M200 140
         <clipPath id="bodyShapeClip"><path d="${bodyPath}" /></clipPath>
         <clipPath id="mindClip"><circle cx="200" cy="60" r="20" /></clipPath>
         <clipPath id="bodyOrbClip"><circle cx="120" cy="220" r="20" /></clipPath>
-        <clipPath id="soulClip"><circle cx="280" cy="220" r="20" /></clipPath>
+        <clipPath id="willClip"><circle cx="280" cy="220" r="20" /></clipPath>
       </defs>
       <path d="${bodyPath}" fill="rgba(0,0,0,0.3)" stroke="#888" stroke-width="2" />
       <circle id="coreHalo" cx="200" cy="180" r="70" fill="none" stroke="gold" stroke-width="4" opacity="0" />
@@ -49,9 +49,9 @@ const bodyPath = `M200 140
       <circle id="bodyOrb" cx="120" cy="220" r="20" fill="none" stroke="#ff8888" stroke-width="2" />
       <text id="bodyText" x="120" y="255" text-anchor="middle" class="orb-text"></text>
       <circle cx="280" cy="220" r="20" fill="rgba(180,100,255,0.3)" />
-      <rect id="soulFill" x="260" y="240" width="40" height="0" fill="rgba(180,100,255,0.6)" clip-path="url(#soulClip)" />
-      <circle id="soulOrb" cx="280" cy="220" r="20" fill="none" stroke="#cc88ff" stroke-width="2" />
-      <text id="soulText" x="280" y="255" text-anchor="middle" class="orb-text"></text>
+      <rect id="willFill" x="260" y="240" width="40" height="0" fill="rgba(180,100,255,0.6)" clip-path="url(#willClip)" />
+      <circle id="willOrb" cx="280" cy="220" r="20" fill="none" stroke="#cc88ff" stroke-width="2" />
+      <text id="willText" x="280" y="255" text-anchor="middle" class="orb-text"></text>
       <text id="coreProgressText" x="200" y="260" text-anchor="middle" class="orb-text"></text>
     </svg>
   `;
@@ -72,7 +72,7 @@ export function addCoreXP(type, amt = 1) {
   const orb =
     type === 'mental' ? coreState.mind :
     type === 'physical' ? coreState.body :
-    type === 'soul' ? coreState.soul : null;
+    type === 'will' ? coreState.will : null;
   if (!orb) return;
   const maxLevel = coreState.coreLevel * 5;
   if (orb.level >= maxLevel) return;
@@ -121,7 +121,7 @@ function breakthrough() {
   coreState.meditationProgress = 0;
   coreState.mind.xp = 0;
   coreState.body.xp = 0;
-  coreState.soul.xp = 0;
+  coreState.will.xp = 0;
   meditateBtn.textContent = 'Meditate Core';
   renderCore();
 }
@@ -130,7 +130,7 @@ function renderCore() {
   if (!container) return;
   const mindFill = Math.min(1, coreState.mind.xp / coreState.mind.maxXP);
   const bodyFill = Math.min(1, coreState.body.xp / coreState.body.maxXP);
-  const soulFill = Math.min(1, coreState.soul.xp / coreState.soul.maxXP);
+  const willFill = Math.min(1, coreState.will.xp / coreState.will.maxXP);
 
   const coreFill = Math.min(1, coreState.meditationProgress / 100);
 
@@ -145,26 +145,26 @@ function renderCore() {
 
   updateRect('#mindFill', 200, 60, 20, mindFill);
   updateRect('#bodyOrbFill', 120, 220, 20, bodyFill);
-  updateRect('#soulFill', 280, 220, 20, soulFill);
+  updateRect('#willFill', 280, 220, 20, willFill);
   updateRect('#bodyFill', 200, 180, 60, coreFill);
 
   const mindOrb = container.querySelector('#mindOrb');
   if (mindOrb) mindOrb.setAttribute('stroke', mindFill >= 1 ? '#ffffaa' : '#88aaff');
   const bodyOrb = container.querySelector('#bodyOrb');
   if (bodyOrb) bodyOrb.setAttribute('stroke', bodyFill >= 1 ? '#ffcccc' : '#ff8888');
-  const soulOrb = container.querySelector('#soulOrb');
-  if (soulOrb) soulOrb.setAttribute('stroke', soulFill >= 1 ? '#ddaaff' : '#cc88ff');
+  const willOrb = container.querySelector('#willOrb');
+  if (willOrb) willOrb.setAttribute('stroke', willFill >= 1 ? '#ddaaff' : '#cc88ff');
 
   const mindText = container.querySelector('#mindText');
   if (mindText) mindText.textContent = `${Math.floor(coreState.mind.xp)}/${coreState.mind.maxXP}`;
   const bodyText = container.querySelector('#bodyText');
   if (bodyText) bodyText.textContent = `${Math.floor(coreState.body.xp)}/${coreState.body.maxXP}`;
-  const soulText = container.querySelector('#soulText');
-  if (soulText) soulText.textContent = `${Math.floor(coreState.soul.xp)}/${coreState.soul.maxXP}`;
+  const willText = container.querySelector('#willText');
+  if (willText) willText.textContent = `${Math.floor(coreState.will.xp)}/${coreState.will.maxXP}`;
   const progressText = container.querySelector('#coreProgressText');
   if (progressText) progressText.textContent = `${Math.floor(coreState.meditationProgress)}/100`;
   levelDisplay.textContent = `Core Level: ${coreState.coreLevel}`;
-  const ready = mindFill >= 1 && bodyFill >= 1 && soulFill >= 1 && !coreState.meditating && coreState.meditationProgress === 0;
+  const ready = mindFill >= 1 && bodyFill >= 1 && willFill >= 1 && !coreState.meditating && coreState.meditationProgress === 0;
 
   if (coreState.meditationProgress >= 100) {
     meditateBtn.textContent = 'Breakthrough';

--- a/enemySpawning.js
+++ b/enemySpawning.js
@@ -58,3 +58,17 @@ export function spawnBoss(stageData, enemyAttackProgress, onAttack, onDefeat) {
   boss.attackTimer = boss.attackInterval * enemyAttackProgress;
   return boss;
 }
+
+export function spawnSpeaker(stageData, enemyAttackProgress, onAttack, onDefeat) {
+  const stage = stageData.stage;
+  const world = stageData.world;
+  const enemy = new Enemy(stage, world, {
+    name: "The Speaker",
+    maxHp: calculateEnemyHp(stage, world) * 3,
+    onAttack,
+    onDefeat
+  });
+  enemy.attackTimer = enemy.attackInterval * enemyAttackProgress;
+  enemy.isSpeaker = true;
+  return enemy;
+}

--- a/index.html
+++ b/index.html
@@ -40,23 +40,25 @@
     </div>
 
     <!---tabs container--->
-    <div class=tabsContainer>
-      <button class="mainTabButton">main</button>
+    <div class="tabsContainer">
+      <button class="mainTabButton">imaginary</button>
       <button class="deckTabButton">deck</button>
       <button class="starChartTabButton">star chart</button>
       <button class="playerStatsTabButton">stats</button>
-      <!-- upgrades tabs removed -->
-      <button class="worldTabButton">worlds</button>
-      <button class="playerTabButton">player</button>
+      <button class="playerTabButton">real</button>
     </div>
 
     <!--------------main tab panel----------------->
     <div class="mainTab">
-
-      <div class="dealerContainer casino-section">
-        <div id="stage">
-          Stage 1
-        </div>
+      <div class="imaginary-subtabs">
+        <button class="cardSubTabButton active">cards</button>
+        <button class="worldSubTabButton">worlds</button>
+      </div>
+      <div class="cardSubTab">
+        <div class="dealerContainer casino-section">
+          <div id="stage">
+            Stage 1
+          </div>
         <span id="kills">kills: 0</span>
         <span id="cashPerSecDisplay">Avg Cash/sec: 0</span>
         <div class="dealerLifeDisplay">
@@ -139,6 +141,11 @@
         <div class="jokerContainer casino-section">
         </div>
       </div>
+      </div>
+      <div class="worldsTab" style="display:none;">
+        <span id="worldProgressPerSecDisplay">Avg World Progress/sec: 0%</span>
+        <div class="worldsContainer casino-section"></div>
+      </div>
     </div>
     <!-- close mainTab -->
     <!--------------deck tab----------------->
@@ -167,10 +174,6 @@
     </div>
     <div class="playerStatsTab">
       <div id="playerStatsContainer" class="casino-section"></div>
-    </div>
-    <div class="worldsTab">
-      <span id="worldProgressPerSecDisplay">Avg World Progress/sec: 0%</span>
-      <div class="worldsContainer casino-section"></div>
     </div>
     <div class="playerTab">
       <div class="playerSidePanel casino-section">

--- a/style.css
+++ b/style.css
@@ -72,6 +72,31 @@ body {
     color: #220000;
     box-shadow: inset 0 0 8px #fff8c6, 0 0 12px #d4af37;
 }
+.imaginary-subtabs {
+    display: flex;
+    gap: 12px;
+    padding: 6px;
+}
+.imaginary-subtabs button {
+    background: rgba(0,0,0,0.4);
+    color: #d4af37;
+    border: 3px solid #d4af37;
+    padding: 6px 10px;
+    border-radius: 8px;
+    font-weight: bold;
+    text-shadow: 0 0 6px #000;
+    box-shadow: 0 0 8px rgba(212,175,55,0.5);
+    transition: all 0.2s;
+}
+.imaginary-subtabs button:hover {
+    box-shadow: 0 0 12px rgba(212,175,55,0.8);
+    color: #fff4b3;
+}
+.imaginary-subtabs button.active {
+    background: #d4af37;
+    color: #220000;
+    box-shadow: inset 0 0 8px #fff8c6, 0 0 12px #d4af37;
+}
 
 /* tabs container */
 /*.tabsContainer {
@@ -1342,6 +1367,30 @@ body {
     .handContainer {
         gap: 8px;
     }
+}
+.speaker-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    background: rgba(0, 0, 0, 0.8);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 5001;
+}
+.speaker-overlay .speaker-quote {
+    font-size: 1.6rem;
+    color: #ddd;
+    font-style: italic;
+    text-shadow: 0 0 8px #fff;
+    animation: fogFade 3s ease-in-out;
+}
+@keyframes fogFade {
+    from { opacity: 0; filter: blur(4px); }
+    50% { opacity: 1; filter: blur(0); }
+    to { opacity: 0; filter: blur(4px); }
 }
 
 /* worlds menu */


### PR DESCRIPTION
## Summary
- rename main tab display to **imaginary** and show "real" tab
- restore player tab layout and add worlds subtab content
- fix CSS rules for active tabs and new imaginary subtabs

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854a470d4bc83269978cb24f05d4633