### PR TITLE
Update player tab UI layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -198,12 +198,16 @@
     </div>
     <div class="playerTab">
       <div class="playerSidePanel casino-section">
-        <button class="playerCoreSubTabButton active">Core</button>
         <div id="speechGains" class="speech-gains"></div>
-        <div id="secondaryResources" class="secondary-resources"></div>
         <div id="speechUpgrades" class="speech-upgrades"></div>
       </div>
       <div class="playerMainContainer">
+        <div class="player-header">
+          <div class="player-subtabs">
+            <button class="playerCoreSubTabButton active">Core</button>
+          </div>
+          <div id="secondaryResources" class="secondary-resources"></div>
+        </div>
         <div class="player-core-panel">
           <div class="core-main">
             <div id="coreTabContent"></div>

--- a/style.css
+++ b/style.css
@@ -2041,7 +2041,6 @@ body {
 
 .player-subtabs {
     display: flex;
-    flex-direction: column;
     gap: 6px;
 }
 .player-subtabs button {
@@ -2064,6 +2063,14 @@ body {
 .player-subtabs button:hover {
     box-shadow: 0 0 12px rgba(183, 110, 255, 0.8);
     color: #fff4b3;
+}
+
+.player-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 6px;
+    gap: 10px;
 }
 
 .stats-subtabs {


### PR DESCRIPTION
## Summary
- restructure the Player tab layout
- show secondary resources beside sub tabs
- move upgrades and resource generation to a dedicated side panel

## Testing
- `PUPPETEER_SKIP_DOWNLOAD=1 npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685dff1c02b4832690cc9066a0870038