### PR TITLE
Remove next stage button and revamp canvas buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -136,20 +136,21 @@
             </div>
           </div>
           <!--<button id="moveForwardBtn" title="Move Forward">➡️</button>-->
-          <div class="progress-wrapper">
-            <svg class="progress-ring" width="48" height="48">
-              <circle class="progress-ring-bg" cx="24" cy="24" r="22" />
-              <circle id="nextStageProgress" class="progress-ring-fill" cx="24" cy="24" r="22" />
-            </svg>
-            <button id="nextStageBtn" style="display:none;" disabled title="Next Stage">🚀</button>
-          </div>
-          <button id="campBtn" style="display:none;" title="Find the Light"><i data-lucide="eye"></i></button>
-          <div class="progress-wrapper boss-progress">
-            <svg class="progress-ring" width="48" height="48">
-              <circle class="progress-ring-bg" cx="24" cy="24" r="22" />
-              <circle id="bossProgress" class="progress-ring-fill boss" cx="24" cy="24" r="22" />
-            </svg>
-            <button id="fightBossBtn" style="display:none;" title="Fight Boss">💀</button>
+          <div class="canvasButtonsRow">
+            <div class="progress-wrapper">
+              <svg class="progress-ring" width="48" height="48">
+                <circle class="progress-ring-bg" cx="24" cy="24" r="22" />
+                <circle id="nextStageProgress" class="progress-ring-fill" cx="24" cy="24" r="22" />
+              </svg>
+            </div>
+            <button id="campBtn" style="display:none;" title="Find the Light"><i data-lucide="eye"></i></button>
+            <div class="progress-wrapper boss-progress">
+              <svg class="progress-ring" width="48" height="48">
+                <circle class="progress-ring-bg" cx="24" cy="24" r="22" />
+                <circle id="bossProgress" class="progress-ring-fill boss" cx="24" cy="24" r="22" />
+              </svg>
+              <button id="fightBossBtn" style="display:none;" title="Fight Boss">💀</button>
+            </div>
           </div>
         </div>
         <div class="handContainer casino-section"></div>

--- a/script.js
+++ b/script.js
@@ -947,11 +947,13 @@ document.addEventListener("DOMContentLoaded", () => {
   shuffleArray(deck);
   checkUpgradeUnlocks();
 
-  nextStageBtn.style.display = 'none';
-  nextStageBtn.addEventListener("click", () => {
+  if (nextStageBtn) {
     nextStageBtn.style.display = 'none';
-    openCamp(() => openCardUpgradeSelection(nextStage));
-  });
+    nextStageBtn.addEventListener("click", () => {
+      nextStageBtn.style.display = 'none';
+      openCamp(() => openCardUpgradeSelection(nextStage));
+    });
+  }
   fightBossBtn.addEventListener("click", () => {
     fightBossBtn.style.display = "none";
     spawnBossEvent();
@@ -1326,7 +1328,7 @@ function nextStage() {
   inCombat = false;
   currentEnemy = null;
   redrawAllowed = false;
-  nextStageBtn.style.display = 'none';
+  if (nextStageBtn) nextStageBtn.style.display = 'none';
   if (isBossStage) {
     respawnDealerStage();
   } else {
@@ -1361,7 +1363,7 @@ function nextWorld() {
   inCombat = false;
   currentEnemy = null;
   redrawAllowed = false;
-  nextStageBtn.style.display = 'none';
+  if (nextStageBtn) nextStageBtn.style.display = 'none';
   respawnDealerStage();
 }
 
@@ -1390,7 +1392,7 @@ function goToWorld(id) {
   inCombat = false;
   currentEnemy = null;
   redrawAllowed = false;
-  nextStageBtn.style.display = 'none';
+  if (nextStageBtn) nextStageBtn.style.display = 'none';
   renderWorldsMenu();
   updateWorldTabNotification();
   respawnDealerStage();
@@ -1403,6 +1405,7 @@ function resetStageCashStats() {
 }
 
 function updateNextStageAvailability() {
+  if (!nextStageBtn) return;
   if (stageData.kills >= STAGE_KILL_REQUIREMENT) {
     nextStageBtn.disabled = false;
     nextStageBtn.style.display = 'inline-block';

--- a/style.css
+++ b/style.css
@@ -818,6 +818,13 @@ body {
     align-items: center;
 }
 
+.canvasButtonsRow {
+    display: flex;
+    gap: 5px;
+    width: 100%;
+    justify-content: center;
+}
+
 .buttonsContainer > button,
 .progress-wrapper > button {
     display: flex; /* turn the button into a flex container */
@@ -829,10 +836,10 @@ body {
     padding: 0;
 
     color: #080707; /* no quotes here */
-    background: linear-gradient(135deg, #f0f0f0, #fafafa);
-    border: 2px solid #4caf50;
+    background: linear-gradient(135deg, #fff2b0, #fff8d0);
+    border: 2px solid #d4af37;
     border-radius: 6px;
-    box-shadow: 0 2px 6px rgba(0, 128, 0, 0.4);
+    box-shadow: 0 2px 6px rgba(212, 175, 55, 0.4);
 
     font-size: 1.2rem;
     cursor: pointer;
@@ -854,9 +861,6 @@ body {
     overflow: hidden;
 }
 
-#nextStageBtn {
-    flex-basis: 100%;
-}
 
 .progress-wrapper {
     position: relative;
@@ -952,8 +956,8 @@ body {
 .buttonsContainer > button:hover,
 .progress-wrapper > button:hover {
     transform: translateY(-2px);
-    box-shadow: 0 4px 12px rgba(0, 128, 0, 0.6);
-    background: linear-gradient(135deg, #fafafa, #f0f0f0);
+    box-shadow: 0 4px 12px rgba(212, 175, 55, 0.6);
+    background: linear-gradient(135deg, #fff8d0, #fff2b0);
 }
 
 


### PR DESCRIPTION
## Summary
- remove the `Next Stage` button from the main UI
- wrap stage actions in new `.canvasButtonsRow`
- add golden flair styling to canvas buttons
- ensure JS checks for missing `nextStageBtn`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b270c3b5083269d721529719a8124