### PR TITLE
Fix extra orbs on core tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -211,7 +211,6 @@
         <div class="player-core-panel">
           <div class="core-main">
             <div id="coreTabContent"></div>
-            <div id="speechPanel" class="speech-panel"></div>
           </div>
         </div>
       </div>

--- a/speech.js
+++ b/speech.js
@@ -131,6 +131,7 @@ function onDrop(e) {
 }
 
 function renderLists() {
+  if (!container) return;
   const makeTile = (word, type) => {
     const d = document.createElement('div');
     d.className = 'word-tile';
@@ -151,6 +152,7 @@ function renderLists() {
 }
 
 function createSlots() {
+  if (!container) return;
   const slotContainer = container.querySelector('#phraseSlots');
   slotContainer.innerHTML = '';
   speechState.slots.forEach((_, idx) => {
@@ -164,20 +166,24 @@ function createSlots() {
 }
 
 function renderOrbs() {
-  const update = (id, orb) => {
-    const fill = container.querySelector(`#${id} .orb-fill`);
-    if (!fill) return;
-    const pct = Math.max(0, Math.min(1, orb.current / orb.max)) * 100;
-    fill.style.height = `${pct}%`;
-    const el = container.querySelector(`#${id}`);
-    if (el) el.title = `${Math.floor(orb.current)}/${orb.max}`;
-  };
-  update('orbBody', speechState.orbs.body);
-  update('orbInsight', speechState.orbs.insight);
-  update('orbWill', speechState.orbs.will);
+  if (container) {
+    const update = (id, orb) => {
+      const fill = container.querySelector(`#${id} .orb-fill`);
+      if (!fill) return;
+      const pct = Math.max(0, Math.min(1, orb.current / orb.max)) * 100;
+      fill.style.height = `${pct}%`;
+      const el = container.querySelector(`#${id}`);
+      if (el) el.title = `${Math.floor(orb.current)}/${orb.max}`;
+    };
+    update('orbBody', speechState.orbs.body);
+    update('orbInsight', speechState.orbs.insight);
+    update('orbWill', speechState.orbs.will);
+  }
+  window.dispatchEvent(new CustomEvent('orbs-changed'));
 }
 
 function renderSlots() {
+  if (!container) return;
   createSlots();
   container.querySelectorAll('.phrase-slot').forEach(slot => {
     const idx = Number(slot.dataset.index);
@@ -187,6 +193,7 @@ function renderSlots() {
 }
 
 function renderPhraseInfo() {
+  if (!container) return;
   const info = container.querySelector('#phraseInfo');
   if (!info) return;
   const wordsArr = speechState.slots.filter(Boolean);
@@ -260,8 +267,9 @@ function castPhrase() {
 }
 
 function renderEcho() {
+  if (!container) return;
   const log = container.querySelector('#echoLog');
-  log.innerHTML = speechState.echo.map(e => `<div>${e}</div>`).join('');
+  if (log) log.innerHTML = speechState.echo.map(e => `<div>${e}</div>`).join('');
 }
 
 function addSpeechXP(amt) {
@@ -282,6 +290,7 @@ function addSpeechXP(amt) {
 }
 
 function renderXpBar() {
+  if (!container) return;
   const bar = container.querySelector('.speech-xp-bar');
   const fill = bar ? bar.querySelector('.speech-xp-fill') : null;
   if (!bar || !fill) return;
@@ -367,6 +376,7 @@ function renderUpgrades() {
 }
 
 export function tickSpeech(delta) {
+  if (!container) return;
   const dt = delta / 1000;
   ['insight', 'body', 'will'].forEach(k => {
     const orb = speechState.orbs[k];


### PR DESCRIPTION
## Summary
- remove the speech system's panel from the Player Core view
- guard speech rendering functions when the panel is absent
- link player core orbs to speech resources and rename Mind orb to Insight

## Testing
- `npm test` *(fails: `mocha` not found)*
- `npm install` *(fails: puppeteer download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685e175654688326ac93e048da896699