### PR TITLE
Fix openCamp syntax error

### DIFF
--- a/script.js
+++ b/script.js
@@ -1925,7 +1925,8 @@ function openCamp(withUpgrade = false) {
   redrawAllowed = true;
   gamePaused = true;
   campOverlay = document.createElement('div');
-  campOverlay.classList.add('upgrade-selection-  const continueBtn = document.createElement('button');
+  campOverlay.classList.add('upgrade-selection-overlay');
+  const continueBtn = document.createElement('button');
   continueBtn.textContent = 'Continue';
   continueBtn.addEventListener('click', () => {
     closeCamp();


### PR DESCRIPTION
## Summary
- fix typo in `openCamp` that caused a browser console error

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685600637c84832686f6e632f74646b1