### PR TITLE
Update basic deck upgrades and remove draw points

### DIFF
--- a/cardUpgrades.js
+++ b/cardUpgrades.js
@@ -24,14 +24,6 @@ export const cardUpgradeDefinitions = {
       stats.attackSpeed = Math.max(1000, stats.attackSpeed - 100);
     }
   },
-  redrawCooldownReduction: {
-    id: 'redrawCooldownReduction',
-    name: 'Redraw Cooldown Reduction',
-    rarity: 'rare',
-    effect: ({ stats }) => {
-      stats.redrawCooldownReduction += 0.1;
-    }
-  },
   extraCardSlot: {
     id: 'extraCardSlot',
     name: 'Extra Card Slot',
@@ -57,31 +49,12 @@ export const cardUpgradeDefinitions = {
       stats.extraDamageMultiplier = (stats.extraDamageMultiplier || 1) * 1.1;
     }
   },
-  drawPointsIncrease: {
-    id: 'drawPointsIncrease',
-    name: 'Draw Points +10%',
-    rarity: 'common',
+  cashOutNoRedraw: {
+    id: 'cashOutNoRedraw',
+    name: 'Cash Out w/out Redraw',
+    rarity: 'rare',
     effect: ({ stats }) => {
-      stats.drawPointsMult = (stats.drawPointsMult || 1) * 1.1;
-    }
-  },
-  damageBuff30s: {
-    id: 'damageBuff30s',
-    name: 'Damage Buff 30s',
-    rarity: 'uncommon',
-    noLevel: true,
-    effect: ({ stats, updateActiveEffects }) => {
-      const now = Date.now();
-      const expiry = now + 30000;
-      stats.damageBuffMultiplier = 1.3;
-      stats.damageBuffExpiration = Math.max(stats.damageBuffExpiration || 0, expiry);
-      updateActiveEffects?.();
-      setTimeout(() => {
-        if (Date.now() >= stats.damageBuffExpiration) {
-          stats.damageBuffMultiplier = 1;
-          updateActiveEffects?.();
-        }
-      }, expiry - now);
+      stats.cashOutWithoutRedraw = true;
     }
   },
   spadeDamage15: {
@@ -223,9 +196,8 @@ export const upgrades = {
     effect: ({ stats }) => {
       stats.jokerCooldownReduction = upgrades.jokerCooldownReduction.level * 0.05;
     }
-  },
-  // redrawCooldownReduction upgrade handled via card upgrades
-}; 
+  }
+};
 
 const rarityCostMultiplier = {
   common: 1,
@@ -245,11 +217,11 @@ export const unlockedCardUpgrades = [
   'healOnRedraw',
   'hpPerKill',
   'attackSpeedReduction',
-  'redrawCooldownReduction',
   'extraCardSlot',
-  'drawPointsIncrease',
-  'damageBuff30s',
-  'spadeDamage15'
+  'damageMultiplier',
+  'hpMultiplier',
+  'spadeDamage15',
+  'cashOutNoRedraw'
 ];
 
 export const upgradeLevels = {};

--- a/deck.js
+++ b/deck.js
@@ -28,9 +28,10 @@ export const deckConfigs = {
     damageMultiplier: 1,
     upgrades: [
       'hpPerKill',
-      'healOnRedraw',
-      'damageBuff30s',
-      'drawPointsIncrease'
+      'damageMultiplier',
+      'hpMultiplier',
+      'spadeDamage15',
+      'cashOutNoRedraw'
     ]
   }
 };
