### PR TITLE
Align XP scaling with docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,33 @@ Max HP	value * level * baseHPMultiplier	HP influenced by card value, level, and 
 Ability Power	Tied to attribute/stat	Determines potency of magical abilities
 XP Requirement	XpReq = value * (level^2)	Higher value cards require more XP to level up
 
+XP per Kill     0.389 * L^2 / (1 + 0.007*(L-1))  L = stage + 10*(world-1)
+
+### XP Calculation
+
+Cards level up by defeating enemies. Two formulas keep the pace near
+"one level per stage" for an average value card:
+
+1. **Requirement** for level `L`
+
+   `XpReq = value * (L^2)`
+
+   Low-value cards reach higher levels quickly, while face cards require
+   more grinding.
+
+2. **XP award** when an enemy from stage `s` and world `w` is defeated
+
+   ```
+   L = s + 10 * (w - 1)
+   XP = 0.389 * L^2 / (1 + 0.007 * (L - 1))
+   ```
+
+   `L` is the effective difficulty across worlds. Each new world adds 10
+   levels to the scale. The small epsilon term increases kills needed by
+   roughly one every few stages (e.g., stage 9 takes ~3m10s instead of 3m).
+
+Cards in the deck but not currently drawn gain only half of this XP.
+
 
 🧠 Attributes
 

--- a/card.js
+++ b/card.js
@@ -14,6 +14,8 @@ export const suitColors = {
 
 export const suits = ['Hearts', 'Spades', 'Diamonds', 'Clubs'];
 
+import { xpRequirement } from './utils/xp.js';
+
 const names = {
   1: 'Ace',
   11: 'Jack',
@@ -34,7 +36,7 @@ export class Card {
 
     this.currentLevel = 1;
     this.XpCurrent = 0;
-    this.XpReq = 1;
+    this.XpReq = xpRequirement(this.value, this.currentLevel);
 
     const baseMultiplier = 1 + (value - 1) / 12;
     this.baseDamage = 5 * baseMultiplier;
@@ -63,7 +65,7 @@ export class Card {
 
   levelUp() {
     this.currentLevel++;
-    this.XpReq += this.currentLevel * 1.7 * (this.value ** 2);
+    this.XpReq = xpRequirement(this.value, this.currentLevel);
     this.damage = this.baseDamage + 5 * (this.currentLevel - 1);
     const baseMultiplier = 1 + (this.value - 1) / 12;
     const prevHp = this.currentHp;

--- a/enemySpawning.js
+++ b/enemySpawning.js
@@ -1,6 +1,7 @@
 import Enemy from './enemy.js';
 import { Boss, BossTemplates } from './boss.js';
 import { AbilityRegistry } from './dealerabilities.js';
+import { calculateKillXp } from './utils/xp.js';
 
 export function calculateEnemyHp(stage, world, isBoss = false) {
   const baseHp = 10 + stage;
@@ -51,7 +52,7 @@ export function spawnBoss(stageData, enemyAttackProgress, onAttack, onDefeat) {
     name: template.name,
     icon: template.icon,
     iconColor: template.iconColor,
-    xp: Math.pow(stage, 1.5) * world,
+    xp: calculateKillXp(stage, world),
     abilities,
     rarity: 'legendary',
     onAttack,

--- a/script.js
+++ b/script.js
@@ -28,6 +28,7 @@ import { runAnimation } from "./utils/animation.js";
 import { initCore, refreshCore } from './core.js';
 import { createOverlay } from './ui/overlay.js';
 import { showRestartScreen } from './ui/restartOverlay.js';
+import { calculateKillXp, XP_EFFICIENCY } from './utils/xp.js';
 import {
   rollNewCardUpgrades,
   applyCardUpgrade,
@@ -182,7 +183,7 @@ let stageData = {
 
 const STAGE_KILL_REQUIREMENT = 10;
 
-const xpEfficiency = 0.5;
+const xpEfficiency = XP_EFFICIENCY;
 
 let speakerEncounterPending = false;
 
@@ -1654,7 +1655,7 @@ function respawnDealerStage() {
 function onDealerDefeat() {
   // capture remaining attack progress before resetting
   enemyAttackProgress = currentEnemy.attackTimer / currentEnemy.attackInterval;
-  cardXp(stageData.stage ** 1.5 * stageData.world);
+  cardXp(calculateKillXp(stageData.stage, stageData.world));
   chips += computeChipReward();
   updateChipsDisplay();
   healCardsOnKill();
@@ -1672,7 +1673,7 @@ function onDealerDefeat() {
       hidePlayerAttackBar();
       respawnDealerStage();
     });
-} // need to define xp formula
+}
 
 function onSpeakerDefeat() {
   playerStats.speakerEncounters += 1;

--- a/test/advanced.simulation.test.cjs
+++ b/test/advanced.simulation.test.cjs
@@ -171,6 +171,7 @@ describe('🧪 General Simulation Test Templates', () => {
   it('Boss defeat grants card XP', async () => {
     const { Card } = await import('../card.js');
     const { Boss } = await import('../boss.js');
+    const { calculateKillXp } = await import('../utils/xp.js');
 
     const card = new Card('Hearts', 2);
     const drawn = [card];
@@ -178,7 +179,7 @@ describe('🧪 General Simulation Test Templates', () => {
 
     const boss = new Boss(5, 1, {
       maxHp: 1,
-      xp: Math.pow(5, 1.5) * 1,
+      xp: calculateKillXp(5, 1),
       onDefeat: b => cardXp(b.xp)
     });
 

--- a/test/xp.progression.test.cjs
+++ b/test/xp.progression.test.cjs
@@ -1,0 +1,17 @@
+const { expect } = require('chai');
+
+describe('📊 XP progression', () => {
+  it('levels match stage after ~18 kills each stage', async () => {
+    const { Card } = await import('../card.js');
+    const { calculateKillXp } = await import('../utils/xp.js');
+
+    const card = new Card('Hearts', 7); // average value
+    for (let stage = 1; stage <= 5; stage++) {
+      for (let i = 0; i < 18; i++) {
+        card.gainXp(calculateKillXp(stage, 1));
+      }
+      expect(card.currentLevel).to.be.at.least(stage);
+    }
+    expect(card.currentLevel).to.equal(5);
+  });
+});

--- a/utils/xp.js
+++ b/utils/xp.js
@@ -1,0 +1,17 @@
+// Constants tuned so an average card levels roughly once every 18 kills
+export const XP_KILL_BASE = 0.389;
+export const XP_KILL_EPSILON = 0.007;
+export const XP_EFFICIENCY = 0.5; // deck cards gain half XP when not drawn
+
+export function xpRequirement(value, level) {
+  return value * (level ** 2);
+}
+
+export function effectiveLevel(stage, world) {
+  return stage + 10 * (world - 1);
+}
+
+export function calculateKillXp(stage, world) {
+  const level = effectiveLevel(stage, world);
+  return XP_KILL_BASE * (level ** 2) / (1 + XP_KILL_EPSILON * (level - 1));
+}


### PR DESCRIPTION
## Summary
- sync card XP requirement with README
- scale enemy XP with new formula and expose calculateKillXp helper
- document XP per kill formula
- add regression test for level progression
- move xp constants to utils

## Testing
- `npm test --silent`
- `npx mocha test/advanced.simulation.test.cjs --reporter dot`


------
https://chatgpt.com/codex/tasks/task_e_6859d746ae608326b3c7aa9874096848