### PR TITLE
Implement blood splatter overlay

### DIFF
--- a/rendering.js
+++ b/rendering.js
@@ -70,3 +70,47 @@ export function renderDiscardCard(card, discardContainer, backImages) {
   discardContainer.appendChild(img);
   card.discardElement = img;
 }
+
+function drawBloodSplat(canvas) {
+  const ctx = canvas.getContext('2d');
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  for (let i = 0; i < 6; i++) {
+    const r = Math.random() * 10 + 5;
+    const x = Math.random() * canvas.width;
+    const y = Math.random() * canvas.height;
+    ctx.beginPath();
+    ctx.fillStyle = `rgba(150,0,0,${0.5 + Math.random() * 0.5})`;
+    ctx.arc(x, y, r, 0, Math.PI * 2);
+    ctx.fill();
+  }
+}
+
+export function applyBloodSplat(card) {
+  if (!card.cardElement) return;
+  if (card.bloodSplatEl) return;
+  const rect = card.cardElement.getBoundingClientRect();
+  const canvas = document.createElement('canvas');
+  canvas.classList.add('blood-splat');
+  canvas.width = rect.width;
+  canvas.height = rect.height;
+  drawBloodSplat(canvas);
+  card.cardElement.appendChild(canvas);
+  card.bloodSplatEl = canvas;
+}
+
+export function removeBloodSplat(card) {
+  if (card.bloodSplatEl) {
+    card.bloodSplatEl.remove();
+    card.bloodSplatEl = null;
+  }
+}
+
+export function updateBloodSplat(card) {
+  if (!card) return;
+  const ratio = card.maxHp > 0 ? card.currentHp / card.maxHp : 0;
+  if (ratio <= 0.1) {
+    applyBloodSplat(card);
+  } else {
+    removeBloodSplat(card);
+  }
+}

--- a/script.js
+++ b/script.js
@@ -55,7 +55,10 @@ import {
   renderDealerLifeBar,
   renderEnemyAttackBar,
   renderPlayerAttackBar,
-  renderDealerLifeBarFill
+  renderDealerLifeBarFill,
+  applyBloodSplat,
+  removeBloodSplat,
+  updateBloodSplat
 } from "./rendering.js";
 import { drawCard, redrawHand } from "./cardManagement.js";
 import {
@@ -1617,6 +1620,7 @@ function cDealerDamage(damageAmount = null, ability = null, source = "dealer") {
     // Show actual damage dealt after shield reduction
     showDamageFloat(card, finalDamage);
   }
+  updateBloodSplat(card);
   // if it’s dead, remove it
   if (card.currentHp === 0) {
     // immediately remove from data so new draws don't shift the wrong card
@@ -1624,6 +1628,7 @@ function cDealerDamage(damageAmount = null, ability = null, source = "dealer") {
 
     animateCardDeath(card, () => {
       // 1) from the DOM
+      removeBloodSplat(card);
       card.wrapperElement?.remove();
 
       discardCard(card);
@@ -1725,6 +1730,7 @@ function updateHandDisplay() {
     card.hpDisplay.textContent = `HP: ${formatNumber(Math.round(card.currentHp))}/${formatNumber(Math.round(card.maxHp))}`;
     card.xpLabel.textContent = `LV: ${card.currentLevel}`;
     card.xpBarFill.style.width = `${(card.XpCurrent / card.XpReq) * 100}%`;
+    updateBloodSplat(card);
   });
 }
 
@@ -2011,6 +2017,8 @@ function drawSpeakerIcon(canvas) {
 }
 
 
+
+
 // Visual pulse when a card gains health
 function animateCardHeal(card) {
   const w = card.wrapperElement;
@@ -2131,6 +2139,7 @@ function useJoker(joker) {
         card.currentHp = Math.round(Math.min(card.maxHp, card.currentHp + healAmt));
         card.hpDisplay.textContent = `HP: ${formatNumber(Math.round(card.currentHp))}/${formatNumber(Math.round(card.maxHp))}`;
         animateCardHeal(card);
+        updateBloodSplat(card);
       });
       addLog(`Healed ${healAmt} HP`,
         "heal");

--- a/style.css
+++ b/style.css
@@ -1039,6 +1039,15 @@ body {
         transform 0.2s ease,
         box-shadow 0.2s ease;
 }
+
+.card .blood-splat {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+}
 .card-wrapper:hover {
     transform: scale(1.05);
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);


### PR DESCRIPTION
## Summary
- add blood splatter canvas effect
- display splatter when cards fall below 10% HP
- remove overlay once healed
- centralize splatter effect code in `rendering.js`

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859f72e00bc8326a03129ca84661672