### PR TITLE
Improve stage progress UI

### DIFF
--- a/script.js
+++ b/script.js
@@ -294,6 +294,14 @@ const manaText = document.getElementById("manaText");
 const manaRegenDisplay = document.getElementById("manaRegenDisplay");
 const dpsDisplay = document.getElementById("dpsDisplay");
 
+function hideStageProgressBar() {
+  if (stageProgressBar) stageProgressBar.style.display = "none";
+}
+
+function showStageProgressBar() {
+  if (stageProgressBar) stageProgressBar.style.display = "block";
+}
+
 const unlockedJokers = [];
 
 // attack progress bars
@@ -990,6 +998,7 @@ document.addEventListener("DOMContentLoaded", () => {
   nextStageBtn.addEventListener("click", nextStage);
   fightBossBtn.addEventListener("click", () => {
     fightBossBtn.style.display = "none";
+    hideStageProgressBar();
     stageData.stage = 10;
     stageData.kills = playerStats.stageKills[stageData.stage] || 0;
     renderStageInfo();
@@ -1461,6 +1470,7 @@ function removeDealerLifeBar() {
 
 function spawnDealerEvent(powerMult = 1) {
   stopStageProgress();
+  hideStageProgressBar();
   inCombat = true;
   removeDealerLifeBar();
   const temp = { ...stageData, stage: Math.round(stageData.stage * powerMult) };
@@ -1472,6 +1482,7 @@ function spawnDealerEvent(powerMult = 1) {
 
 function spawnBossEvent() {
   stopStageProgress();
+  hideStageProgressBar();
   inCombat = true;
   removeDealerLifeBar();
   currentEnemy = spawnEnemy('boss', stageData, enemyAttackProgress, () => onBossDefeat(currentEnemy));
@@ -1541,6 +1552,7 @@ function stepStageProgress() {
 
 function startStageProgress() {
   if (stageProgressing) return;
+  showStageProgressBar();
   stageProgressing = true;
   stageProgressInterval = setInterval(stepStageProgress, 1000);
 }
@@ -1552,6 +1564,7 @@ function moveForward() {
 
 // After a kill, decide whether to spawn a dealer or a boss
 function respawnDealerStage() {
+  hideStageProgressBar();
   removeDealerLifeBar();
   if (speakerEncounterPending) {
     speakerEncounterPending = false;
@@ -1583,6 +1596,7 @@ function onDealerDefeat() {
     inCombat = false;
     currentEnemy = null;
     updateDealerLifeDisplay();
+    showStageProgressBar();
   });
 } // need to define xp formula
 
@@ -1605,6 +1619,7 @@ function onSpeakerDefeat() {
     inCombat = false;
     currentEnemy = null;
     updateDealerLifeDisplay();
+    showStageProgressBar();
   });
 }
 
@@ -1638,6 +1653,7 @@ function onBossDefeat(boss) {
   dealerBarDeathAnimation(() => {
     inCombat = false;
     currentEnemy = null;
+    showStageProgressBar();
     nextWorld();
   });
 }

--- a/style.css
+++ b/style.css
@@ -1476,7 +1476,7 @@ body {
 /* Stage traversal progress bar */
 .stage-progress {
     width: 50%;
-    height: 8px;
+    height: 4px;
     background: #090b09;
     border: 1px solid grey;
     border-radius: 4px;


### PR DESCRIPTION
## Summary
- shrink the stage traversal progress bar
- hide stage progress bar whenever an enemy appears
- show it again when combat ends or travel resumes

## Testing
- `npm test` *(fails: `mocha` not found)*
- `npm install` *(fails: chrome download blocked)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6856c4baebe883268dfdbe1c16e1042c