### PR TITLE
Add auto stage progress and fullscreen camp overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,6 +65,9 @@
         <div class="dealerLifeDisplay">
           Life:10
         </div>
+        <div id="stageProgressBar" class="stage-progress">
+          <div id="stageProgressFill" class="stage-progress-fill"></div>
+        </div>
         <div class="dCardContainer"></div>
       </div>
 
@@ -118,9 +121,6 @@
         <div class="buttonsContainer casino-section">
           <div id="playerAttackBar" class="playerAttackBar">
             <div class="playerAttackFill"></div>
-          </div>
-          <div id="stageProgressBar" class="stage-progress">
-            <div id="stageProgressFill" class="stage-progress-fill"></div>
           </div>
           <button id="moveForwardBtn" title="Move Forward">➡️</button>
           <button id="clickalipse" title="Draw">🃏</button>

--- a/style.css
+++ b/style.css
@@ -425,6 +425,20 @@ body {
     padding: 10px;
 }
 
+.camp-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    background: rgba(0, 0, 0, 0.8);
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    z-index: 5000;
+}
+
 .camp-overlay button {
     font-size: 1rem;
     padding: 6px 10px;


### PR DESCRIPTION
## Summary
- make camp overlay fullscreen and append directly to body
- move stage progress bar into dealer container
- start stage progress when progress bar is clicked and progress automatically
- pause attacks during stage progression

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68562eb352388326b18010454b87f95c