### PR TITLE
UI adjustments and progress tweaks

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,7 +61,6 @@
           </div>
         <span id="kills">kills: 0</span>
         <span id="distanceDisplay">distance: 0/0</span>
-        <span id="cashPerSecDisplay">Avg Cash/sec: 0</span>
         <div class="dealerLifeDisplay">
           Life:10
         </div>
@@ -123,7 +122,6 @@
             <div class="playerAttackFill"></div>
           </div>
           <button id="moveForwardBtn" title="Move Forward">➡️</button>
-          <button id="clickalipse" title="Draw">🃏</button>
           <button id="nextStageBtn" style="display:none;" disabled title="Next Stage">🚀</button>
           <button id="fightBossBtn" style="display:none;" title="Fight Boss">👑</button>
         </div>
@@ -168,7 +166,12 @@
       <div id="star-chart-container"></div>
     </div>
     <div class="playerStatsTab">
-      <div id="playerStatsContainer" class="casino-section"></div>
+      <div class="stats-subtabs">
+        <button class="statsOverviewSubTabButton active">Overview</button>
+        <button class="statsEconomySubTabButton">Economy</button>
+      </div>
+      <div id="statsOverviewContainer" class="casino-section"></div>
+      <div id="statsEconomyContainer" class="casino-section" style="display:none;"></div>
     </div>
     <div class="playerTab">
       <div class="playerSidePanel casino-section">

--- a/style.css
+++ b/style.css
@@ -617,7 +617,8 @@ body {
 /* auto attack progress bars */
 .playerAttackBar {
     width: 50%;
-    height: 4px;
+    height: 2px;
+    display: none;
     background: rgba(0, 0, 0, 0.8);
     border: 1px solid #d4af37;
     border-radius: 8px;
@@ -639,7 +640,7 @@ body {
 
 .enemyAttackBar {
     width: 50%;
-    height: 4px;
+    height: 2px;
     background: rgba(0, 0, 0, 0.8);
     border: 1px solid #d4af37;
     border-radius: 8px;
@@ -1447,7 +1448,7 @@ body {
 }
 .world-progress {
     width: 100%;
-    height: 8px;
+    height: 4px;
     background: #090b09;
     border: 1px solid grey;
     border-radius: 4px;
@@ -1470,7 +1471,7 @@ body {
 /* Stage traversal progress bar */
 .stage-progress {
     width: 50%;
-    height: 4px;
+    height: 2px;
     background: #090b09;
     border: 1px solid grey;
     border-radius: 4px;
@@ -1705,6 +1706,30 @@ body {
 .player-subtabs button:hover {
     box-shadow: 0 0 12px rgba(183, 110, 255, 0.8);
     color: #fff4b3;
+}
+
+.stats-subtabs {
+    display: flex;
+    gap: 6px;
+    margin-bottom: 6px;
+}
+
+.stats-subtabs button {
+    flex: 1;
+    border: 2px solid #b76eff;
+    padding: 4px 6px;
+    border-radius: 6px;
+    font-size: 0.8rem;
+    background: #4b0082;
+    color: #e0d0ff;
+    text-shadow: 0 0 6px #000;
+    transition: all 0.2s;
+}
+
+.stats-subtabs button.active {
+    background: #b76eff;
+    color: #220000;
+    box-shadow: inset 0 0 8px #fff8c6, 0 0 12px #b76eff;
 }
 
 .playerCoreSubTabButton {


### PR DESCRIPTION
## Summary
- remove draw card button and add draw option within camp overlay
- hide player attack bar when not in combat
- reduce stage distance requirement to 10
- shrink progress bar heights
- add economy subtab in statistics with cash/sec metrics
- track cash rates over 1h and 24h windows
- ensure Next Stage isn't offered in events

## Testing
- `npm test` *(fails: mocha not found)*
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_6856cf4587988326a2035cac55a2c7ce