### PR TITLE
Add free upgrades and overlay info

### DIFF
--- a/style.css
+++ b/style.css
@@ -550,6 +550,24 @@ body {
     justify-content: center;
 }
 
+.overlay-stats {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    font-size: 0.7rem;
+    justify-content: center;
+}
+
+.overlay-hand {
+    display: flex;
+    gap: 4px;
+    justify-content: center;
+    flex-wrap: wrap;
+}
+.overlay-hand .card-wrapper {
+    transform: scale(0.8);
+}
+
 .card-flavor {
     font-size: 0.6rem;
     font-style: italic;


### PR DESCRIPTION
## Summary
- restrict card upgrade rolls to deck allowed upgrades
- ensure one free upgrade option when rendering upgrades
- apply rarity styling to upgrade card list
- display stats and current hand in camp/upgrade overlays

## Testing
- `npm test` *(fails: mocha not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685714f3a6148326a717345308157a9a