### PR TITLE
Fix boss stage flow and card reset

### DIFF
--- a/cardManagement.js
+++ b/cardManagement.js
@@ -15,6 +15,7 @@ export function drawCard(state) {
     renderPurchasedUpgrades,
     updateActiveEffects,
     updateAllCardHp,
+    updateHandDisplay,
     pDeck,
     renderDeckTop,
     updatePileCounts
@@ -35,6 +36,7 @@ export function drawCard(state) {
     renderPurchasedUpgrades();
     updateActiveEffects();
     updateAllCardHp();
+    if (typeof updateHandDisplay === 'function') updateHandDisplay();
     return null;
   }
 

--- a/script.js
+++ b/script.js
@@ -111,8 +111,8 @@ function upgradePowerCost() {
   return Math.floor(50 * Math.pow(1.5, upgradePowerPurchased));
 }
 
-// Persistent player stats affecting combat and rewards
-const stats = {
+// Base player stats used for resets
+const BASE_STATS = {
   points: 0,
   upgradePower: 0,
   pDamage: 0,
@@ -144,6 +144,9 @@ const stats = {
   damageBuffExpiration: 0,
   cashOutWithoutRedraw: false
 };
+
+// Persistent player stats affecting combat and rewards
+const stats = { ...BASE_STATS };
 
 const systems = {
   manaUnlocked: false
@@ -268,6 +271,7 @@ function getCardState() {
     renderPurchasedUpgrades,
     updateActiveEffects,
     updateAllCardHp: recalcAllCardHp,
+    updateHandDisplay,
     pDeck,
     shuffleArray,
     updateDrawButton,
@@ -1449,6 +1453,7 @@ function nextStage() {
   playerStats.stageKills[stageData.stage] = stageData.kills;
   stageData.stage += 1;
   stageData.kills = playerStats.stageKills[stageData.stage] || 0;
+  const isBossStage = stageData.stage % 10 === 0;
   stats.sanity = stats.maxSanity;
   updateSanityBar();
   resetStageCashStats();
@@ -1464,10 +1469,15 @@ function nextStage() {
   inCombat = false;
   currentEnemy = null;
   redrawAllowed = false;
-  moveForwardBtn.style.display = 'inline-block';
+  moveForwardBtn.style.display = isBossStage ? 'none' : 'inline-block';
   nextStageBtn.style.display = 'none';
   updateStageProgressDisplay();
-  if (progressButtonActive) startStageProgress();
+  if (isBossStage) {
+    progressButtonActive = false;
+    respawnDealerStage();
+  } else if (progressButtonActive) {
+    startStageProgress();
+  }
 }
 
 // Called when a boss is defeated to move to the next world
@@ -1674,7 +1684,7 @@ function respawnDealerStage() {
   if (speakerEncounterPending) {
     speakerEncounterPending = false;
     currentEnemy = spawnEnemy('speaker', stageData, enemyAttackProgress, onSpeakerDefeat);
-  } else if (stageData.stage === 10) {
+  } else if (stageData.stage % 10 === 0) {
     currentEnemy = spawnEnemy('boss', stageData, enemyAttackProgress, () => onBossDefeat(currentEnemy));
   } else {
     currentEnemy = spawnEnemy('dealer', stageData, enemyAttackProgress, onDealerDefeat);
@@ -1777,7 +1787,7 @@ function onBossDefeat(boss) {
     updateChipsDisplay();
     hidePlayerAttackBar();
     showStageProgressBar();
-    nextWorld();
+    nextStage();
     progressButtonActive = true;
     startStageProgress();
   });
@@ -2440,6 +2450,7 @@ function spawnPlayer() {
 function respawnPlayer() {
   enemyAttackProgress = 0;
   playerStats.hasDied = false;
+  Object.assign(stats, BASE_STATS);
   cash = 0;
   chips = 0;
   resetCashRates(cash);

--- a/style.css
+++ b/style.css
@@ -1734,7 +1734,7 @@ body {
 /* Stage traversal progress bar */
 .stage-progress {
     width: 50%;
-    height: 2px;
+    height: 8px;
     background: #090b09;
     border: 1px solid grey;
     border-radius: 4px;
@@ -1749,7 +1749,7 @@ body {
     left: 0;
     height: 100%;
     width: 0;
-    background: green;
+    background: #2ecc71;
 }
 
 .card-upgrades {


### PR DESCRIPTION
## Summary
- reset player stats on respawn to remove lingering upgrades
- spawn bosses every 10th stage and continue to next stage after victory
- update progress bar visuals
- refresh card HP display when drawing HP multiplier upgrades

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_68573841bf548326b09450262f97bdc8