### PR TITLE
Implement camp on next stage and adjust attack speed

### DIFF
--- a/cardUpgrades.js
+++ b/cardUpgrades.js
@@ -187,7 +187,7 @@ export const upgrades = {
   autoAttackSpeed: {
     name: 'Auto-Attack Speed',
     level: 0,
-    baseValue: 5000,
+    baseValue: 10000,
     unlocked: false,
     unlockCondition: ({ stageData }) => stageData.stage >= 10,
     costFormula: level => Math.floor(300 * level ** 2),

--- a/index.html
+++ b/index.html
@@ -136,8 +136,8 @@
             </div>
           </div>
           <!--<button id="moveForwardBtn" title="Move Forward">➡️</button>-->
-          <button id="campBtn" style="display:none;" title="Find the Light"><i data-lucide="eye"></i></button>
           <button id="nextStageBtn" style="display:none;" disabled title="Next Stage">🚀</button>
+          <button id="campBtn" style="display:none;" title="Find the Light"><i data-lucide="eye"></i></button>
           <button id="fightBossBtn" style="display:none;" title="Fight Boss">👑</button>
         </div>
         <div class="handContainer casino-section"></div>

--- a/script.js
+++ b/script.js
@@ -123,7 +123,7 @@ const BASE_STATS = {
   upgradeDamageMultiplier: 1,
   cardSlots: 3,
   //at start max
-  attackSpeed: 5000,
+  attackSpeed: 10000,
   //ms between automatic attacks
   hpPerKill: 1,
   baseCardHpBoost: 0,
@@ -1086,7 +1086,10 @@ document.addEventListener("DOMContentLoaded", () => {
   checkUpgradeUnlocks();
 
   nextStageBtn.style.display = 'none';
-  nextStageBtn.addEventListener("click", nextStage);
+  nextStageBtn.addEventListener("click", () => {
+    nextStageBtn.style.display = 'none';
+    openCamp(nextStage);
+  });
   fightBossBtn.addEventListener("click", () => {
     fightBossBtn.style.display = "none";
     stageData.stage = 10;

--- a/simulation.js
+++ b/simulation.js
@@ -12,7 +12,7 @@ export class GameSimulator {
       hpPerKill: 1,
       baseCardHpBoost: 0,
       cardSlots: 3,
-      attackSpeed: 5000,
+      attackSpeed: 10000,
       stage: 1,
       cash: 500,
       xp: 0,

--- a/style.css
+++ b/style.css
@@ -853,6 +853,10 @@ body {
     overflow: hidden;
 }
 
+#nextStageBtn {
+    flex-basis: 100%;
+}
+
 /* auto attack progress bars */
 .playerAttackBar {
     width: 50%;

--- a/test/attackSpeedUpgrade.test.cjs
+++ b/test/attackSpeedUpgrade.test.cjs
@@ -2,11 +2,11 @@ const { expect } = require('chai');
 
 describe('⚙️ autoAttackSpeed Upgrade', () => {
   function setup() {
-    const stats = { attackSpeed: 5000 };
+    const stats = { attackSpeed: 10000 };
     const upgrades = {
       autoAttackSpeed: {
         level: 0,
-        baseValue: 5000,
+        baseValue: 10000,
         costFormula: level => Math.floor(300 * level ** 2),
         effect: player => {
           const lvl = upgrades.autoAttackSpeed.level;
@@ -27,15 +27,15 @@ describe('⚙️ autoAttackSpeed Upgrade', () => {
   it('reduces attack interval with each purchase', () => {
     const { stats, purchase } = setup();
     const expected = [
-      4500,
-      4000,
-      3500,
-      3000,
-      2750,
-      2500,
-      2250,
-      2000,
-      2000
+      9500,
+      9000,
+      8500,
+      8000,
+      7750,
+      7500,
+      7250,
+      7000,
+      6750
     ];
     expected.forEach(val => {
       purchase();


### PR DESCRIPTION
## Summary
- display the camp overlay when advancing to the next stage
- move the `next stage` button below the attack bar
- match player attack speed to enemies at 10 seconds
- update the auto-attack speed upgrade and tests

## Testing
- `PUPPETEER_SKIP_DOWNLOAD=1 npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859879317dc8326ad2f240fa7dc86e6