### PR TITLE
Fix devTools spawn functions

### DIFF
--- a/script.js
+++ b/script.js
@@ -2925,8 +2925,8 @@ if (btn) btn.addEventListener("click", toggleDebug);
 
 // Developer helpers exposed on the console for testing
 window.devTools = {
-spawnBoss,
-spawnDealer,
+  spawnBoss: () => spawnBossEvent(),
+  spawnDealer: () => spawnDealerEvent(),
 cDealerDamage,
 killEnemy: () => {
 if (!currentEnemy) return;


### PR DESCRIPTION
## Summary
- fix `devTools` helpers to use the proper spawn event functions

## Testing
- `npm test` *(fails: `mocha` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685739f867d88326898cf81adb1f2f2b