### PR TITLE
Fix speech word tile drags

### DIFF
--- a/speech.js
+++ b/speech.js
@@ -98,6 +98,13 @@ function addWordXp(word, amt) {
 }
 
 let container;
+function attachWordListeners() {
+  if (!container) return;
+  container.querySelectorAll('.word-tile').forEach(t => {
+    t.removeEventListener('dragstart', onDrag);
+    t.addEventListener('dragstart', onDrag);
+  });
+}
 
 export function initSpeech() {
   container = document.getElementById('speechPanel');
@@ -123,9 +130,7 @@ export function initSpeech() {
   renderLists();
   renderOrbs();
   createSlots();
-  container.querySelectorAll('.word-tile').forEach(t => {
-    t.addEventListener('dragstart', onDrag);
-  });
+  attachWordListeners();
   const castBtn = container.querySelector('#castPhraseBtn');
   castBtn.addEventListener('click', castPhrase);
   castBtn.addEventListener('mouseenter', e => {
@@ -191,6 +196,7 @@ function renderLists() {
     words.targets.forEach(w => targetList.appendChild(makeTile(w, 'target')));
     targetList.style.display = words.targets.length ? 'flex' : 'none';
   }
+  attachWordListeners();
 }
 
 function createSlots() {


### PR DESCRIPTION
## Summary
- ensure new word tiles can be dragged after unlocking

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f1c3984f8832690db4e81a4b9a3ff