### PR TITLE
Fix HP scaling and damage float

### DIFF
--- a/card.js
+++ b/card.js
@@ -52,18 +52,18 @@ export class Card {
     this.traits = [];
   }
 
-  gainXp(amount) {
+  gainXp(amount, stats, barUpgrades) {
     this.XpCurrent += amount;
     let leveled = false;
     while (this.XpCurrent >= this.XpReq) {
       this.XpCurrent -= this.XpReq;
-      this.levelUp();
+      this.levelUp(stats, barUpgrades);
       leveled = true;
     }
     return leveled;
   }
 
-  levelUp() {
+  levelUp(stats, barUpgrades) {
     this.currentLevel++;
     this.XpReq = xpRequirement(this.value, this.currentLevel);
     this.damage = this.baseDamage + 5 * (this.currentLevel - 1);
@@ -71,11 +71,14 @@ export class Card {
     const prevHp = this.currentHp;
     this.maxHp = Math.round(5 * baseMultiplier + 5 * (this.currentLevel - 1) + this.baseHpBoost);
     this.currentHp = Math.min(this.maxHp, prevHp);
+    if (stats || barUpgrades) {
+      this.recalcHp(stats, barUpgrades);
+    }
   }
 
   healFromKill() {
     const healed = Math.min(this.maxHp, this.currentHp + this.hpPerKill);
-    this.currentHp = Math.round(healed);
+    this.currentHp = healed;
   }
 
   upgradeHpPerKill(amount = 1) {

--- a/script.js
+++ b/script.js
@@ -1170,7 +1170,7 @@ function showDamageFloat(card, amount) {
   dmg.addEventListener("animationend", () => dmg.remove(), {
     once: true
   });
-  setTimeout(() => dmg.remove(), 1000);
+  setTimeout(() => dmg.remove(), 1200);
 }
 
 //=========stage functions===========
@@ -1682,7 +1682,7 @@ function cardXp(xpAmount) {
     const amount = drawnCards.includes(card)
       ? xpAmount
       : xpAmount * xpEfficiency;
-    const leveled = card.gainXp(amount);
+    const leveled = card.gainXp(amount, stats, barUpgrades);
     if (leveled) {
       cardPoints += 1;
       if (card.wrapperElement) animateCardLevelUp(card);

--- a/style.css
+++ b/style.css
@@ -1026,6 +1026,7 @@ body {
 }
 
 .card-hp {
+    position: relative;
     align-self: flex-end;
     margin-right: 4px;
     margin-bottom: 2px;
@@ -1454,7 +1455,7 @@ body {
     font-weight: bold;
     pointer-events: none;
     text-shadow: 0 0 2px #000;
-    animation: damage-float 1s ease-out forwards;
+    animation: damage-float 1.2s ease-out forwards;
 }
 
 @keyframes damage-float {
@@ -1464,7 +1465,7 @@ body {
     }
     to {
         opacity: 0;
-        transform: translate(-50%, -20px);
+        transform: translate(-50%, -24px);
     }
 }
 


### PR DESCRIPTION
## Summary
- adjust HP scaling when cards level up
- avoid rounding HP gain per kill
- show damage text at the card HP location
- make floating damage animation last slightly longer

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a22154e0083269a9ba46a3070de12