### PR TITLE
Tune XP curve and expand progression tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Max HP	value * level * baseHPMultiplier	HP influenced by card value, level, and 
 Ability Power	Tied to attribute/stat	Determines potency of magical abilities
 XP Requirement	XpReq = value * (level^2)	Higher value cards require more XP to level up
 
-XP per Kill     0.389 * L^2 / (1 + 0.007*(L-1))  L = stage + 10*(world-1)
+XP per Kill     (7/18) * L^2 / (1 + 0.007*(L-1))  L = stage + 10*(world-1)
 
 ### XP Calculation
 
@@ -151,7 +151,7 @@ Cards level up by defeating enemies. Two formulas keep the pace near
 
    ```
    L = s + 10 * (w - 1)
-   XP = 0.389 * L^2 / (1 + 0.007 * (L - 1))
+   XP = (7/18) * L^2 / (1 + 0.007 * (L - 1))
    ```
 
    `L` is the effective difficulty across worlds. Each new world adds 10

--- a/test/xp.progression.test.cjs
+++ b/test/xp.progression.test.cjs
@@ -14,4 +14,42 @@ describe('📊 XP progression', () => {
     }
     expect(card.currentLevel).to.equal(5);
   });
+
+  it('world two continues the one-level pace', async () => {
+    const { Card } = await import('../card.js');
+    const { calculateKillXp, xpRequirement } = await import('../utils/xp.js');
+
+    const card = new Card('Spades', 7);
+    card.currentLevel = 10;
+    card.XpCurrent = 0;
+    card.XpReq = xpRequirement(card.value, card.currentLevel);
+
+    for (let stage = 1; stage <= 5; stage++) {
+      for (let i = 0; i < 18; i++) {
+        card.gainXp(calculateKillXp(stage, 2));
+      }
+      expect(card.currentLevel).to.be.at.least(10 + stage);
+    }
+    expect(card.currentLevel).to.equal(15);
+  });
+
+  it('higher worlds do not drastically slow progression', async () => {
+    const { Card } = await import('../card.js');
+    const { calculateKillXp, xpRequirement } = await import('../utils/xp.js');
+
+    const card = new Card('Clubs', 7);
+    card.currentLevel = 20;
+    card.XpCurrent = 0;
+    card.XpReq = xpRequirement(card.value, card.currentLevel);
+
+    for (let stage = 1; stage <= 5; stage++) {
+      for (let i = 0; i < 18; i++) {
+        card.gainXp(calculateKillXp(stage, 3));
+      }
+      // First stage may fall short of a level due to epsilon scaling
+      const expected = 20 + Math.max(0, stage - 1);
+      expect(card.currentLevel).to.be.at.least(expected);
+    }
+    expect(card.currentLevel).to.equal(24);
+  });
 });

--- a/utils/xp.js
+++ b/utils/xp.js
@@ -1,5 +1,6 @@
 // Constants tuned so an average card levels roughly once every 18 kills
-export const XP_KILL_BASE = 0.389;
+// Using 7/18 keeps stage-one progression exact
+export const XP_KILL_BASE = 7 / 18;
 export const XP_KILL_EPSILON = 0.007;
 export const XP_EFFICIENCY = 0.5; // deck cards gain half XP when not drawn
 


### PR DESCRIPTION
## Summary
- adjust XP_KILL_BASE constant to use the exact `7/18` ratio
- document updated XP formula in README
- add world scaling tests to `xp.progression.test.cjs`

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ac989d4688326abab9831bdf822d7