### PR TITLE
Add speech resource system with upgrades

### DIFF
--- a/index.html
+++ b/index.html
@@ -199,6 +199,9 @@
     <div class="playerTab">
       <div class="playerSidePanel casino-section">
         <button class="playerCoreSubTabButton active">Core</button>
+        <div id="speechGains" class="speech-gains"></div>
+        <div id="secondaryResources" class="secondary-resources"></div>
+        <div id="speechUpgrades" class="speech-upgrades"></div>
       </div>
       <div class="playerMainContainer">
         <div class="player-core-panel">

--- a/script.js
+++ b/script.js
@@ -20,7 +20,7 @@ import {
 import {
   initStarChart
 } from "./starChart.js"; // optional star chart tab
-import { initSpeech } from "./speech.js";
+import { initSpeech, tickSpeech } from "./speech.js";
 import { Jobs, assignJob, getAvailableJobs, renderJobAssignments, renderJobCarousel } from "./jobs.js"; // job definitions
 import RateTracker from "./utils/rateTracker.js";
 import { formatNumber } from "./utils/numberFormat.js";
@@ -2687,17 +2687,18 @@ if (currentEnemy) {
     }
   }
 
-if (systems.manaUnlocked) {
-stats.mana = Math.min(
-stats.maxMana,
-stats.mana + (stats.manaRegen * deltaTime) / 1000
+  if (systems.manaUnlocked) {
+  stats.mana = Math.min(
+  stats.maxMana,
+  stats.mana + (stats.manaRegen * deltaTime) / 1000
 );
  updateManaBar();
 }
 
   // passive progress for bar upgrades
   tickBarProgress(deltaTime);
-requestAnimationFrame(gameLoop);
+  tickSpeech(deltaTime);
+  requestAnimationFrame(gameLoop);
 }
 
 //devtools

--- a/style.css
+++ b/style.css
@@ -2330,3 +2330,55 @@ body {
     overflow-y: auto;
     width: 100%;
 }
+
+/* Speech resource panels */
+.speech-gains, .speech-upgrades, .secondary-resources {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    font-size: 0.8rem;
+}
+
+.secondary-resources .resource {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.resource-bar {
+    position: relative;
+    width: 100%;
+    height: 8px;
+    background: #222;
+    border: 1px solid #555;
+    border-radius: 4px;
+}
+
+.resource-fill {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: 0%;
+    background: #789;
+}
+
+.resource-text {
+    font-size: 0.7rem;
+    text-align: center;
+}
+
+.speech-orb#orbWill {
+    background: rgba(128,0,255,0.3);
+    border-color: #a060ff;
+}
+
+.speech-orb#orbBody {
+    background: rgba(255,0,0,0.3);
+    border-color: #ff8888;
+}
+
+.speech-orb#orbInsight {
+    background: rgba(0,0,255,0.3);
+    border-color: #8888ff;
+}


### PR DESCRIPTION
## Summary
- extend speech system with resource bars and upgrades
- color-code orbs and show gains panel
- show secondary resource panel with thought bar
- allow purchasing "cohere" upgrade to boost insight gain
- tick speech resources in game loop

## Testing
- `npm test` *(fails: mocha not found)*
- `npm run lint` *(fails: missing eslint packages)*

------
https://chatgpt.com/codex/tasks/task_e_685df30a64748326a757760a75c91821