### PR TITLE
Extract restart overlay logic

### DIFF
--- a/script.js
+++ b/script.js
@@ -27,6 +27,7 @@ import { formatNumber } from "./utils/numberFormat.js";
 import { runAnimation } from "./utils/animation.js";
 import { initCore, refreshCore } from './core.js';
 import { createOverlay } from './ui/overlay.js';
+import { showRestartScreen } from './ui/restartOverlay.js';
 import {
   rollNewCardUpgrades,
   applyCardUpgrade,
@@ -1788,7 +1789,8 @@ function updateDealerLifeDisplay() {
 function cDealerDamage(damageAmount = null, ability = null, source = "dealer") {
   // If no card is available to take the hit, trigger game over
   if (drawnCards.length === 0) {
-    showRestartScreen();
+    playerStats.hasDied = true;
+    showRestartScreen(respawnPlayer);
     return;
   }
 
@@ -1842,8 +1844,9 @@ function cDealerDamage(damageAmount = null, ability = null, source = "dealer") {
       updatePlayerStats(stats);
       updateDrawButton();
       updateDeckDisplay();
-      if (drawnCards.length === 0 && deck.length === 0) {
-        showRestartScreen();
+      if (drawnCards.length === 0) {
+        playerStats.hasDied = true;
+        showRestartScreen(respawnPlayer);
       }
     });
   }
@@ -2472,45 +2475,6 @@ function respawnPlayer() {
   checkSpeakerEncounter();
 }
 
-let restartOverlay = null;
-let restartTimer = null;
-
-function showRestartScreen() {
-if (restartOverlay) return;
-playerStats.hasDied = true;
-restartOverlay = document.createElement("div");
-restartOverlay.classList.add("restart-overlay");
-
-const message = document.createElement("div");
-message.classList.add("restart-message");
-message.textContent = "Game Over";
-
-const btn = document.createElement("button");
-btn.textContent = "Restart";
-btn.addEventListener("click", () => {
-respawnPlayer();
-hideRestartScreen();
-});
-
-restartOverlay.append(message, btn);
-document.body.appendChild(restartOverlay);
-
-restartTimer = setTimeout(() => {
-respawnPlayer();
-hideRestartScreen();
-}, 5000);
-}
-
-function hideRestartScreen() {
-if (restartOverlay) {
-restartOverlay.remove();
-restartOverlay = null;
-}
-if (restartTimer) {
-clearTimeout(restartTimer);
-restartTimer = null;
-}
-}
 
 let speakerOverlay = null;
 function showSpeakerQuote(text) {

--- a/style.css
+++ b/style.css
@@ -1607,17 +1607,7 @@ body {
 }
 
 .restart-overlay {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100vw;
-    height: 100vh;
-    background: rgba(0, 0, 0, 0.8);
-    display: flex;
     flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    z-index: 5000;
 }
 
 .restart-overlay .restart-message {
@@ -1625,10 +1615,27 @@ body {
     margin-bottom: 1rem;
 }
 
-.restart-overlay button {
-    padding: 6px 12px;
+.restart-overlay .restart-flavor {
+    font-size: 0.9rem;
+    margin-bottom: 0.5rem;
+    opacity: 0.8;
+    text-align: center;
+}
+
+.restart-overlay .restart-button {
+    padding: 6px 16px;
     font-size: 1rem;
     cursor: pointer;
+    background: linear-gradient(#900, #500);
+    border: 1px solid #600;
+    color: #fff;
+    border-radius: 4px;
+}
+
+.restart-art {
+    width: 80px;
+    height: 60px;
+    margin-bottom: 8px;
 }
 
 @media (min-width: 768px) {

--- a/ui/restartOverlay.js
+++ b/ui/restartOverlay.js
@@ -1,0 +1,77 @@
+import { createOverlay } from './overlay.js';
+
+let restartOverlay = null;
+let restartTimer = null;
+
+export function drawRestartArt(canvas) {
+  const ctx = canvas.getContext('2d');
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  ctx.fillStyle = '#111';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  // skull
+  ctx.fillStyle = '#eee';
+  ctx.beginPath();
+  ctx.arc(canvas.width / 2, canvas.height / 2 - 5, 12, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.fillRect(canvas.width / 2 - 8, canvas.height / 2 + 7, 16, 8);
+  ctx.fillStyle = '#000';
+  ctx.beginPath();
+  ctx.arc(canvas.width / 2 - 5, canvas.height / 2 - 5, 3, 0, Math.PI * 2);
+  ctx.arc(canvas.width / 2 + 5, canvas.height / 2 - 5, 3, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.beginPath();
+  ctx.moveTo(canvas.width / 2 - 6, canvas.height / 2 + 4);
+  ctx.lineTo(canvas.width / 2 + 6, canvas.height / 2 + 4);
+  ctx.strokeStyle = '#000';
+  ctx.lineWidth = 2;
+  ctx.stroke();
+}
+
+export function showRestartScreen(onRestart) {
+  if (restartOverlay) return;
+
+  restartOverlay = createOverlay({ className: 'restart-overlay' });
+  const { box } = restartOverlay;
+
+  const canvas = document.createElement('canvas');
+  canvas.width = 80;
+  canvas.height = 60;
+  canvas.classList.add('restart-art');
+  box.appendChild(canvas);
+  drawRestartArt(canvas);
+
+  const message = document.createElement('div');
+  message.classList.add('restart-message');
+  message.textContent = 'Game Over';
+  box.appendChild(message);
+
+  const flavor = document.createElement('div');
+  flavor.classList.add('restart-flavor');
+  flavor.textContent = 'The deck runs cold. Try your luck again.';
+  box.appendChild(flavor);
+
+  const btn = document.createElement('button');
+  btn.classList.add('restart-button');
+  btn.textContent = 'Draw New Hand';
+  btn.addEventListener('click', () => {
+    if (onRestart) onRestart();
+    hideRestartScreen();
+  });
+  box.appendChild(btn);
+
+  restartTimer = setTimeout(() => {
+    if (onRestart) onRestart();
+    hideRestartScreen();
+  }, 5000);
+}
+
+export function hideRestartScreen() {
+  if (restartOverlay) {
+    restartOverlay.close();
+    restartOverlay = null;
+  }
+  if (restartTimer) {
+    clearTimeout(restartTimer);
+    restartTimer = null;
+  }
+}


### PR DESCRIPTION
## Summary
- move restart overlay code to a dedicated module
- invoke the new module when the player's hand empties

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6857368b3d408326ba67b728ad2d0116