### PR TITLE
Fix camp halo & low sanity prompt

### DIFF
--- a/script.js
+++ b/script.js
@@ -224,22 +224,12 @@ async function initCampHalo() {
   }
   let app;
   try {
-    app = new PIXI.Application();
-    await app.init({ width: 60, height: 60, backgroundAlpha: 0 });
+    app = new PIXI.Application({ width: 60, height: 60, backgroundAlpha: 0 });
   } catch (err) {
     console.error('Failed to create camp halo PIXI app:', err);
     return;
   }
-  let view;
-  try {
-    view = app.canvas ?? app.view;
-  } catch (err) {
-    console.error('Camp halo renderer view unavailable:', err);
-    if (typeof app.destroy === 'function') {
-      try { app.destroy(true); } catch (e) {}
-    }
-    return;
-  }
+  const view = app.view;
   if (!view) {
     console.error('Camp halo view not created');
     if (typeof app.destroy === 'function') {
@@ -1215,7 +1205,6 @@ function updateInsanityOrb(ratio) {
   insanityOrb.style.setProperty('--pulse-duration', `${dur}s`);
   if (ratio < 0.3) {
     insanityOrb.classList.add('critical');
-    document.body.classList.add('insanity-low');
     const now = Date.now();
     if (now - lastInsanityMsg > 5000) {
       addLog(insanityMessages[insanityMsgIndex]);
@@ -1223,12 +1212,11 @@ function updateInsanityOrb(ratio) {
       lastInsanityMsg = now;
     }
     if (ratio < 0.1 && !lowSanityOverlayShown) {
-      showSpeakerQuote("Reach for the light. before it's too late");
+      showCampMessage("Reach for the light. before it's too late");
       lowSanityOverlayShown = true;
     }
   } else {
     insanityOrb.classList.remove('critical');
-    document.body.classList.remove('insanity-low');
     if (ratio >= 0.1) lowSanityOverlayShown = false;
   }
 }
@@ -2625,6 +2613,20 @@ function hideSpeakerQuote() {
     speakerOverlay.remove();
     speakerOverlay = null;
   }
+}
+
+let campMessageElem = null;
+function showCampMessage(text) {
+  if (!campBtn || campMessageElem) return;
+  const msg = document.createElement('div');
+  msg.classList.add('camp-message');
+  msg.textContent = text;
+  campMessageElem = msg;
+  campBtn.appendChild(msg);
+  setTimeout(() => {
+    msg.remove();
+    if (campMessageElem === msg) campMessageElem = null;
+  }, 2000);
 }
 
 // Fully wipe saved data and reload the page

--- a/style.css
+++ b/style.css
@@ -289,18 +289,7 @@ body {
     box-shadow: 0 0 10px rgba(255, 0, 0, 0.8), 0 0 20px rgba(255, 0, 0, 0.6);
 }
 
-body.insanity-low {
-    filter: grayscale(0.4);
-}
 
-body.insanity-low::after {
-    content: '';
-    position: fixed;
-    inset: 0;
-    pointer-events: none;
-    background: radial-gradient(circle, rgba(0, 0, 0, 0) 60%, rgba(0, 0, 0, 0.6) 100%);
-    z-index: 999;
-}
 
 
 
@@ -1723,6 +1712,26 @@ body.insanity-low::after {
     font-style: italic;
     text-shadow: 0 0 8px #fff;
     animation: fogFade 7s ease-in-out;
+}
+
+.camp-message {
+    position: absolute;
+    bottom: -1.2em;
+    left: 50%;
+    transform: translateX(-50%);
+    color: #fff;
+    font-size: 0.9rem;
+    pointer-events: none;
+    text-shadow: 0 0 4px #000;
+    animation: camp-msg-fade 2s ease-in-out;
+    white-space: nowrap;
+}
+
+@keyframes camp-msg-fade {
+    from { opacity: 0; }
+    20% { opacity: 1; }
+    80% { opacity: 1; }
+    to { opacity: 0; }
 }
 @keyframes fogFade {
     from { opacity: 0; filter: blur(4px); }


### PR DESCRIPTION
## Summary
- ensure camp halo Pixi app initializes synchronously
- show low sanity hint below camp button instead of full-screen overlay
- drop darkening overlay from low sanity state

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_68587b669df88326a63d74619eacfcd0