### PR TITLE
Add low sanity overlay and local pixi scripts

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,12 +4,10 @@
   <link rel="stylesheet" href="style.css">
   <script src="https://unpkg.com/lucide@latest"></script>
   <title>Page Title</title>
-  <script src="https://cdn.jsdelivr.net/npm/pixi.js@6.5.8/dist/browser/pixi.min.js"></script>
-  <!-- :contentReference[oaicite:0]{index=0} -->
+  <script src="pixi.min.js"></script>
 
   <!-- And the GlowFilter plugin: -->
-  <script src="https://cdn.jsdelivr.net/npm/pixi-filters@latest/dist/browser/pixi-filters.min.js"></script>
-  <!-- :contentReference[oaicite:1]{index=1} -->
+  <script src="pixi-filters.min.js"></script>
 </head>
   <body>
     <div id="insanityOrb" class="insanity-orb" title="The mind frays..."></div>

--- a/script.js
+++ b/script.js
@@ -348,6 +348,7 @@ const insanityMessages = [
 ];
 let insanityMsgIndex = 0;
 let lastInsanityMsg = 0;
+let lowSanityOverlayShown = false;
 const manaRegenDisplay = document.getElementById("manaRegenDisplay");
 const dpsDisplay = document.getElementById("dpsDisplay");
 
@@ -1194,9 +1195,14 @@ function updateInsanityOrb(ratio) {
       insanityMsgIndex = (insanityMsgIndex + 1) % insanityMessages.length;
       lastInsanityMsg = now;
     }
+    if (ratio < 0.1 && !lowSanityOverlayShown) {
+      showSpeakerQuote("Reach for the light. before it's too late");
+      lowSanityOverlayShown = true;
+    }
   } else {
     insanityOrb.classList.remove('critical');
     document.body.classList.remove('insanity-low');
+    if (ratio >= 0.1) lowSanityOverlayShown = false;
   }
 }
 


### PR DESCRIPTION
## Summary
- load PixiJS and filters from local files so the camp halo glow works without network access
- show a narrative overlay when sanity drops below 10%

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68578f2b0fcc8326b41a3deeff3228c3