### PR TITLE
Fix UI elements and enemy targeting

### DIFF
--- a/script.js
+++ b/script.js
@@ -1810,8 +1810,9 @@ function cDealerDamage(damageAmount = null, ability = null, source = "dealer") {
     finalDamage -= absorbed;
   }
 
-  // target the front‐line card
-  const card = drawnCards[0];
+  // randomly target one of the drawn cards
+  const idx = Math.floor(Math.random() * drawnCards.length);
+  const card = drawnCards[idx];
 
   // subtract **one** hit’s worth
   card.currentHp = Math.round(Math.max(0, card.currentHp - finalDamage));
@@ -1831,7 +1832,7 @@ function cDealerDamage(damageAmount = null, ability = null, source = "dealer") {
   // if it’s dead, remove it
   if (card.currentHp === 0) {
     // immediately remove from data so new draws don't shift the wrong card
-    drawnCards.shift();
+    drawnCards.splice(idx, 1);
 
     animateCardDeath(card, () => {
       // 1) from the DOM
@@ -2118,28 +2119,37 @@ function openCamp(onCloseCallback = null) {
   btnRow.classList.add('camp-buttons');
   box.appendChild(btnRow);
 
-  function addBtn(label, handler) {
+  function addBtn(label, handler, infoText) {
+    const wrap = document.createElement('div');
+    wrap.classList.add('camp-btn');
     const btn = document.createElement('button');
     btn.textContent = label;
     btn.addEventListener('click', handler);
-    btnRow.appendChild(btn);
+    wrap.appendChild(btn);
+    if (infoText) {
+      const info = document.createElement('div');
+      info.classList.add('camp-btn-info');
+      info.textContent = infoText;
+      wrap.appendChild(info);
+    }
+    btnRow.appendChild(wrap);
     return btn;
   }
 
-  addBtn('▶ Continue', () => closeCamp());
+  addBtn('▶ Continue', () => closeCamp(), 'Resume journey');
 
   if (stats.cashOutWithoutRedraw) {
     addBtn('💰 Cash Out', () => {
       cashOut();
       closeCamp();
-    });
+    }, 'Collect chips and quit');
   }
 
   addBtn('⟳ Redraw & Cash Out', () => {
     cashOut();
     handleRedraw();
     closeCamp();
-  });
+  }, 'Cash out then draw again');
 
   addBtn('♥ Heal Party', () => {
     drawnCards.forEach(c => {
@@ -2148,7 +2158,7 @@ function openCamp(onCloseCallback = null) {
     });
     updateHandDisplay();
     closeCamp();
-  });
+  }, 'Restore half HP');
   updateRedrawButton();
 
   const handRow = document.createElement('div');
@@ -2512,7 +2522,7 @@ function showSpeakerQuote(text) {
   msg.textContent = text;
   speakerOverlay.appendChild(msg);
   document.body.appendChild(speakerOverlay);
-  setTimeout(hideSpeakerQuote, 4000);
+  setTimeout(hideSpeakerQuote, 8000);
 }
 
 function hideSpeakerQuote() {

--- a/style.css
+++ b/style.css
@@ -505,6 +505,19 @@ body {
     gap: 8px;
 }
 
+.camp-btn {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2px;
+}
+
+.camp-btn-info {
+    font-size: 0.7rem;
+    text-align: center;
+    max-width: 90px;
+}
+
 .camp-fire {
     width: 80px;
     height: 60px;
@@ -1637,7 +1650,7 @@ body {
     color: #ddd;
     font-style: italic;
     text-shadow: 0 0 8px #fff;
-    animation: fogFade 3s ease-in-out;
+    animation: fogFade 7s ease-in-out;
 }
 @keyframes fogFade {
     from { opacity: 0; filter: blur(4px); }
@@ -1688,7 +1701,6 @@ body {
     position: relative;
     overflow: hidden;
     margin: 4px auto;
-    flex-basis: 100%;
 }
 
 .stage-progress-fill {


### PR DESCRIPTION
## Summary
- prevent dealer container shrinkage by removing flex basis
- add descriptions under camp actions
- randomize enemy attacks across the whole hand
- extend speaker quote display time

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68572d0f65fc8326a2ac83ad0233262e