### PR TITLE
Enhance speech UI and cooldown logic

### DIFF
--- a/style.css
+++ b/style.css
@@ -2284,9 +2284,21 @@ body {
     margin-top: 10px;
 }
 
+.speech-xp-container {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    width: 100%;
+}
+
+.speech-icon {
+    width: 16px;
+    height: 16px;
+}
+
 .speech-xp-bar {
     position: relative;
-    width: 100%;
+    flex: 1;
     height: 6px;
     background: #222;
     border: 1px solid #555;
@@ -2302,7 +2314,7 @@ body {
 }
 .speech-level {
     font-size: 0.8rem;
-    text-align: center;
+    white-space: nowrap;
 }
 
 .capacity-display {
@@ -2369,6 +2381,38 @@ body {
     align-items: center;
     justify-content: center;
     font-size: 0.8rem;
+}
+
+.cast-wrapper {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.cast-button {
+    position: relative;
+    padding: 4px 8px;
+    border: 1px solid #555;
+    background: #222;
+    color: #ddd;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 0.8rem;
+    overflow: hidden;
+}
+
+.cast-button.onCooldown {
+    opacity: 0.6;
+}
+
+.cast-cooldown {
+    position: relative;
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    overflow: hidden;
+    border: 1px solid #555;
+    background: #222;
 }
 
 .echo-log {


### PR DESCRIPTION
## Summary
- add speech progress container with icon and level to the right
- provide cooldown overlay and circle for speech casting
- refactor cast chance calculation using a difficulty variable

## Testing
- `npm test` *(fails: mocha not found)*
- `npm run lint` *(fails: missing @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_685e171d874083269563ba498b540e91