### PR TITLE
Adjust enemy and boss difficulty

### DIFF
--- a/dealerabilities.js
+++ b/dealerabilities.js
@@ -5,15 +5,15 @@ export const AbilityRegistry = {
       const ability = {
         name: "Heal",
         icon: "cross",
-        cooldown: 3000,
+        cooldown: 5000,
         timer: 0,
         colorClass: "green",
-        maxTimer: 3000,
+        maxTimer: 5000,
 
         tick(deltaTime, enemy) {
           this.timer += deltaTime;
           if (this.timer >= this.cooldown) {
-            const healAmount = Math.floor(enemy.maxHp * 0.2);
+            const healAmount = Math.floor(enemy.maxHp * 0.1);
             enemy.currentHp = Math.min(enemy.currentHp + healAmount, enemy.maxHp);
             this.timer = 0;
           }

--- a/enemySpawning.js
+++ b/enemySpawning.js
@@ -43,7 +43,7 @@ export function calculateRelativeEnemyStats(stage, world, opts = {}) {
   const expectedHp = expectedStat * hp;
   return {
     hp: Math.round(expectedDamage * 3),
-    damage: Math.round(expectedHp / 3)
+    damage: Math.round(expectedHp / 5)
   };
 }
 
@@ -105,6 +105,9 @@ export function spawnBoss(stageData, enemyAttackProgress, onAttack, onDefeat) {
   assignEnemyStats(boss, stage, world);
   boss.maxHp *= 5;
   boss.currentHp = boss.maxHp;
+  boss.minDamage = Math.max(1, Math.floor(boss.minDamage / 2));
+  boss.maxDamage = Math.max(1, Math.floor(boss.maxDamage / 2));
+  boss.damage = Math.max(1, Math.floor(boss.damage / 2));
   boss.attackTimer = boss.attackInterval * enemyAttackProgress;
   return boss;
 }

--- a/test/enemy.scaling.test.cjs
+++ b/test/enemy.scaling.test.cjs
@@ -33,14 +33,14 @@ describe('🧮 Enemy Scaling Functions', () => {
 
   describe('calculateEnemyBasicDamage', () => {
     const cases = [
-      { stage: 1, world: 1, min: 2, max: 3 },
-      { stage: 1, world: 2, min: 20, max: 38 },
-      { stage: 5, world: 1, min: 5, max: 9 },
-      { stage: 5, world: 2, min: 27, max: 52 },
-      { stage: 10, world: 1, min: 10, max: 18 },
-      { stage: 10, world: 2, min: 35, max: 68 },
-      { stage: 15, world: 1, min: 14, max: 26 },
-      { stage: 15, world: 2, min: 43, max: 85 }
+      { stage: 1, world: 1, min: 2, max: 2 },
+      { stage: 1, world: 2, min: 12, max: 23 },
+      { stage: 5, world: 1, min: 4, max: 6 },
+      { stage: 5, world: 2, min: 16, max: 31 },
+      { stage: 10, world: 1, min: 6, max: 11 },
+      { stage: 10, world: 2, min: 21, max: 41 },
+      { stage: 15, world: 1, min: 9, max: 16 },
+      { stage: 15, world: 2, min: 26, max: 51 }
     ];
 
     cases.forEach(({ stage, world, min, max }) => {
@@ -53,9 +53,9 @@ describe('🧮 Enemy Scaling Functions', () => {
 
   describe('calculateRelativeEnemyStats', () => {
     const cases = [
-      { stage: 1, world: 1, hp: 23, dmg: 3 },
-      { stage: 5, world: 1, hp: 83, dmg: 9 },
-      { stage: 1, world: 2, hp: 345, dmg: 38 }
+      { stage: 1, world: 1, hp: 23, dmg: 2 },
+      { stage: 5, world: 1, hp: 83, dmg: 6 },
+      { stage: 1, world: 2, hp: 345, dmg: 23 }
     ];
     cases.forEach(({ stage, world, hp, dmg }) => {
       it(`stage ${stage} world ${world} => hp ${hp} dmg ${dmg}`, () => {
@@ -80,8 +80,8 @@ describe('🧮 Enemy Scaling Functions', () => {
         maxHp: 23,
         currentHp: 23,
         minDamage: 2,
-        maxDamage: 3,
-        damage: 3
+        maxDamage: 2,
+        damage: 2
       });
     });
   });


### PR DESCRIPTION
## Summary
- scale enemy damage based on 1/5 of card HP
- nerf boss damage and healing
- update unit tests accordingly

## Testing
- `npm test --silent` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_685acf18f7dc83269891f39479f13f48