### PR TITLE
Fix upgrade panel crash when life upgrades present

### DIFF
--- a/script.js
+++ b/script.js
@@ -660,6 +660,7 @@ function updateUpgradeButtons() {
     const btn = row.querySelector("button");
     if (!key || !btn) return;
     const up = upgrades[key];
+    if (!up || typeof up.costFormula !== 'function') return;
     const cost = up.costFormula(up.level + 1);
     const affordable = cash >= cost;
     btn.disabled = !affordable;


### PR DESCRIPTION
## Summary
- skip non-combat upgrades when updating upgrade button states

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685b223569608326be0f026927ae1c75