### PR TITLE
Enhance speech interface with tooltips and info

### DIFF
--- a/core.js
+++ b/core.js
@@ -60,7 +60,29 @@ const bodyPath = `M200 140
   progressText = container.querySelector("#coreProgressText");
   const mindOrb = container.querySelector('#mindOrb');
   mindOrb.addEventListener('click', onMindOrbClick);
+  mindOrb.addEventListener('mouseenter', e => {
+    window.showTooltip(`Mind: ${Math.floor(coreState.mind.xp)}/${coreState.mind.maxXP}`, e.pageX + 10, e.pageY + 10);
+  });
+  mindOrb.addEventListener('mouseleave', window.hideTooltip);
   meditateBtn.addEventListener('click', startMeditation);
+  meditateBtn.addEventListener('mouseenter', e => {
+    window.showTooltip('Begin or advance meditation', e.pageX + 10, e.pageY + 10);
+  });
+  meditateBtn.addEventListener('mouseleave', window.hideTooltip);
+  const bodyOrbEl = container.querySelector('#bodyOrb');
+  if (bodyOrbEl) {
+    bodyOrbEl.addEventListener('mouseenter', e => {
+      window.showTooltip(`Body: ${Math.floor(coreState.body.xp)}/${coreState.body.maxXP}`, e.pageX + 10, e.pageY + 10);
+    });
+    bodyOrbEl.addEventListener('mouseleave', window.hideTooltip);
+  }
+  const willOrbEl = container.querySelector('#willOrb');
+  if (willOrbEl) {
+    willOrbEl.addEventListener('mouseenter', e => {
+      window.showTooltip(`Will: ${Math.floor(coreState.will.xp)}/${coreState.will.maxXP}`, e.pageX + 10, e.pageY + 10);
+    });
+    willOrbEl.addEventListener('mouseleave', window.hideTooltip);
+  }
   renderCore();
 }
 

--- a/script.js
+++ b/script.js
@@ -2149,17 +2149,32 @@ function renderJokers() {
 }
 
 
-function showJokerTooltip(joker, x, y) {
+function showTooltip(html, x, y) {
   if (!tooltip) return;
-  tooltip.innerHTML = `<strong>${joker.name}</strong><br>${joker.description}<br>Mana Cost: ${joker.manaCost}`;
+  tooltip.innerHTML = html;
   tooltip.style.display = "block";
   tooltip.style.left = x + "px";
   tooltip.style.top = y + "px";
 }
 
+function hideTooltip() {
+  if (tooltip) tooltip.style.display = "none";
+}
+
+window.showTooltip = showTooltip;
+window.hideTooltip = hideTooltip;
+
+function showJokerTooltip(joker, x, y) {
+  showTooltip(
+    `<strong>${joker.name}</strong><br>${joker.description}<br>Mana Cost: ${joker.manaCost}`,
+    x,
+    y
+  );
+}
+
 document.addEventListener("click", e => {
   if (!e.target.closest(".joker-wrapper")) {
-    if (tooltip) tooltip.style.display = "none";
+    hideTooltip();
   }
 });
 

--- a/style.css
+++ b/style.css
@@ -2300,6 +2300,10 @@ body {
     width: 0%;
     background: #88f;
 }
+.speech-level {
+    font-size: 0.8rem;
+    text-align: center;
+}
 
 .capacity-display {
     font-size: 0.8rem;


### PR DESCRIPTION
## Summary
- add general tooltip helpers and expose them globally
- show speech level and cast chance
- show phrase difficulty and success chance in phrase info
- display tooltips for speech and core orbs
- style speech level text

## Testing
- `PUPPETEER_SKIP_DOWNLOAD=1 npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e12ce96dc8326a6fcd4e645e37a31