### PR TITLE
Improve redraw and pile UI

### DIFF
--- a/cardManagement.js
+++ b/cardManagement.js
@@ -15,7 +15,9 @@ export function drawCard(state) {
     renderPurchasedUpgrades,
     updateActiveEffects,
     updateAllCardHp,
-    pDeck
+    pDeck,
+    renderDeckTop,
+    updatePileCounts
   } = state;
 
   if (deck.length === 0) return null;
@@ -39,6 +41,8 @@ export function drawCard(state) {
   drawnCards.push(card);
   renderCard(card, handContainer);
   updateDeckDisplay();
+  if (renderDeckTop) renderDeckTop();
+  if (updatePileCounts) updatePileCounts();
   return card;
 }
 
@@ -53,12 +57,24 @@ export function redrawHand(state) {
     updateDrawButton,
     updateDeckDisplay,
     updatePlayerStats,
-    pDeck
+    pDeck,
+    discardPile,
+    discardContainer,
+    cardBackImages,
+    renderDiscardCard,
+    renderDeckTop,
+    updatePileCounts
   } = state;
 
-  deck.push(...drawnCards);
+  // move current hand to discard pile
+  drawnCards.forEach(c => {
+    discardPile.push(c);
+    if (renderDiscardCard)
+      renderDiscardCard(c, discardContainer, cardBackImages);
+  });
   drawnCards.length = 0;
   handContainer.innerHTML = '';
+
   shuffleArray(deck);
   if (stats.healOnRedraw > 0) {
     pDeck.forEach(c => {
@@ -68,6 +84,8 @@ export function redrawHand(state) {
   while (drawnCards.length < stats.cardSlots && deck.length > 0) {
     drawCard(state);
   }
+  if (renderDeckTop) renderDeckTop();
+  if (updatePileCounts) updatePileCounts();
   updateDrawButton();
   updateDeckDisplay();
   updatePlayerStats(stats);

--- a/index.html
+++ b/index.html
@@ -116,7 +116,14 @@
             <div id="game-log"></div>
           </div>
         </div>
-        <div class="discardContainer casino-section"></div>
+        <div class="deck-info">
+          <div class="deckContainer casino-section"></div>
+          <div id="deckCount" class="pile-count"></div>
+        </div>
+        <div class="discard-info">
+          <div class="discardContainer casino-section"></div>
+          <div id="discardCount" class="pile-count"></div>
+        </div>
       </div>
       <div class="gameColumn">
         <div class="buttonsContainer casino-section">

--- a/script.js
+++ b/script.js
@@ -248,9 +248,15 @@ function getCardState() {
   return {
     deck,
     drawnCards,
+    discardPile,
+    discardContainer,
+    cardBackImages,
     handContainer,
     renderCard: card => renderCard(card, handContainer),
     updateDeckDisplay,
+    renderDiscardCard,
+    renderDeckTop,
+    updatePileCounts,
     stats,
     showUpgradePopup,
     applyCardUpgrade,
@@ -277,6 +283,9 @@ const chipsDisplay = document.getElementById("chipsDisplay");
 const cardPointsDisplay = document.getElementById("cardPointsDisplay");
 const handContainer = document.getElementsByClassName("handContainer")[0];
 const discardContainer = document.getElementsByClassName("discardContainer")[0];
+const deckContainer = document.getElementsByClassName("deckContainer")[0];
+const deckCountDisplay = document.getElementById("deckCount");
+const discardCountDisplay = document.getElementById("discardCount");
 const dealerLifeDisplay =
 document.getElementsByClassName("dealerLifeDisplay")[0];
 const killsDisplay = document.getElementById("kills");
@@ -947,6 +956,24 @@ function updateDeckDisplay() {
   });
   renderJobAssignments(deckJobsContainer, pDeck);
   updateMasteryBars();
+}
+
+function renderDeckTop() {
+  if (!deckContainer) return;
+  deckContainer.innerHTML = '';
+  if (deck.length > 0) {
+    const top = deck[0];
+    const img = document.createElement('img');
+    img.alt = 'Deck';
+    img.src = cardBackImages[top.backType] || cardBackImages['basic-red'];
+    img.classList.add('card-back', top.backType);
+    deckContainer.appendChild(img);
+  }
+}
+
+function updatePileCounts() {
+  if (deckCountDisplay) deckCountDisplay.textContent = `Deck: ${deck.length}`;
+  if (discardCountDisplay) discardCountDisplay.textContent = `Discard: ${discardPile.length}`;
 }
 
 function updateMasteryBars() {
@@ -1907,7 +1934,8 @@ function updateHandDisplay() {
 // Move a card to the discard pile and update the UI
 function discardCard(card) {
   discardPile.push(card);
-  renderDiscardCard(card);
+  renderDiscardCard(card, discardContainer, cardBackImages);
+  updatePileCounts();
 }
 
 
@@ -2312,6 +2340,8 @@ function spawnPlayer() {
   while (drawnCards.length < stats.cardSlots && deck.length > 0) {
     drawCard(getCardState());
   }
+  renderDeckTop();
+  updatePileCounts();
 }
 
 function respawnPlayer() {
@@ -2342,6 +2372,8 @@ function respawnPlayer() {
   handContainer.innerHTML = "";
   discardContainer.innerHTML = "";
   deckTabContainer.innerHTML = "";
+  renderDeckTop();
+  updatePileCounts();
 
   cashDisplay.textContent = `Cash: $${formatNumber(cash)}`;
   updateChipsDisplay();

--- a/style.css
+++ b/style.css
@@ -11,8 +11,8 @@ body {
     font-family: Trebuchet MS;
     padding: 5px;
     color: #fff;
-    height: 100vh;
-    overflow: hidden;
+    min-height: 100vh;
+    overflow-y: auto;
 }
 
 #debugPanel {
@@ -265,7 +265,7 @@ body {
     display: flex;
     flex-direction: column;
     gap: 10px;
-    font-size: 0.5rem;
+    font-size: 0.45rem;
 }
 
 .vignette-toggle {
@@ -295,6 +295,8 @@ body {
     background: rgba(133, 163, 139, 0.5);
     color: white;
     text-shadow: 0 0 5px black;
+    max-height: 120px;
+    overflow-y: auto;
 }
 
 .statsSidePanel > div {
@@ -324,7 +326,7 @@ body {
     border-radius: 8px;
     color: white;
     text-shadow: 0 0 5px black;
-    max-height: 150px;
+    max-height: 120px;
     overflow-y: auto;
 }
 
@@ -818,6 +820,34 @@ body {
     position: relative;
     margin-top: auto;
     align-self: center;
+}
+
+.deckContainer {
+    border: 2px solid rgb(91, 91, 87);
+    display: flex;
+    width: 75px;
+    height: 100px;
+    justify-content: center;
+    align-items: center;
+    border-bottom: 2px solid rgba(255, 255, 100, 0.3);
+    overflow: hidden;
+    position: relative;
+    margin-top: auto;
+    align-self: center;
+}
+
+.pile-count {
+    text-align: center;
+    font-size: 0.5rem;
+    color: #d4af37;
+    text-shadow: 0 0 5px black;
+}
+
+.deck-info, .discard-info {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2px;
 }
 
 .card-wrapper {


### PR DESCRIPTION
## Summary
- show deck and discard counts in side panel
- move hand to discard pile when redrawing
- fix discard pile rendering bug
- ensure layout can scroll vertically and shrink sidebar panels

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_68570fee16d08326a590e31e10e93355