### PR TITLE
Implement basic life simulation with stamina

### DIFF
--- a/index.html
+++ b/index.html
@@ -180,6 +180,7 @@
           <div class="core-main">
             <div id="coreTabContent"></div>
             <div id="coreActivityText" class="core-activity-text"></div>
+            <div id="staminaBar" class="stamina-bar"><div id="staminaFill" class="stamina-fill"></div></div>
             <div class="core-actions"></div>
           </div>
           <div class="core-resources casino-section"></div>

--- a/style.css
+++ b/style.css
@@ -1801,6 +1801,20 @@ body {
     height: 1rem;
 }
 
+.stamina-bar {
+    width: 100%;
+    height: 8px;
+    background: #222;
+    border: 1px solid #555;
+    margin-bottom: 4px;
+}
+
+.stamina-fill {
+    height: 100%;
+    background: #33cc33;
+    width: 100%;
+}
+
 .core-button-wrapper {
     display: flex;
     flex-direction: column;

--- a/test/playerLife.test.js
+++ b/test/playerLife.test.js
@@ -1,0 +1,25 @@
+import assert from 'node:assert/strict';
+import { LifeGame, Activity } from '../lifeCore.js';
+
+describe('Life activities', () => {
+  let game;
+  beforeEach(() => {
+    game = new LifeGame();
+    game.addActivity(new Activity('ponder', { skill: 'mentalAcuity', resource: 'thought', rate: 1, tags: ['mental'], stamina: 1 }));
+    game.addActivity(new Activity('read', { skill: 'literacy', resource: 'knowledge', rate: 0.2, xpRate: 0.1, stamina: -1, unlock: g => g.skills.mentalAcuity.level >= 1 }));
+  });
+
+  it('simulates ponder for N ticks', () => {
+    game.start('ponder');
+    for (let i = 0; i < 5; i++) game.tick(1);
+    assert.equal(game.resources.thought.amount, 5);
+  });
+
+  it('levels up mental acuity and unlocks read', () => {
+    game.start('ponder');
+    for (let i = 0; i < 10; i++) game.tick(1);
+    assert.equal(game.skills.mentalAcuity.level, 1);
+    const readAct = game.activities.read;
+    assert.ok(readAct.unlock(game));
+  });
+});


### PR DESCRIPTION
## Summary
- implement `LifeGame` logic in new `lifeCore.js`
- overhaul `playerLife.js` to use new activity model and persistence
- add stamina bar to core panel
- style stamina bar
- test life activities logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854cb0b34e88326b949ccea35662d5b