### PR TITLE
Add defeat reset and UI polish

### DIFF
--- a/cardUpgrades.js
+++ b/cardUpgrades.js
@@ -256,6 +256,11 @@ export const upgradeLevels = {};
 
 let activeCardUpgrades = [];
 
+export function resetCardUpgrades() {
+  Object.keys(upgradeLevels).forEach(k => delete upgradeLevels[k]);
+  activeCardUpgrades.length = 0;
+}
+
 export function removeActiveUpgrade(id) {
   activeCardUpgrades = activeCardUpgrades.filter(a => a !== id);
 }
@@ -295,10 +300,10 @@ export function getCardUpgradeCost(id, stats = {}, stageData = {}) {
   const def = cardUpgradeDefinitions[id];
   if (!def) return 0;
   const rarityMult = rarityCostMultiplier[def.rarity] || 1;
-  const kills = Math.floor(Math.random() * 6) + 10; // 10-15 kills
-  const points = stats.points || 30;
-  const baseReward = Math.floor(points * (1 + Math.sqrt(stageData.stage || 1)));
-  return Math.floor(baseReward * kills * rarityMult);
+  const stage = stageData.stage || 1;
+  const world = stageData.world || 1;
+  const base = 100 * stage * world;
+  return Math.floor(base * rarityMult);
 }
 
 export function addActiveUpgradeCardsToDeck(deck) {

--- a/index.html
+++ b/index.html
@@ -71,6 +71,11 @@
       </div>
 
       <div class="sidePanel">
+        <div class="chipsContainer">
+          <div id="chipsDisplay">
+            Chips: 0
+          </div>
+        </div>
         <div class="vignette stats open">
           <button class="vignette-toggle">Stats</button>
           <div class="vignette-content">
@@ -80,9 +85,6 @@
               </div>
               <div id="cashDisplay">
                 Cash: 0
-              </div>
-              <div id="chipsDisplay">
-                Chips: 0
               </div>
               <div id="damageDisplay">
                 Damage: 0

--- a/script.js
+++ b/script.js
@@ -37,7 +37,8 @@ import {
   cardUpgradeDefinitions,
   upgrades,
   upgradeLevels as cardUpgradeLevels,
-  removeActiveUpgrade
+  removeActiveUpgrade,
+  resetCardUpgrades
 } from "./cardUpgrades.js";
 import {
   calculateEnemyHp,
@@ -1953,6 +1954,10 @@ function openCardUpgradeSelection(onCloseCallback = null) {
   const header = document.createElement('h2');
   header.textContent = 'Upgrades';
   upgradeOverlay.element.prepend(header);
+  const info = document.createElement('p');
+  info.classList.add('upgrade-text');
+  info.textContent = 'Choose an upgrade';
+  upgradeOverlay.append(info);
   const ids = rollNewCardUpgrades(3);
   ids.forEach(id => {
     const def = cardUpgradeDefinitions[id];
@@ -1963,12 +1968,17 @@ function openCardUpgradeSelection(onCloseCallback = null) {
     card.classList.add('card', 'upgrade-card');
     card.innerHTML = `<div class="card-suit"><i data-lucide="sword"></i></div><div class="card-desc">${def.name} - $${cost}</div>`;
     wrap.appendChild(card);
-    wrap.addEventListener('click', () => {
-      purchaseCardUpgrade(id, cost);
-      closeCardUpgradeSelection();
-    });
+    if (cash >= cost) {
+      wrap.addEventListener('click', () => {
+        purchaseCardUpgrade(id, cost);
+        closeCardUpgradeSelection();
+      });
+    } else {
+      card.classList.add('unaffordable');
+    }
     upgradeOverlay.append(wrap);
   });
+  upgradeOverlay.appendButton('Skip', () => closeCardUpgradeSelection());
   lucide.createIcons();
 }
 
@@ -2227,6 +2237,9 @@ function respawnPlayer() {
   chips = 0;
   resetCashRates(cash);
 
+  resetCardUpgrades();
+  pDeck = generateDeck();
+
   deck = [...pDeck];
   drawnCards = [];
   discardPile = [];
@@ -2250,6 +2263,9 @@ function respawnPlayer() {
   updateChipsDisplay();
   resetCashRates(cash);
   updateUpgradeButtons();
+  stageData.world = 1;
+  stageData.stage = 1;
+  stageData.kills = playerStats.stageKills[stageData.stage] || 0;
   renderStageInfo();
 
   spawnPlayer();

--- a/style.css
+++ b/style.css
@@ -309,6 +309,16 @@ body {
     margin-bottom: 0;
 }
 
+.chipsContainer {
+    background: rgba(133, 163, 139, 0.5);
+    color: white;
+    text-shadow: 0 0 5px black;
+    border: 1px solid #d4af37;
+    border-radius: 4px;
+    padding: 4px;
+    font-size: 0.6rem;
+}
+
 #log-panel {
     border: 2px solid grey;
     border-radius: 8px;
@@ -1387,6 +1397,19 @@ body {
 .upgrade-card button:disabled {
     opacity: 0.5;
     filter: grayscale(1);
+}
+
+.upgrade-card.unaffordable {
+    opacity: 0.5;
+    filter: grayscale(1);
+    pointer-events: none;
+}
+
+.upgrade-selection-overlay .upgrade-text {
+    width: 100%;
+    text-align: center;
+    color: #fff;
+    margin-bottom: 6px;
 }
 
 .upgrade-popup {


### PR DESCRIPTION
## Summary
- reset player state on defeat including card upgrades, deck, and progress
- move chips display to its own container in the sidebar
- dim unaffordable card upgrades, add skip option, show helper text
- balance upgrade costs by stage

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856e982c31883268d045c4efc632dcd