### PR TITLE
Implement speech system expansions

### DIFF
--- a/style.css
+++ b/style.css
@@ -2284,6 +2284,27 @@ body {
     margin-top: 10px;
 }
 
+.speech-xp-bar {
+    position: relative;
+    width: 100%;
+    height: 6px;
+    background: #222;
+    border: 1px solid #555;
+    border-radius: 4px;
+}
+.speech-xp-fill {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: 0%;
+    background: #88f;
+}
+
+.capacity-display {
+    font-size: 0.8rem;
+}
+
 .speech-orbs {
     display: flex;
     gap: 10px;


### PR DESCRIPTION
## Summary
- expand speech system to support XP and capacity
- unlock Form target when Thought reaches 15
- add dynamic word slots and speech XP bar
- show capacity and resource Structure

## Testing
- `npm test` *(fails: `mocha` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e07627944832681f721d42678d8e6