### PR TITLE
Reposition sanity orb to dealer header

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,6 @@
   <script src="pixi-filters.min.js"></script>
 </head>
   <body>
-    <div id="insanityOrb" class="insanity-orb" title="The mind frays..."></div>
     <button id="debugToggle" class="debug-toggle">Debug</button>
     <div id="debugPanel" style="display:none;">
       <label>Cash: <input id="debugCash" type="number" value="10000" style="width: 60px;"></label>
@@ -55,8 +54,9 @@
       </div>
       <div class="cardSubTab">
         <div class="dealerContainer casino-section">
-          <div id="stage">
-            Stage 1
+          <div class="dealer-header">
+            <div id="stage">Stage 1</div>
+            <div id="insanityOrb" class="insanity-orb" title="The mind frays..."></div>
           </div>
         <span id="kills">kills: 0</span>
         <span id="distanceDisplay">distance: 0/0</span>

--- a/script.js
+++ b/script.js
@@ -220,7 +220,7 @@ function updateCampButtonGlow(ratio) {
 
 function initCampHalo() {
   if (!campBtn || typeof PIXI !== 'object') return;
-  campHaloApp = new PIXI.Application({ width: 60, height: 60, transparent: true });
+  campHaloApp = new PIXI.Application({ width: 60, height: 60, backgroundAlpha: 0 });
   campBtn.appendChild(campHaloApp.view);
   campHaloApp.view.style.position = 'absolute';
   campHaloApp.view.style.inset = '0';

--- a/style.css
+++ b/style.css
@@ -261,10 +261,7 @@ body {
 }
 
 .insanity-orb {
-    position: fixed;
-    top: 50%;
-    left: 10px;
-    transform: translateY(-50%);
+    display: inline-block;
     width: 40px;
     height: 40px;
     border-radius: 50%;
@@ -272,15 +269,14 @@ body {
     box-shadow: 0 0 10px rgba(155, 89, 182, 0.7), 0 0 20px rgba(155, 89, 182, 0.5);
     animation: orbPulse var(--pulse-duration, 3s) infinite;
     pointer-events: auto;
-    z-index: 1000;
 }
 
 @keyframes orbPulse {
     0%, 100% {
-        transform: translateY(-50%) scale(1);
+        transform: scale(1);
     }
     50% {
-        transform: translateY(-50%) scale(1.1);
+        transform: scale(1.1);
     }
 }
 
@@ -389,6 +385,13 @@ body.insanity-low::after {
 
 .dealerContainer > .dealerLifeDisplay {
     justify-self: center;
+}
+
+.dealer-header {
+    align-self: flex-start;
+    display: flex;
+    align-items: center;
+    gap: 4px;
 }
 #stage {
     align-self: flex-start;


### PR DESCRIPTION
## Summary
- move sanity orb inside dealer header in `index.html`
- adjust orb styling to be inline
- add `.dealer-header` styles for layout
- initialize camp halo with `backgroundAlpha: 0`

## Testing
- `PUPPETEER_SKIP_DOWNLOAD=1 npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685790650f848326813f080f5db8d842