### PR TITLE
Fix crash when clearing stage enemies

### DIFF
--- a/script.js
+++ b/script.js
@@ -1717,6 +1717,10 @@ function onBossDefeat(boss) {
 
 // Update text and bar UI for the current enemy's health
 function updateDealerLifeDisplay() {
+  if (!currentEnemy) {
+    removeDealerLifeBar();
+    return;
+  }
   dealerLifeDisplay.textContent = `Life: ${formatNumber(currentEnemy.currentHp)}/${formatNumber(currentEnemy.maxHp)}`;
   renderDealerLifeBar(dealerLifeDisplay, currentEnemy);
   renderDealerLifeBarFill(currentEnemy);


### PR DESCRIPTION
## Summary
- handle when there is no active enemy in `updateDealerLifeDisplay`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856dda3dca883269e0a4f3cfd9a34a6