### PR TITLE
Fix upgrade selection after camp

### DIFF
--- a/script.js
+++ b/script.js
@@ -1088,7 +1088,7 @@ document.addEventListener("DOMContentLoaded", () => {
   nextStageBtn.style.display = 'none';
   nextStageBtn.addEventListener("click", () => {
     nextStageBtn.style.display = 'none';
-    openCamp(nextStage);
+    openCamp(() => openCardUpgradeSelection(nextStage));
   });
   fightBossBtn.addEventListener("click", () => {
     fightBossBtn.style.display = "none";


### PR DESCRIPTION
## Summary
- trigger card upgrade overlay when moving to the next stage via camping

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859c4063b388326b6b9d18e2411a2a7