### PR TITLE
Implement phrase cloud and capacity upgrade

### DIFF
--- a/style.css
+++ b/style.css
@@ -317,17 +317,18 @@ body {
 .vignette-toggle {
     width: 100%;
     padding: 4px 6px;
-    background: linear-gradient(135deg, #f0f0f0, #fafafa);
-    border: 2px solid #4caf50;
+    background: linear-gradient(135deg, #333, #111);
+    border: 2px solid #d4af37;
     border-radius: 6px;
-    color: #080707;
-    box-shadow: 0 2px 6px rgba(0, 128, 0, 0.4);
+    color: #d4af37;
+    box-shadow: 0 2px 6px rgba(212, 175, 55, 0.4);
     cursor: pointer;
     font-size: inherit; /* match side panel text size */
+    text-shadow: 0 0 5px black;
 }
 
 .vignette-toggle:hover {
-    box-shadow: 0 4px 12px rgba(0, 128, 0, 0.6);
+    box-shadow: 0 4px 12px rgba(212, 175, 55, 0.6);
 }
 
 .vignette-content {
@@ -1788,6 +1789,26 @@ body {
     text-shadow: 0 0 8px #fff;
     animation: fogFade 7s ease-in-out;
 }
+
+/* Floating phrase effect */
+.phrase-cloud {
+    position: absolute;
+    left: 50%;
+    top: 40%;
+    transform: translate(-50%, 0);
+    font-size: 1.2rem;
+    color: #ddd;
+    font-style: italic;
+    text-shadow: 0 0 8px #fff;
+    pointer-events: none;
+    animation: cloud-rise 3s ease-out forwards;
+}
+
+@keyframes cloud-rise {
+    0% { opacity: 0; transform: translate(-50%, 20px); filter: blur(4px); }
+    20% { opacity: 1; filter: blur(0); }
+    100% { opacity: 0; transform: translate(-50%, -60px); filter: blur(4px); }
+}
 @keyframes fogFade {
     from { opacity: 0; filter: blur(4px); }
     50% { opacity: 1; filter: blur(0); }
@@ -2282,6 +2303,7 @@ body {
     gap: 8px;
     align-items: center;
     margin-top: 10px;
+    position: relative; /* allow floating phrase clouds */
 }
 
 .speech-xp-container {


### PR DESCRIPTION
## Summary
- add phrase cloud animation and update speech panel layout
- adjust side panel buttons to match casino theme
- unlock capacity upgrade when Form unlocks and implement purchase logic

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f1003ced48326b0b6d26021ef1c5c