### PR TITLE
Implement manual stage advancement with event checkpoints

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,6 +60,7 @@
             Stage 1
           </div>
         <span id="kills">kills: 0</span>
+        <span id="distanceDisplay">distance: 0/0</span>
         <span id="cashPerSecDisplay">Avg Cash/sec: 0</span>
         <div class="dealerLifeDisplay">
           Life:10
@@ -118,10 +119,14 @@
           <div id="playerAttackBar" class="playerAttackBar">
             <div class="playerAttackFill"></div>
           </div>
+          <div id="stageProgressBar" class="stage-progress">
+            <div id="stageProgressFill" class="stage-progress-fill"></div>
+          </div>
+          <button id="moveForwardBtn" title="Move Forward">➡️</button>
           <button id="clickalipse" title="Draw">🃏</button>
           <button id="redrawBtn" title="Re-draw">🔄</button>
           <div id="redrawCostDisplay" class="redraw-cost"></div>
-          <button id="nextStageBtn" disabled title="Next Stage">🚀</button>
+          <button id="nextStageBtn" style="display:none;" disabled title="Next Stage">🚀</button>
           <button id="fightBossBtn" style="display:none;" title="Fight Boss">👑</button>
         </div>
         <div class="handContainer casino-section"></div>

--- a/style.css
+++ b/style.css
@@ -345,6 +345,11 @@ body {
     font-size: 0.8rem;
 }
 
+#distanceDisplay {
+    align-self: flex-start;
+    font-size: 0.8rem;
+}
+
 #cashPerSecDisplay {
     align-self: flex-start;
     font-size: 0.8rem;
@@ -418,6 +423,12 @@ body {
     gap: 10px;
     z-index: 10;
     padding: 10px;
+}
+
+.camp-overlay button {
+    font-size: 1rem;
+    padding: 6px 10px;
+    margin: 4px;
 }
 
 /* Dealer card base */
@@ -1443,6 +1454,28 @@ body {
 .world-progress-text {
     font-size: 12px;
     margin-left: 4px;
+}
+
+/* Stage traversal progress bar */
+.stage-progress {
+    width: 50%;
+    height: 8px;
+    background: #090b09;
+    border: 1px solid grey;
+    border-radius: 4px;
+    position: relative;
+    overflow: hidden;
+    margin: 4px auto;
+    flex-basis: 100%;
+}
+
+.stage-progress-fill {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: 0;
+    background: green;
 }
 
 .card-upgrades {


### PR DESCRIPTION
## Summary
- add stage progress bar and Move Forward button in HTML
- style progress bar for stage traversal
- track progress manually and trigger random events at 50% and 75%
- reveal Next Stage button when progress reaches 100%
- remove automatic travel logic and start without camp overlay

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855cd248b7c8326a06cdc1adfb1ce6c