### PR TITLE
Implement speech word leveling and color coding

### DIFF
--- a/style.css
+++ b/style.css
@@ -2381,6 +2381,14 @@ body {
     user-select: none;
     font-size: 0.8rem;
 }
+.word-tile.verb {
+    background: #223;
+    border-color: #556;
+}
+.word-tile.target {
+    background: #322;
+    border-color: #755;
+}
 
 .phrase-slots {
     display: flex;
@@ -2403,6 +2411,12 @@ body {
     align-items: center;
     justify-content: center;
     font-size: 0.8rem;
+}
+.phrase-slot.verb-slot {
+    background: rgba(34,34,51,0.4);
+}
+.phrase-slot.target-slot {
+    background: rgba(51,34,34,0.4);
 }
 
 .cast-wrapper {


### PR DESCRIPTION
## Summary
- add per-word leveling with potency scaling and xp requirements
- unlock Murmur only after gaining speech XP
- allow dropping targets into non-verb slots
- display word level, xp and potency in tooltips
- color code words and slots depending on their category
- remove cooldown from `Murmur`

## Testing
- `npm test` *(fails: `mocha: not found`)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685f16a3aa3483268a5e9fe3ad99d50a