### PR TITLE
Improve player resource bars

### DIFF
--- a/index.html
+++ b/index.html
@@ -130,24 +130,25 @@
           <div id="playerAttackBar" class="playerAttackBar">
             <div class="playerAttackFill"></div>
           </div>
+          <div class="manaBar" id="manaBar" style="display:none;">
+            <div class="manaBarInner">
+              <div class="manaFill" id="manaFill"></div>
+              <div class="manaText" id="manaText">0/0</div>
+            </div>
+          </div>
+          <div class="sanityBar" id="sanityBar">
+            <div class="sanityBarInner">
+              <div id="sanityFill" class="sanityFill"></div>
+              <div id="sanityText" class="sanityText">100/100</div>
+            </div>
+          </div>
           <button id="moveForwardBtn" title="Move Forward">➡️</button>
+          <button id="campBtn" style="display:none;" title="Camp">🏕️</button>
           <button id="nextStageBtn" style="display:none;" disabled title="Next Stage">🚀</button>
           <button id="fightBossBtn" style="display:none;" title="Fight Boss">👑</button>
         </div>
         <div class="handContainer casino-section"></div>
         <div class="jokerContainer casino-section"></div>
-        <div class="manaBar" id="manaBar" style="display:none;">
-          <div class="manaBarInner">
-            <div class="manaFill" id="manaFill"></div>
-            <div class="manaText" id="manaText">0/0</div>
-          </div>
-        </div>
-        <div class="sanityBar" id="sanityBar">
-          <div class="sanityBarInner">
-            <div id="sanityFill" class="sanityFill"></div>
-            <div id="sanityText" class="sanityText">100/100</div>
-          </div>
-        </div>
       </div>
       </div>
       <div class="worldsTab" style="display:none;">

--- a/script.js
+++ b/script.js
@@ -284,6 +284,7 @@ function getCardState() {
 const nextStageBtn = document.getElementById("nextStageBtn");
 const moveForwardBtn = document.getElementById("moveForwardBtn");
 const fightBossBtn = document.getElementById("fightBossBtn");
+const campBtn = document.getElementById("campBtn");
 const pointsDisplay = document.getElementById("pointsDisplay");
 const cashDisplay = document.getElementById("cashDisplay");
 const chipsDisplay = document.getElementById("chipsDisplay");
@@ -1105,6 +1106,13 @@ document.addEventListener("DOMContentLoaded", () => {
     enemyAttackFill = renderEnemyAttackBar();
     dealerDeathAnimation();
   });
+  if (campBtn) {
+    campBtn.addEventListener('click', () => {
+      campBtn.style.display = 'none';
+      stageComplete = false;
+      openCamp(() => openCardUpgradeSelection(nextStage));
+    });
+  }
   renderJokers();
   const buttons = document.querySelector('.buttonsContainer');
   playerAttackFill = renderPlayerAttackBar(buttons);
@@ -1654,6 +1662,8 @@ function stepStageProgress() {
     stopStageProgress();
     moveForwardBtn.style.display = 'none';
     stageEndEnemyActive = true;
+    stageComplete = true;
+    if (campBtn) campBtn.style.display = 'inline-block';
     spawnDealerEvent(1.3);
   }
 }
@@ -1717,7 +1727,9 @@ function onDealerDefeat() {
       hidePlayerAttackBar();
       if (stageEndEnemyActive) {
         stageEndEnemyActive = false;
-        openCamp(() => openCardUpgradeSelection(nextStage));
+        respawnDealerStage();
+      } else if (stageComplete) {
+        respawnDealerStage();
       } else {
         showStageProgressBar();
         progressButtonActive = true;
@@ -1988,6 +2000,7 @@ let stageProgressing = false;
 let stageProgressInterval = null;
 let progressButtonActive = false;
 let stageEndEnemyActive = false;
+let stageComplete = false;
 
 function rarityClass(rarity) {
   switch (rarity) {

--- a/style.css
+++ b/style.css
@@ -197,11 +197,9 @@ body {
 .gameColumn {
     display: grid;
     grid-template-columns: 1fr;
-    grid-template-rows: auto auto auto 1fr auto;
+    grid-template-rows: auto 1fr auto;
     grid-template-areas:
         "buttons"
-        "mana"
-        "sanity"
         "hand"
         "jokers";
     overflow-y: auto;
@@ -223,12 +221,12 @@ body {
 }
 
 .manaBar {
-    grid-area: mana;
     display: flex;
     justify-content: center;
     align-items: center;
     height: 30px;
-    width: 80%;
+    width: 50%;
+    margin: 0 auto;
 }
 
 .manaBarInner {
@@ -237,6 +235,8 @@ body {
     height: 100%;
     background: rgba(0, 0, 0, 0.8);
     border: 1px solid #3498db;
+    border-radius: 8px;
+    overflow: hidden;
     box-shadow: inset 0 0 6px #3498db;
 }
 
@@ -247,6 +247,7 @@ body {
     height: 100%;
     width: 0%;
     background: #3498db;
+    transition: width 0.3s;
 }
 
 .manaText {
@@ -260,12 +261,12 @@ body {
 }
 
 .sanityBar {
-    grid-area: sanity;
     display: flex;
     justify-content: center;
     align-items: center;
     height: 30px;
-    width: 80%;
+    width: 50%;
+    margin: 0 auto;
 }
 
 .sanityBarInner {
@@ -274,6 +275,8 @@ body {
     height: 100%;
     background: rgba(0, 0, 0, 0.8);
     border: 1px solid #9b59b6;
+    border-radius: 8px;
+    overflow: hidden;
     box-shadow: inset 0 0 6px #9b59b6;
 }
 
@@ -284,6 +287,7 @@ body {
     height: 100%;
     width: 0%;
     background: #9b59b6;
+    transition: width 0.3s;
 }
 
 .sanityText {


### PR DESCRIPTION
## Summary
- place mana/sanity bars within the buttons container
- give mana and sanity bars same style as enemy health
- add camp button for stage transition
- keep spawning enemies after progress completion until camping

## Testing
- `npm test` *(fails: mocha not found)*
- `npm run lint` *(fails: ESLint module missing)*

------
https://chatgpt.com/codex/tasks/task_e_68574d86f800832688de20a1f7a6c3c7