### PR TITLE
Add progress effects to stage and boss buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -136,9 +136,21 @@
             </div>
           </div>
           <!--<button id="moveForwardBtn" title="Move Forward">➡️</button>-->
-          <button id="nextStageBtn" style="display:none;" disabled title="Next Stage">🚀</button>
+          <div class="progress-wrapper">
+            <svg class="progress-ring" width="48" height="48">
+              <circle class="progress-ring-bg" cx="24" cy="24" r="22" />
+              <circle id="nextStageProgress" class="progress-ring-fill" cx="24" cy="24" r="22" />
+            </svg>
+            <button id="nextStageBtn" style="display:none;" disabled title="Next Stage">🚀</button>
+          </div>
           <button id="campBtn" style="display:none;" title="Find the Light"><i data-lucide="eye"></i></button>
-          <button id="fightBossBtn" style="display:none;" title="Fight Boss">👑</button>
+          <div class="progress-wrapper boss-progress">
+            <svg class="progress-ring" width="48" height="48">
+              <circle class="progress-ring-bg" cx="24" cy="24" r="22" />
+              <circle id="bossProgress" class="progress-ring-fill boss" cx="24" cy="24" r="22" />
+            </svg>
+            <button id="fightBossBtn" style="display:none;" title="Fight Boss">💀</button>
+          </div>
         </div>
         <div class="handContainer casino-section"></div>
         <div class="jokerContainer casino-section"></div>

--- a/script.js
+++ b/script.js
@@ -185,6 +185,7 @@ let stageData = {
 };
 
 const STAGE_KILL_REQUIREMENT = 10;
+const PROGRESS_CIRCUMFERENCE = 2 * Math.PI * 22;
 
 const xpEfficiency = XP_EFFICIENCY;
 
@@ -291,8 +292,10 @@ function getCardState() {
 }
 
 const nextStageBtn = document.getElementById("nextStageBtn");
+const nextStageProgress = document.getElementById("nextStageProgress");
 //const moveForwardBtn = document.getElementById("moveForwardBtn");
 const fightBossBtn = document.getElementById("fightBossBtn");
+const bossProgress = document.getElementById("bossProgress");
 const campBtn = document.getElementById("campBtn");
 const pointsDisplay = document.getElementById("pointsDisplay");
 const cashDisplay = document.getElementById("cashDisplay");
@@ -994,6 +997,7 @@ function renderStageInfo() {
   stageDisplay.textContent = `Stage ${stageData.stage} World ${stageData.world} (Lv ${lvl})`;
   killsDisplay.textContent = `Kills: ${formatNumber(stageData.kills)}`;
   updateNextStageAvailability();
+  updateBossProgress();
 }
 
 function renderPlayerStats(stats) {
@@ -1165,6 +1169,7 @@ function recordWorldKill(world, stage) {
   if (data.progress >= data.progressTarget && !data.bossDefeated) return;
   data.progress += stageWeight(stage);
   updateWorldProgressUI(world);
+  if (world === stageData.world) updateBossProgress();
   if (world === stageData.world) {
     worldProgressRateTracker.record(computeWorldProgress(world) * 100);
   }
@@ -1188,6 +1193,7 @@ function updateWorldProgressUI(id) {
     `.world-progress[data-world="${id}"] .world-progress-fill`
   );
   if (fill) fill.style.width = `${pct}%`;
+  if (id == stageData.world) updateBossProgress();
   const textEl = document.querySelector(
     `.world-progress-text[data-world="${id}"]`
   );
@@ -1291,6 +1297,7 @@ function nextStage() {
   const isBossStage = stageData.stage % 10 === 0;
   resetStageCashStats();
   killsDisplay.textContent = `Kills: ${formatNumber(stageData.kills)}`;
+  updateNextStageProgress();
   updateNextStageAvailability();
   renderGlobalStats();
   renderStageInfo();
@@ -1325,6 +1332,8 @@ function nextWorld() {
     worldProgressPerSecDisplay.textContent = "Avg World Progress/sec: 0%";
   }
   killsDisplay.textContent = `Kills: ${formatNumber(stageData.kills)}`;
+  updateNextStageProgress();
+  updateBossProgress();
   updateNextStageAvailability();
   renderGlobalStats();
   renderStageInfo();
@@ -1354,6 +1363,8 @@ function goToWorld(id) {
     worldProgressPerSecDisplay.textContent = "Avg World Progress/sec: 0%";
   }
   killsDisplay.textContent = `Kills: ${formatNumber(stageData.kills)}`;
+  updateNextStageProgress();
+  updateBossProgress();
   renderGlobalStats();
   renderStageInfo();
   checkUpgradeUnlocks();
@@ -1381,6 +1392,22 @@ function updateNextStageAvailability() {
     nextStageBtn.disabled = true;
     nextStageBtn.style.display = 'none';
   }
+  updateNextStageProgress();
+}
+
+function setProgress(circle, ratio) {
+  if (!circle) return;
+  const clamped = Math.max(0, Math.min(1, ratio));
+  const offset = PROGRESS_CIRCUMFERENCE * (1 - clamped);
+  circle.style.strokeDashoffset = offset;
+}
+
+function updateNextStageProgress() {
+  setProgress(nextStageProgress, stageData.kills / STAGE_KILL_REQUIREMENT);
+}
+
+function updateBossProgress() {
+  setProgress(bossProgress, computeWorldProgress(stageData.world));
 }
 
 // Enable the next stage button when kill requirements met

--- a/style.css
+++ b/style.css
@@ -818,7 +818,8 @@ body {
     align-items: center;
 }
 
-.buttonsContainer > button {
+.buttonsContainer > button,
+.progress-wrapper > button {
     display: flex; /* turn the button into a flex container */
     align-items: center; /* vertically center icon */
     justify-content: center; /* horizontally center content */
@@ -855,6 +856,51 @@ body {
 
 #nextStageBtn {
     flex-basis: 100%;
+}
+
+.progress-wrapper {
+    position: relative;
+    width: 48px;
+    height: 48px;
+    margin: 0 6px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.progress-wrapper > button {
+    position: relative;
+    z-index: 1;
+}
+
+.progress-ring {
+    position: absolute;
+    top: 0;
+    left: 0;
+    transform: rotate(-90deg);
+    pointer-events: none;
+}
+
+.progress-ring-bg,
+.progress-ring-fill {
+    fill: none;
+    stroke-width: 4;
+}
+
+.progress-ring-bg {
+    stroke: rgba(120, 120, 130, 0.3);
+}
+
+.progress-ring-fill {
+    stroke: #6b5b95;
+    stroke-dasharray: 138;
+    stroke-dashoffset: 138;
+    stroke-linecap: round;
+    transition: stroke-dashoffset 0.3s ease;
+}
+
+.progress-wrapper.boss-progress .progress-ring-fill {
+    stroke: #8b0000;
 }
 
 /* auto attack progress bars */
@@ -903,7 +949,8 @@ body {
     background: #ffd700; /* brighter gold for clarity */
 }
 
-.buttonsContainer > button:hover {
+.buttonsContainer > button:hover,
+.progress-wrapper > button:hover {
     transform: translateY(-2px);
     box-shadow: 0 4px 12px rgba(0, 128, 0, 0.6);
     background: linear-gradient(135deg, #fafafa, #f0f0f0);


### PR DESCRIPTION
## Summary
- show progress rings around Next Stage and Fight Boss buttons
- update progress rings based on kills and world progress

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b190b573c832689032df7482f6934