### PR TITLE
Update speech orbs UI and add phrase info

### DIFF
--- a/style.css
+++ b/style.css
@@ -2290,11 +2290,20 @@ body {
 }
 
 .speech-orb {
-    padding: 4px 8px;
-    background: rgba(0,0,0,0.5);
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
     border: 1px solid #888;
-    border-radius: 4px;
-    font-size: 0.8rem;
+    position: relative;
+    overflow: hidden;
+}
+
+.speech-orb .orb-fill {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: 0%;
 }
 
 .word-list {
@@ -2318,6 +2327,12 @@ body {
     display: flex;
     gap: 6px;
     justify-content: center;
+}
+
+.phrase-info {
+    font-size: 0.8rem;
+    margin-left: 8px;
+    align-self: center;
 }
 
 .phrase-slot {
@@ -2376,16 +2391,25 @@ body {
 }
 
 .speech-orb#orbWill {
-    background: rgba(128,0,255,0.3);
+    background: rgba(128,0,255,0.2);
     border-color: #a060ff;
+}
+.speech-orb#orbWill .orb-fill {
+    background: rgba(128,0,255,0.6);
 }
 
 .speech-orb#orbBody {
-    background: rgba(255,0,0,0.3);
+    background: rgba(255,0,0,0.2);
     border-color: #ff8888;
+}
+.speech-orb#orbBody .orb-fill {
+    background: rgba(255,0,0,0.6);
 }
 
 .speech-orb#orbInsight {
-    background: rgba(0,0,255,0.3);
+    background: rgba(0,0,255,0.2);
     border-color: #8888ff;
+}
+.speech-orb#orbInsight .orb-fill {
+    background: rgba(0,0,255,0.6);
 }


### PR DESCRIPTION
## Summary
- update speech orbs to be circular and fill based on resource max
- remove text labels from speech orbs
- show cost/effect/cooldown of a phrase beside the cast button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e018d731083268e35d886ef777074