### PR TITLE
Add rarity styling for elite enemies

### DIFF
--- a/enemy.js
+++ b/enemy.js
@@ -4,6 +4,9 @@ class Enemy  {
     this.world = world;
     this.name = config.name || "dealer";
 
+    // rarity tier for styling
+    this.rarity = config.rarity || "basic";
+
     // We expect the caller to supply these values
     this.maxHp = config.maxHp
     this.currentHp = this.maxHp;

--- a/enemySpawning.js
+++ b/enemySpawning.js
@@ -30,6 +30,7 @@ export function spawnDealer(stageData, enemyAttackProgress, onAttack, onDefeat) 
   const world = stageData.world;
   const enemy = new Enemy(stage, world, {
     maxHp: calculateEnemyHp(stage, world),
+    rarity: 'basic',
     onAttack,
     onDefeat
   });
@@ -52,6 +53,7 @@ export function spawnBoss(stageData, enemyAttackProgress, onAttack, onDefeat) {
     iconColor: template.iconColor,
     xp: Math.pow(stage, 1.5) * world,
     abilities,
+    rarity: 'legendary',
     onAttack,
     onDefeat
   });
@@ -65,6 +67,7 @@ export function spawnSpeaker(stageData, enemyAttackProgress, onAttack, onDefeat)
   const enemy = new Enemy(stage, world, {
     name: "The Speaker",
     maxHp: calculateEnemyHp(stage, world) * 3,
+    rarity: 'rare',
     onAttack,
     onDefeat
   });

--- a/script.js
+++ b/script.js
@@ -1241,7 +1241,7 @@ function renderBossCard(enemy) {
   const wrapper = document.createElement('div');
   wrapper.classList.add('dCardWrapper');
   const pane = document.createElement('div');
-  pane.classList.add('dCardPane', 'boss');
+  pane.classList.add('dCardPane', 'boss', `rarity-${enemy.rarity || 'basic'}`);
   const abilityPane = document.createElement('div');
   abilityPane.classList.add('dCardAbilityPane');
   const iconColor = enemy.iconColor || '#a04444';
@@ -1256,7 +1256,7 @@ function renderDealerCardBase(enemy) {
   const wrapper = document.createElement('div');
   wrapper.classList.add('dCardWrapper');
   const pane = document.createElement('div');
-  pane.classList.add('dCardPane', 'dealer');
+  pane.classList.add('dCardPane', 'dealer', `rarity-${enemy.rarity || 'basic'}`);
   const abilityPane = document.createElement('div');
   abilityPane.classList.add('dCardAbilityPane');
   const { color, blur } = getDealerIconStyle(stageData.stage);

--- a/style.css
+++ b/style.css
@@ -575,21 +575,21 @@ body {
 }
 
 .rarity-basic {
-    border-color: #888;
+    border-color: #888 !important;
 }
 
 .rarity-rare {
-    border-color: #39f;
+    border-color: #39f !important;
     box-shadow: 0 0 8px rgba(51,102,255,0.6);
 }
 
 .rarity-epic {
-    border-color: #b450ff;
+    border-color: #b450ff !important;
     box-shadow: 0 0 8px rgba(180,80,255,0.6);
 }
 
 .rarity-legendary {
-    border-color: gold;
+    border-color: gold !important;
     box-shadow: 0 0 10px rgba(255,215,0,0.7);
 }
 


### PR DESCRIPTION
## Summary
- add `rarity` property to `Enemy`
- mark dealers, bosses and the Speaker with rarity tiers
- style enemy cards according to rarity

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_68571885dd9c832684ababea854b7473