### PR TITLE
Fix hp heal per kill & restore damage float

### DIFF
--- a/card.js
+++ b/card.js
@@ -76,8 +76,8 @@ export class Card {
     }
   }
 
-  healFromKill() {
-    const healed = Math.min(this.maxHp, this.currentHp + this.hpPerKill);
+  healFromKill(amount = this.hpPerKill) {
+    const healed = Math.min(this.maxHp, this.currentHp + amount);
     this.currentHp = healed;
   }
 

--- a/script.js
+++ b/script.js
@@ -2061,7 +2061,7 @@ function animateCardDeath(card, callback) {
 function healCardsOnKill() {
   drawnCards.forEach(card => {
     if (!card) return;
-    card.healFromKill();
+    card.healFromKill(stats.hpPerKill);
   });
   updateHandDisplay();
   updateDeckDisplay();

--- a/style.css
+++ b/style.css
@@ -1026,7 +1026,6 @@ body {
 }
 
 .card-hp {
-    position: relative;
     align-self: flex-end;
     margin-right: 4px;
     margin-bottom: 2px;
@@ -1454,6 +1453,7 @@ body {
     color: red;
     font-weight: bold;
     pointer-events: none;
+    z-index: 1;
     text-shadow: 0 0 2px #000;
     animation: damage-float 1.2s ease-out forwards;
 }


### PR DESCRIPTION
## Summary
- fix HP heal from kills by passing stats value directly
- ensure damage float renders by removing relative positioning on `.card-hp` and raising float z-index

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685acab2715c8326b595cd6ae51d1d38