@@ -96,10 +97,9 @@ export function renderDeckList(container) {
       <span>DMG ×${cfg.damageMultiplier}</span>
     `;
 
-    const details = document.createElement('details');
-    const summary = document.createElement('summary');
-    summary.textContent = 'Upgrades';
-    details.appendChild(summary);
+    const upContainer = document.createElement('div');
+    const upTitle = document.createElement('div');
+    upTitle.textContent = 'Upgrades';
     const upList = document.createElement('ul');
     upList.classList.add('deck-upgrade-list');
     (cfg.upgrades || []).forEach(u => {
@@ -107,9 +107,9 @@ export function renderDeckList(container) {
       li.textContent = cardUpgradeDefinitions[u]?.name || u;
       upList.appendChild(li);
     });
-    details.appendChild(upList);
+    upContainer.append(upTitle, upList);
 
-    row.append(name, bottom, caps, details);
+    row.append(name, bottom, caps, upContainer);
     row.addEventListener('click', () => {
       selectedDeck = id;
       const event = new CustomEvent('deck-selected', { detail: { id } });

--- a/index.html
+++ b/index.html
@@ -95,9 +95,6 @@
               <div id="cardPointsDisplay">
                 Card Points: 0
               </div>
-              <div id="drawPointsDisplay">
-                DP: 0
-              </div>
               <div id="hpPerKillDisplay">
                 HP per Kill: 1
               </div>

--- a/script.js
+++ b/script.js
@@ -138,10 +138,9 @@ const stats = {
   redrawCooldownReduction: 0,
   hpMultiplier: 1,
   extraDamageMultiplier: 1,
-  drawPoints: 0,
-  drawPointsMult: 1,
   damageBuffMultiplier: 1,
-  damageBuffExpiration: 0
+  damageBuffExpiration: 0,
+  cashOutWithoutRedraw: false
 };
 
 const systems = {
@@ -1128,8 +1127,6 @@ function renderPlayerStats(stats) {
   cashMultiDisplay.textContent = `Cash Multi: ${formatNumber(Math.floor(stats.cashMulti))}`;
   pointsDisplay.textContent = `Points: ${formatNumber(stats.points)}`;
   cardPointsDisplay.textContent = `Card Points: ${formatNumber(cardPoints)}`;
-  const dpDisp = document.getElementById('drawPointsDisplay');
-  if (dpDisp) dpDisp.textContent = `DP: ${formatNumber(stats.drawPoints)}`;
   attackSpeedDisplay.textContent = `Attack Speed: ${Math.floor(stats.attackSpeed / 1000)}s`;
   if (manaRegenDisplay) {
     manaRegenDisplay.textContent = `Mana Regen: ${stats.manaRegen.toFixed(2)}/s`;
@@ -1930,7 +1927,6 @@ function handleRedraw() {
   if (!redrawAllowed) return;
   if (cash < redrawCost) return;
   spendCash(redrawCost);
-  stats.drawPoints = (stats.drawPoints || 0) + stats.drawPointsMult;
   redrawCost = redrawCost * 2;
   redrawHand(getCardState());
   renderPlayerStats(stats);
@@ -2011,6 +2007,12 @@ function openCamp(onCloseCallback = null) {
   campOverlay.appendButton('Continue', () => {
     closeCamp();
   });
+  if (stats.cashOutWithoutRedraw) {
+    campOverlay.appendButton('Cash Out', () => {
+      cashOut();
+      closeCamp();
+    });
+  }
   campOverlay.appendButton('Redraw & Cash Out', () => {
     cashOut();
     handleRedraw();
@@ -2482,7 +2484,6 @@ Object.entries(upgrades).map(([k, u]) => [k, u.unlocked])
     lastCashOutPoints,
     cardPoints,
     redrawCost,
-    drawPoints: stats.drawPoints,
     deck: deckData,
     upgrades: upgradeLevels,
     unlockedJokers: unlockedJokers.map(j => j.id),
@@ -2511,7 +2512,6 @@ const state = JSON.parse(json);
   chips = state.chips || 0;
   cardPoints = state.cardPoints || 0;
   redrawCost = state.redrawCost || 10;
-  stats.drawPoints = state.drawPoints || 0;
   upgradePowerPurchased = state.upgradePowerPurchased || 0;
   lastCashOutPoints = state.lastCashOutPoints || 0;
   Object.assign(stats, state.stats || {});


### PR DESCRIPTION
## Summary
- tweak upgrade list for the basic deck and always display upgrades
- remove draw points system
- add `cashOutNoRedraw` card upgrade
- enable `Cash Out` option in camp when upgrade is owned

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857018facd083269ff06871b61e0a21