### PR TITLE
Simplify early gameplay

### DIFF
--- a/card.js
+++ b/card.js
@@ -66,8 +66,9 @@ export class Card {
     this.XpReq += this.currentLevel * 1.7 * (this.value ** 2);
     this.damage = this.baseDamage + 5 * (this.currentLevel - 1);
     const baseMultiplier = 1 + (this.value - 1) / 12;
+    const prevHp = this.currentHp;
     this.maxHp = Math.round(5 * baseMultiplier + 5 * (this.currentLevel - 1) + this.baseHpBoost);
-    this.currentHp = this.maxHp;
+    this.currentHp = Math.min(this.maxHp, prevHp);
   }
 
   healFromKill() {

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
   <script src="pixi-filters.min.js"></script>
 </head>
   <body>
-    <div id="insanityOrb" class="insanity-orb" title="The mind frays..."></div>
+    <!--<div id="insanityOrb" class="insanity-orb" title="The mind frays..."></div>-->
     <button id="debugToggle" class="debug-toggle">Debug</button>
     <div id="debugPanel" style="display:none;">
       <label>Cash: <input id="debugCash" type="number" value="10000" style="width: 60px;"></label>
@@ -59,13 +59,13 @@
             Stage 1
           </div>
         <span id="kills">kills: 0</span>
-        <span id="distanceDisplay">distance: 0/0</span>
+        <!--<span id="distanceDisplay">distance: 0/0</span>-->
         <div class="dealerLifeDisplay">
           Life:10
         </div>
-        <div id="stageProgressBar" class="stage-progress">
+        <!--<div id="stageProgressBar" class="stage-progress">
           <div id="stageProgressFill" class="stage-progress-fill"></div>
-        </div>
+        </div>-->
         <div class="dCardContainer"></div>
       </div>
 
@@ -135,7 +135,7 @@
               <div class="manaText" id="manaText">0/0</div>
             </div>
           </div>
-          <button id="moveForwardBtn" title="Move Forward">➡️</button>
+          <!--<button id="moveForwardBtn" title="Move Forward">➡️</button>-->
           <button id="campBtn" style="display:none;" title="Find the Light"><i data-lucide="eye"></i></button>
           <button id="nextStageBtn" style="display:none;" disabled title="Next Stage">🚀</button>
           <button id="fightBossBtn" style="display:none;" title="Fight Boss">👑</button>

--- a/script.js
+++ b/script.js
@@ -130,8 +130,8 @@ const BASE_STATS = {
   maxMana: 0,
   mana: 0,
   manaRegen: 0,
-  maxSanity: 100,
-  sanity: 100,
+  //maxSanity: 100,
+  //sanity: 100,
   healOnRedraw: 0,
   abilityPower: 1,
   spadeDamageMultiplier: 1,
@@ -177,9 +177,7 @@ let stageData = {
   kills: 0,
   cardXp: 1,
   playerXp: 1,
-  attackspeed: 10000, //10 sec at start
-  progress: 0,
-  progressTarget: 10
+  attackspeed: 10000 //10 sec at start
 }; 
 
 let speakerEncounterPending = false;
@@ -262,7 +260,7 @@ async function initCampHalo() {
   campHaloApp.ticker.add(() => {
     halo.alpha = 0.4 + 0.1 * Math.sin(Date.now() / 1000);
   });
-  updateCampButtonGlow(stats.maxSanity > 0 ? stats.sanity / stats.maxSanity : 1);
+  updateCampButtonGlow(1);
 }
 
 const playerStats = {
@@ -334,7 +332,7 @@ function getCardState() {
 }
 
 const nextStageBtn = document.getElementById("nextStageBtn");
-const moveForwardBtn = document.getElementById("moveForwardBtn");
+//const moveForwardBtn = document.getElementById("moveForwardBtn");
 const fightBossBtn = document.getElementById("fightBossBtn");
 const campBtn = document.getElementById("campBtn");
 const pointsDisplay = document.getElementById("pointsDisplay");
@@ -357,25 +355,25 @@ const deckJobsContainer = document.querySelector('.deckJobsContainer');
 const jobCarouselContainer = document.querySelector('.jobCarouselContainer');
 const dCardContainer = document.getElementsByClassName("dCardContainer")[0];
 const dealerContainer = document.querySelector('.dealerContainer');
-const stageProgressFill = document.getElementById("stageProgressFill");
-const stageProgressBar = document.getElementById("stageProgressBar");
 const jokerContainers = document.querySelectorAll(".jokerContainer");
 const manaBar = document.getElementById("manaBar");
 const manaFill = document.getElementById("manaFill");
 const manaText = document.getElementById("manaText");
-const sanityFill = document.getElementById('sanityFill');
-const sanityText = document.getElementById('sanityText');
-const insanityOrb = document.getElementById('insanityOrb');
+//const stageProgressFill = document.getElementById("stageProgressFill");
+//const stageProgressBar = document.getElementById("stageProgressBar");
+const sanityFill = null;
+const sanityText = null;
+const insanityOrb = null;
 let campHaloApp = null;
 let campGlowFilter = null;
-const insanityMessages = [
-  "You feel watched.",
-  "The walls bend inward.",
-  "Thoughts scatter like crows..."
-];
-let insanityMsgIndex = 0;
-let lastInsanityMsg = 0;
-let lowSanityOverlayShown = false;
+//const insanityMessages = [
+//  "You feel watched.",
+//  "The walls bend inward.",
+//  "Thoughts scatter like crows..."
+//];
+//let insanityMsgIndex = 0;
+//let lastInsanityMsg = 0;
+//let lowSanityOverlayShown = false;
 const manaRegenDisplay = document.getElementById("manaRegenDisplay");
 const dpsDisplay = document.getElementById("dpsDisplay");
 
@@ -391,13 +389,13 @@ function hidePlayerAttackBar() {
   playerAttackTimer = 0;
 }
 
-function hideStageProgressBar() {
-  if (stageProgressBar) stageProgressBar.style.display = "none";
-}
+//function hideStageProgressBar() {
+//  if (stageProgressBar) stageProgressBar.style.display = "none";
+//}
 
-function showStageProgressBar() {
-  if (stageProgressBar) stageProgressBar.style.display = "block";
-}
+//function showStageProgressBar() {
+//  if (stageProgressBar) stageProgressBar.style.display = "block";
+//}
 
 const unlockedJokers = [];
 
@@ -408,7 +406,7 @@ let playerAttackTimer = 0;
 let enemyAttackProgress = 0; // carryover ratio of enemy attack timer
 let cashTimer = 0;
 let worldProgressTimer = 0;
-let sanityTimer = 0;
+//let sanityTimer = 0;
 const cashRateTracker = new RateTracker(10000);
 const cashRateTracker1h = new RateTracker(3600000);
 const cashRateTracker24h = new RateTracker(86400000);
@@ -1128,9 +1126,6 @@ document.addEventListener("DOMContentLoaded", () => {
   renderPurchasedUpgrades();
   // Start or resume the game after loading
   spawnPlayer();
-  stageData.progress = 0;
-  stageData.progressTarget = 10;
-  updateStageProgressDisplay();
   renderDealerCard();
   resetStageCashStats();
   renderStageInfo();
@@ -1142,14 +1137,9 @@ document.addEventListener("DOMContentLoaded", () => {
   checkUpgradeUnlocks();
 
   nextStageBtn.style.display = 'none';
-  moveForwardBtn.style.display = 'inline-block';
-
-  moveForwardBtn.addEventListener("click", moveForward);
-  if (stageProgressBar) stageProgressBar.addEventListener("click", moveForward);
   nextStageBtn.addEventListener("click", nextStage);
   fightBossBtn.addEventListener("click", () => {
     fightBossBtn.style.display = "none";
-    hideStageProgressBar();
     stageData.stage = 10;
     stageData.kills = playerStats.stageKills[stageData.stage] || 0;
     renderStageInfo();
@@ -1174,7 +1164,6 @@ document.addEventListener("DOMContentLoaded", () => {
   if (campBtn) {
     campBtn.addEventListener('click', () => {
       campBtn.style.display = 'none';
-      stageComplete = false;
       openCamp(() => openCardUpgradeSelection(nextStage));
     });
   }
@@ -1183,7 +1172,6 @@ document.addEventListener("DOMContentLoaded", () => {
   playerAttackFill = renderPlayerAttackBar(buttons);
   hidePlayerAttackBar();
   updateChipsDisplay();
-  updateSanityBar();
   requestAnimationFrame(gameLoop);
 });
 
@@ -1201,37 +1189,8 @@ function updateManaBar() {
   if (manaText) manaText.textContent = `${Math.floor(stats.mana)}/${Math.floor(stats.maxMana)}`;
 }
 
-function updateSanityBar() {
-  const ratio = stats.maxSanity > 0 ? stats.sanity / stats.maxSanity : 0;
-  if (sanityFill) sanityFill.style.width = `${Math.min(1, ratio) * 100}%`;
-  if (sanityText) sanityText.textContent = `${Math.floor(stats.sanity)}/${Math.floor(stats.maxSanity)}`;
-  updateInsanityOrb(ratio);
-  updateCampButtonGlow(ratio);
-}
-
-function updateInsanityOrb(ratio) {
-  if (!insanityOrb) return;
-  const dur = 3 - 2 * (1 - ratio);
-  insanityOrb.style.setProperty('--pulse-duration', `${dur}s`);
-  if (ratio < 0.3) {
-    insanityOrb.classList.add('critical');
-    document.body.classList.add('insanity-low');
-    const now = Date.now();
-    if (now - lastInsanityMsg > 5000) {
-      addLog(insanityMessages[insanityMsgIndex]);
-      insanityMsgIndex = (insanityMsgIndex + 1) % insanityMessages.length;
-      lastInsanityMsg = now;
-    }
-    if (ratio < 0.1 && !lowSanityOverlayShown) {
-      showSpeakerQuote("Reach for the light. before it's too late");
-      lowSanityOverlayShown = true;
-    }
-  } else {
-    insanityOrb.classList.remove('critical');
-    document.body.classList.remove('insanity-low');
-    if (ratio >= 0.1) lowSanityOverlayShown = false;
-  }
-}
+//function updateSanityBar() {}
+//function updateInsanityOrb(ratio) {}
 
 function unlockManaSystem() {
   // prevent duplicate initialization
@@ -1554,8 +1513,6 @@ function nextStage() {
   stageData.stage += 1;
   stageData.kills = playerStats.stageKills[stageData.stage] || 0;
   const isBossStage = stageData.stage % 10 === 0;
-  stats.sanity = stats.maxSanity;
-  updateSanityBar();
   resetStageCashStats();
   killsDisplay.textContent = `Kills: ${formatNumber(stageData.kills)}`;
   renderGlobalStats();
@@ -1564,19 +1521,14 @@ function nextStage() {
   checkSpeakerEncounter();
   // start the next stage without double-counting points
   lastCashOutPoints = stats.points;
-  stageData.progress = 0;
-  stageData.progressTarget = 10;
   inCombat = false;
   currentEnemy = null;
   redrawAllowed = false;
-  moveForwardBtn.style.display = isBossStage ? 'none' : 'inline-block';
   nextStageBtn.style.display = 'none';
-  updateStageProgressDisplay();
   if (isBossStage) {
-    progressButtonActive = false;
     respawnDealerStage();
-  } else if (progressButtonActive) {
-    startStageProgress();
+  } else {
+    respawnDealerStage();
   }
 }
 
@@ -1586,8 +1538,6 @@ function nextWorld() {
   stageData.world += 1;
   stageData.stage = 1;
   stageData.kills = playerStats.stageKills[stageData.stage] || 0;
-  stats.sanity = stats.maxSanity;
-  updateSanityBar();
   redrawCost = 10;
   updateRedrawButton();
   applyWorldTheme();
@@ -1603,15 +1553,11 @@ function nextWorld() {
   checkUpgradeUnlocks();
   // entering a new world resets cash-out tracking
   lastCashOutPoints = stats.points;
-  stageData.progress = 0;
-  stageData.progressTarget = 10;
   inCombat = false;
   currentEnemy = null;
   redrawAllowed = false;
-  moveForwardBtn.style.display = 'inline-block';
   nextStageBtn.style.display = 'none';
-  updateStageProgressDisplay();
-  if (progressButtonActive) startStageProgress();
+  respawnDealerStage();
 }
 
 // Travel to a specific world when selected in the Worlds tab
@@ -1634,16 +1580,13 @@ function goToWorld(id) {
   renderStageInfo();
   checkUpgradeUnlocks();
   lastCashOutPoints = stats.points;
-  stageData.progress = 0;
-  stageData.progressTarget = 10;
   inCombat = false;
   currentEnemy = null;
   redrawAllowed = false;
-  moveForwardBtn.style.display = 'inline-block';
   nextStageBtn.style.display = 'none';
-  updateStageProgressDisplay();
   renderWorldsMenu();
   updateWorldTabNotification();
+  respawnDealerStage();
 }
 
 // Reset tracking for average cash when a new stage begins
@@ -1653,11 +1596,7 @@ function resetStageCashStats() {
 }
 
 // Enable the next stage button when kill requirements met
-function nextStageChecker() {
-  const ready = stageData.progress >= stageData.progressTarget;
-  nextStageBtn.disabled = !ready;
-  nextStageBtn.style.background = ready ? "green" : "grey";
-}
+//function nextStageChecker() {}
 
 //dealer
 
@@ -1682,8 +1621,6 @@ function removeDealerLifeBar() {
 }
 
 function spawnDealerEvent(powerMult = 1) {
-  stopStageProgress();
-  hideStageProgressBar();
   inCombat = true;
   removeDealerLifeBar();
   const temp = { ...stageData, stage: Math.round(stageData.stage * powerMult) };
@@ -1695,8 +1632,6 @@ function spawnDealerEvent(powerMult = 1) {
 }
 
 function spawnBossEvent() {
-  stopStageProgress();
-  hideStageProgressBar();
   inCombat = true;
   removeDealerLifeBar();
   currentEnemy = spawnEnemy('boss', stageData, enemyAttackProgress, () => onBossDefeat(currentEnemy));
@@ -1725,63 +1660,14 @@ function maybeTriggerEvent() {
   }
 }
 
-function updateStageProgressDisplay() {
-  if (stageProgressFill) {
-    const ratio = Math.min(stageData.progress / stageData.progressTarget, 1);
-    stageProgressFill.style.width = `${ratio * 100}%`;
-  }
-  const disp = document.getElementById('distanceDisplay');
-  if (disp) disp.textContent = `distance: ${Math.floor(stageData.progress)}/${stageData.progressTarget}`;
-}
-
-function stopStageProgress() {
-  if (stageProgressInterval) {
-    clearInterval(stageProgressInterval);
-    stageProgressInterval = null;
-  }
-  stageProgressing = false;
-  moveForwardBtn.classList.remove('active');
-}
-
-function stepStageProgress() {
-  if (currentEnemy || campOverlayOpen || upgradeSelectionOpen) return;
-  // Each tick has a chance to trigger a random event
-  maybeTriggerEvent();
-  stageData.progress = Math.min(stageData.progress + 1, stageData.progressTarget);
-  updateStageProgressDisplay();
-  if (stageData.progress >= stageData.progressTarget) {
-    stopStageProgress();
-    moveForwardBtn.style.display = 'none';
-    stageEndEnemyActive = true;
-    stageComplete = true;
-    if (campBtn) campBtn.style.display = 'inline-block';
-    spawnDealerEvent(1.3);
-  }
-}
-
-function startStageProgress() {
-  if (stageProgressing) return;
-  showStageProgressBar();
-  stageProgressing = true;
-  stageProgressInterval = setInterval(stepStageProgress, 1000);
-  moveForwardBtn.classList.add('active');
-}
-
-function moveForward() {
-  if (currentEnemy || campOverlayOpen || upgradeSelectionOpen) return;
-  if (stageProgressing) {
-    progressButtonActive = false;
-    stopStageProgress();
-    hideStageProgressBar();
-  } else {
-    progressButtonActive = true;
-    startStageProgress();
-  }
-}
+//function updateStageProgressDisplay() {}
+//function stopStageProgress() {}
+//function stepStageProgress() {}
+//function startStageProgress() {}
+//function moveForward() {}
 
 // After a kill, decide whether to spawn a dealer or a boss
 function respawnDealerStage() {
-  hideStageProgressBar();
   removeDealerLifeBar();
   if (speakerEncounterPending) {
     speakerEncounterPending = false;
@@ -1816,16 +1702,7 @@ function onDealerDefeat() {
       currentEnemy = null;
       updateDealerLifeDisplay();
       hidePlayerAttackBar();
-      if (stageEndEnemyActive) {
-        stageEndEnemyActive = false;
-        respawnDealerStage();
-      } else if (stageComplete) {
-        respawnDealerStage();
-      } else {
-        showStageProgressBar();
-        progressButtonActive = true;
-        startStageProgress();
-      }
+      respawnDealerStage();
     });
 } // need to define xp formula
 
@@ -1851,9 +1728,7 @@ function onSpeakerDefeat() {
     updateChipsDisplay();
     updateDealerLifeDisplay();
     hidePlayerAttackBar();
-    showStageProgressBar();
-    progressButtonActive = true;
-    startStageProgress();
+    respawnDealerStage();
   });
 }
 
@@ -1890,10 +1765,7 @@ function onBossDefeat(boss) {
     chips += computeChipReward();
     updateChipsDisplay();
     hidePlayerAttackBar();
-    showStageProgressBar();
     nextStage();
-    progressButtonActive = true;
-    startStageProgress();
   });
 }
 
@@ -2087,11 +1959,11 @@ let redrawAllowed = false;
 let upgradeSelectionOpen = false;
 let upgradeOverlay = null; // overlay instance
 let redrawCost = 10;
-let stageProgressing = false;
-let stageProgressInterval = null;
-let progressButtonActive = false;
-let stageEndEnemyActive = false;
-let stageComplete = false;
+//let stageProgressing = false;
+//let stageProgressInterval = null;
+//let progressButtonActive = false;
+//let stageEndEnemyActive = false;
+//let stageComplete = false;
 
 function rarityClass(rarity) {
   switch (rarity) {
@@ -2121,7 +1993,6 @@ function openCardUpgradeSelection(onCloseCallback = null) {
   if (upgradeSelectionOpen) return;
   upgradeSelectionOpen = true;
   gamePaused = true;
-  stopStageProgress();
   dCardContainer.innerHTML = '';
   upgradeOverlay = createOverlay({ className: 'upgrade-selection-overlay' });
   upgradeOverlay.onClose(() => {
@@ -2129,7 +2000,6 @@ function openCardUpgradeSelection(onCloseCallback = null) {
     dCardContainer.innerHTML = '';
     renderDealerCard();
     gamePaused = false;
-    if (progressButtonActive) startStageProgress();
     onCloseCallback?.();
   });
 
@@ -2207,7 +2077,6 @@ function openCamp(onCloseCallback = null) {
   campOverlayOpen = true;
   redrawAllowed = true;
   gamePaused = true;
-  stopStageProgress();
   hidePlayerAttackBar();
   campOverlay = createOverlay({ className: 'camp-overlay' });
   campOverlay.onClose(() => {
@@ -2215,7 +2084,6 @@ function openCamp(onCloseCallback = null) {
     redrawAllowed = false;
     gamePaused = false;
     updateRedrawButton();
-    if (progressButtonActive) startStageProgress();
     onCloseCallback?.();
   });
 
@@ -2966,7 +2834,6 @@ if (currentEnemy) {
   updatePlayerStats(stats);
   cashTimer += deltaTime;
   worldProgressTimer += deltaTime;
-  sanityTimer += deltaTime;
   if (cashTimer >= 1000) {
     recordCashRates(cash);
     if (statsEconomyContainer && statsEconomyContainer.style.display !== 'none') {
@@ -2982,17 +2849,6 @@ if (currentEnemy) {
       worldProgressPerSecDisplay.textContent = `Avg World Progress/sec: ${rate.toFixed(2)}%`;
     }
     worldProgressTimer = 0;
-  }
-  if (sanityTimer >= 1000) {
-    sanityTimer = 0;
-    if (!campOverlayOpen) {
-      if (stats.sanity > 0) {
-        stats.sanity = Math.max(0, stats.sanity - 1);
-        updateSanityBar();
-      } else {
-        cDealerDamage(1);
-      }
-    }
   }
   if (currentEnemy) {
     playerAttackTimer += deltaTime;

--- a/style.css
+++ b/style.css
@@ -260,7 +260,7 @@ body {
     white-space: nowrap;
 }
 
-.insanity-orb {
+/*.insanity-orb {
     position: fixed;
     top: 50%;
     left: 10px;
@@ -273,7 +273,7 @@ body {
     animation: orbPulse var(--pulse-duration, 3s) infinite;
     pointer-events: auto;
     z-index: 1000;
-}
+}*/
 
 @keyframes orbPulse {
     0%, 100% {
@@ -284,23 +284,23 @@ body {
     }
 }
 
-.insanity-orb.critical {
+/*.insanity-orb.critical {
     background: radial-gradient(circle, #8b0000 0%, #300000 100%);
     box-shadow: 0 0 10px rgba(255, 0, 0, 0.8), 0 0 20px rgba(255, 0, 0, 0.6);
-}
+}*/
 
-body.insanity-low {
+/*body.insanity-low {
     filter: grayscale(0.4);
-}
+}*/
 
-body.insanity-low::after {
+/*body.insanity-low::after {
     content: '';
     position: fixed;
     inset: 0;
     pointer-events: none;
     background: radial-gradient(circle, rgba(0, 0, 0, 0) 60%, rgba(0, 0, 0, 0.6) 100%);
     z-index: 999;
-}
+}*/
 
 
 
@@ -408,14 +408,14 @@ body.insanity-low::after {
     display: block; /* prevent text from jumbling when progress bar appears */
 }
 
-#distanceDisplay {
+/*#distanceDisplay {
     align-self: flex-start;
     font-size: 0.8rem;
     color: #d4af37;
     text-shadow: 0 0 5px black;
     z-index: 1;
     display: block; /* ensure consistent vertical spacing */
-}
+}*/
 
 #chipsDisplay {
     align-self: flex-start;
@@ -1764,7 +1764,7 @@ body.insanity-low::after {
 }
 
 /* Stage traversal progress bar */
-.stage-progress {
+/*.stage-progress {
     width: 50%;
     height: 8px;
     background: #090b09;
@@ -1782,7 +1782,7 @@ body.insanity-low::after {
     height: 100%;
     width: 0;
     background: #2ecc71;
-}
+}*/
 
 .card-upgrades {
     margin-top: 6px;


### PR DESCRIPTION
## Summary
- remove sanity and distance features
- comment out associated UI elements and styles
- stop healing cards on level up
- dealers spawn continuously and stage progress UI is gone

## Testing
- `npm test` *(fails: mocha not found)*
- `npm run lint` *(fails: ESLint config not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858a37e3ac4832699d01192df1c7053