### PR TITLE
Add sanity bar system

### DIFF
--- a/index.html
+++ b/index.html
@@ -142,6 +142,12 @@
             <div class="manaText" id="manaText">0/0</div>
           </div>
         </div>
+        <div class="sanityBar" id="sanityBar">
+          <div class="sanityBarInner">
+            <div id="sanityFill" class="sanityFill"></div>
+            <div id="sanityText" class="sanityText">100/100</div>
+          </div>
+        </div>
       </div>
       </div>
       <div class="worldsTab" style="display:none;">

--- a/script.js
+++ b/script.js
@@ -129,6 +129,8 @@ const stats = {
   maxMana: 0,
   mana: 0,
   manaRegen: 0,
+  maxSanity: 100,
+  sanity: 100,
   healOnRedraw: 0,
   abilityPower: 1,
   spadeDamageMultiplier: 1,
@@ -303,6 +305,8 @@ const jokerContainers = document.querySelectorAll(".jokerContainer");
 const manaBar = document.getElementById("manaBar");
 const manaFill = document.getElementById("manaFill");
 const manaText = document.getElementById("manaText");
+const sanityFill = document.getElementById('sanityFill');
+const sanityText = document.getElementById('sanityText');
 const manaRegenDisplay = document.getElementById("manaRegenDisplay");
 const dpsDisplay = document.getElementById("dpsDisplay");
 
@@ -335,6 +339,7 @@ let playerAttackTimer = 0;
 let enemyAttackProgress = 0; // carryover ratio of enemy attack timer
 let cashTimer = 0;
 let worldProgressTimer = 0;
+let sanityTimer = 0;
 const cashRateTracker = new RateTracker(10000);
 const cashRateTracker1h = new RateTracker(3600000);
 const cashRateTracker24h = new RateTracker(86400000);
@@ -1100,6 +1105,7 @@ document.addEventListener("DOMContentLoaded", () => {
   playerAttackFill = renderPlayerAttackBar(buttons);
   hidePlayerAttackBar();
   updateChipsDisplay();
+  updateSanityBar();
   requestAnimationFrame(gameLoop);
 });
 
@@ -1115,6 +1121,12 @@ function updateManaBar() {
   const ratio = stats.maxMana > 0 ? stats.mana / stats.maxMana: 0;
   if (manaFill) manaFill.style.width = `${Math.min(1, ratio) * 100}%`;
   if (manaText) manaText.textContent = `${Math.floor(stats.mana)}/${Math.floor(stats.maxMana)}`;
+}
+
+function updateSanityBar() {
+  const ratio = stats.maxSanity > 0 ? stats.sanity / stats.maxSanity : 0;
+  if (sanityFill) sanityFill.style.width = `${Math.min(1, ratio) * 100}%`;
+  if (sanityText) sanityText.textContent = `${Math.floor(stats.sanity)}/${Math.floor(stats.maxSanity)}`;
 }
 
 function unlockManaSystem() {
@@ -1437,6 +1449,8 @@ function nextStage() {
   playerStats.stageKills[stageData.stage] = stageData.kills;
   stageData.stage += 1;
   stageData.kills = playerStats.stageKills[stageData.stage] || 0;
+  stats.sanity = stats.maxSanity;
+  updateSanityBar();
   resetStageCashStats();
   killsDisplay.textContent = `Kills: ${formatNumber(stageData.kills)}`;
   renderGlobalStats();
@@ -1462,6 +1476,8 @@ function nextWorld() {
   stageData.world += 1;
   stageData.stage = 1;
   stageData.kills = playerStats.stageKills[stageData.stage] || 0;
+  stats.sanity = stats.maxSanity;
+  updateSanityBar();
   redrawCost = 10;
   updateRedrawButton();
   applyWorldTheme();
@@ -2871,6 +2887,7 @@ if (currentEnemy) {
   updatePlayerStats(stats);
   cashTimer += deltaTime;
   worldProgressTimer += deltaTime;
+  sanityTimer += deltaTime;
   if (cashTimer >= 1000) {
     recordCashRates(cash);
     if (statsEconomyContainer && statsEconomyContainer.style.display !== 'none') {
@@ -2886,6 +2903,17 @@ if (currentEnemy) {
       worldProgressPerSecDisplay.textContent = `Avg World Progress/sec: ${rate.toFixed(2)}%`;
     }
     worldProgressTimer = 0;
+  }
+  if (sanityTimer >= 1000) {
+    sanityTimer = 0;
+    if (!campOverlayOpen) {
+      if (stats.sanity > 0) {
+        stats.sanity = Math.max(0, stats.sanity - 1);
+        updateSanityBar();
+      } else {
+        cDealerDamage(1);
+      }
+    }
   }
   if (currentEnemy) {
     playerAttackTimer += deltaTime;

--- a/style.css
+++ b/style.css
@@ -258,6 +258,43 @@ body {
     white-space: nowrap;
 }
 
+.sanityBar {
+    grid-area: sanity;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 30px;
+    width: 80%;
+}
+
+.sanityBarInner {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.8);
+    border: 1px solid #9b59b6;
+    box-shadow: inset 0 0 6px #9b59b6;
+}
+
+.sanityFill {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: 0%;
+    background: #9b59b6;
+}
+
+.sanityText {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    color: #fff;
+    font-size: 0.7rem;
+    white-space: nowrap;
+}
+
 
 /*============ main tab side panel============== */
 


### PR DESCRIPTION
## Summary
- track `sanity` in player stats
- display sanity bar on the main screen
- style sanity bar elements
- update sanity every second and damage cards when depleted
- refill sanity when advancing stages or worlds

## Testing
- `npm test` *(fails: mocha not found)*
- `npm run lint` *(fails: missing eslint packages)*

------
https://chatgpt.com/codex/tasks/task_e_685736424b1c8326a7bf3b86ddf6a2aa