### PR TITLE
Fix imaginary tab layout issues

### DIFF
--- a/index.html
+++ b/index.html
@@ -124,21 +124,13 @@
           <button id="nextStageBtn" disabled title="Next Stage">🚀</button>
           <button id="fightBossBtn" style="display:none;" title="Fight Boss">👑</button>
         </div>
-        <div class="handContainer casino-section">
-        </div>
-        <div class="jokerContainer casino-section">
-        </div>
+        <div class="handContainer casino-section"></div>
+        <div class="jokerContainer casino-section"></div>
         <div class="manaBar" id="manaBar" style="display:none;">
           <div class="manaBarInner">
             <div class="manaFill" id="manaFill"></div>
-            <div class="manaText" id="manaText">
-              0/0
-            </div>
+            <div class="manaText" id="manaText">0/0</div>
           </div>
-        </div>
-        <div class="handContainer casino-section">
-        </div>
-        <div class="jokerContainer casino-section">
         </div>
       </div>
       </div>

--- a/style.css
+++ b/style.css
@@ -159,13 +159,11 @@ body {
 .cardSubTab {
     flex: 1 1 auto;
     display: grid;
-    grid-template-rows: 30% auto auto 1fr;
+    grid-template-rows: auto 1fr;
     grid-template-columns: 1fr 20%;
     grid-template-areas:
         "dealer sidePanel"
-        "gameColumn sidePanel"
-        "gameColumn sidePanel"
-        "gameColumn discard";
+        "gameColumn sidePanel";
     gap: 10px;
 }
 
@@ -327,7 +325,7 @@ body {
     justify-content: flex-start;
     align-items: center;
     gap: 4px;
-    height: 100%;
+    height: auto;
 }
 
 .dealerContainer > .dealerLifeDisplay {
@@ -640,7 +638,7 @@ body {
 .redraw-cost {
     font-size: 0.8rem;
     color: #fff;
-    width: 100%;
+    width: auto;
     text-align: center;
 }
 


### PR DESCRIPTION
## Summary
- simplify card subtab grid for more flexible sizing
- allow dealer container to size to content
- keep redraw cost inline and remove duplicate hand/joker sections

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854b3c76fd883268f8ef2ab04c299e0