### PR TITLE
Implement speech upgrades and slot removal

### DIFF
--- a/style.css
+++ b/style.css
@@ -2418,6 +2418,9 @@ body {
 .phrase-slot.target-slot {
     background: rgba(51,34,34,0.4);
 }
+.phrase-slot.filled {
+    cursor: pointer;
+}
 
 .cast-wrapper {
     display: flex;


### PR DESCRIPTION
## Summary
- make phrase slots clickable so slotted words can be removed
- block casting when any resource or orb is negative
- add `expandMind` upgrade increasing insight cap
- style filled slots with a pointer cursor

## Testing
- `npm test` *(fails: mocha not found)*
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_685f29c1ac5483269a9f6d29c9442897