### PR TITLE
Distribute XP across entire deck

### DIFF
--- a/script.js
+++ b/script.js
@@ -182,6 +182,8 @@ let stageData = {
 
 const STAGE_KILL_REQUIREMENT = 10;
 
+const xpEfficiency = 0.5;
+
 let speakerEncounterPending = false;
 
 // Weight a kill's contribution toward world completion based on the stage
@@ -1852,13 +1854,16 @@ function dealerBarDeathAnimation(callback) {
 //========deck functions===========
 
 function cardXp(xpAmount) {
-  drawnCards.forEach(card => {
+  pDeck.forEach(card => {
     if (!card) return;
 
-    const leveled = card.gainXp(xpAmount);
+    const amount = drawnCards.includes(card)
+      ? xpAmount
+      : xpAmount * xpEfficiency;
+    const leveled = card.gainXp(amount);
     if (leveled) {
       cardPoints += 1;
-      animateCardLevelUp(card);
+      if (card.wrapperElement) animateCardLevelUp(card);
       addDeckMasteryProgress(selectedDeck, 1);
       addLog(
         `${card.value}${card.symbol} leveled up to level ${card.currentLevel}!`,

--- a/test/deck.xp.test.cjs
+++ b/test/deck.xp.test.cjs
@@ -1,0 +1,22 @@
+const { expect } = require('chai');
+
+describe('📈 Deck XP distribution', () => {
+  it('awards xp to hand and deck cards with efficiency', async () => {
+    const { Card } = await import('../card.js');
+
+    const xpEfficiency = 0.5;
+    const xpAmount = 0.4;
+    const c1 = new Card('Hearts', 2);
+    const c2 = new Card('Spades', 3);
+    const drawnCards = [c1];
+    const pDeck = [c1, c2];
+
+    pDeck.forEach(card => {
+      const amt = drawnCards.includes(card) ? xpAmount : xpAmount * xpEfficiency;
+      card.gainXp(amt);
+    });
+
+    expect(c1.XpCurrent).to.equal(xpAmount);
+    expect(c2.XpCurrent).to.equal(xpAmount * xpEfficiency);
+  });
+});


### PR DESCRIPTION
## Summary
- add `xpEfficiency` constant for cards not in hand
- award XP to every card in the deck via new efficiency check
- test deck-wide XP distribution

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859cac7022083269d353fd7034ff770