### PR TITLE
Fix renderDealerCard null check

### DIFF
--- a/script.js
+++ b/script.js
@@ -1096,6 +1096,7 @@ function renderGlobalStats() {
 }
 
 function renderDealerCard() {
+  if (!currentEnemy) return;
   const {
     minDamage,
     maxDamage


### PR DESCRIPTION
## Summary
- avoid rendering a dealer card when there is no current enemy

## Testing
- `npm test` *(fails: mocha not found)*
- `npm install` *(fails: blocked network access)*

------
https://chatgpt.com/codex/tasks/task_e_68562b51fc348326a2bdf6cba2cd8027