### PR TITLE
Add speech tab and UI tweaks

### DIFF
--- a/index.html
+++ b/index.html
@@ -205,14 +205,17 @@
         <div class="player-header">
           <div class="player-subtabs">
             <button class="playerCoreSubTabButton active">Core</button>
+            <button class="playerSpeechSubTabButton">Speech</button>
           </div>
           <div id="secondaryResources" class="secondary-resources"></div>
         </div>
         <div class="player-core-panel">
           <div class="core-main">
             <div id="coreTabContent"></div>
-            <div id="speechPanel" class="speech-panel"></div>
           </div>
+        </div>
+        <div class="player-speech-panel" style="display:none;">
+          <div id="speechPanel" class="speech-panel"></div>
         </div>
       </div>
     </div>

--- a/script.js
+++ b/script.js
@@ -417,6 +417,8 @@ let deckUpgradesViewBtn;
 let deckUpgradesContainer;
 let playerCoreSubTabButton;
 let playerCorePanel;
+let playerSpeechSubTabButton;
+let playerSpeechPanel;
 let statsOverviewSubTabButton;
 let statsEconomySubTabButton;
 let statsOverviewContainer;
@@ -566,6 +568,8 @@ function initTabs() {
   jobsCarouselBtn = document.querySelector('.jobsCarouselBtn');
   playerCoreSubTabButton = document.querySelector(".playerCoreSubTabButton");
   playerCorePanel = document.querySelector(".player-core-panel");
+  playerSpeechSubTabButton = document.querySelector('.playerSpeechSubTabButton');
+  playerSpeechPanel = document.querySelector('.player-speech-panel');
   statsOverviewSubTabButton = document.querySelector('.statsOverviewSubTabButton');
   statsEconomySubTabButton = document.querySelector('.statsEconomySubTabButton');
   statsOverviewContainer = document.getElementById('statsOverviewContainer');
@@ -618,7 +622,16 @@ function initTabs() {
   if (playerCoreSubTabButton)
     playerCoreSubTabButton.addEventListener("click", () => {
       if (playerCorePanel) playerCorePanel.style.display = "flex";
+      if (playerSpeechPanel) playerSpeechPanel.style.display = "none";
       playerCoreSubTabButton.classList.add("active");
+      if (playerSpeechSubTabButton) playerSpeechSubTabButton.classList.remove("active");
+    });
+  if (playerSpeechSubTabButton)
+    playerSpeechSubTabButton.addEventListener('click', () => {
+      if (playerCorePanel) playerCorePanel.style.display = 'none';
+      if (playerSpeechPanel) playerSpeechPanel.style.display = 'flex';
+      playerSpeechSubTabButton.classList.add('active');
+      if (playerCoreSubTabButton) playerCoreSubTabButton.classList.remove('active');
     });
   if (statsOverviewSubTabButton)
     statsOverviewSubTabButton.addEventListener('click', () => {

--- a/speech.js
+++ b/speech.js
@@ -115,6 +115,11 @@ export function initSpeech() {
   container = document.getElementById('speechPanel');
   if (!container) return;
   container.innerHTML = `
+    <div class="speech-orbs speech-tab-orbs">
+      <div id="orbInsight" class="speech-orb"><div class="orb-fill"></div></div>
+      <div id="orbBody" class="speech-orb"><div class="orb-fill"></div></div>
+      <div id="orbWill" class="speech-orb"><div class="orb-fill"></div></div>
+    </div>
     <div class="speech-xp-container">
       <i data-lucide="mic" class="speech-icon"></i>
       <div class="speech-xp-bar"><div class="speech-xp-fill"></div></div>
@@ -251,7 +256,22 @@ function renderSlots() {
     slot.classList.toggle('verb-slot', idx === 0);
     slot.classList.toggle('target-slot', idx > 0);
     const word = speechState.slots[idx];
-    slot.textContent = word || '';
+    slot.innerHTML = '';
+    if (word) {
+      const span = document.createElement('span');
+      span.className = 'slot-word';
+      span.textContent = word;
+      const x = document.createElement('span');
+      x.className = 'slot-clear';
+      x.textContent = 'x';
+      x.addEventListener('click', ev => {
+        ev.stopPropagation();
+        speechState.slots[idx] = null;
+        renderSlots();
+      });
+      slot.appendChild(span);
+      slot.appendChild(x);
+    }
     slot.classList.toggle('filled', Boolean(word));
   });
   renderPhraseInfo();
@@ -391,9 +411,6 @@ function addSpeechXP(amt) {
   if (speechState.level !== oldLevel) {
     if (!words.verbs.includes('Murmur')) {
       words.verbs.push('Murmur');
-    }
-    if (speechState.level >= 2 && !words.targets.includes('Insight')) {
-      words.targets.push('Insight');
     }
     if (speechState.level >= 10 && speechState.slots.length < 3) {
       speechState.slots.push(null);

--- a/style.css
+++ b/style.css
@@ -2171,11 +2171,19 @@ body {
     width: 100%;
 }
 #coreTabContent svg {
-    max-width: 280px;
-    transform: scale(1);
+    max-width: 360px;
+    transform: scale(1.2);
 }
 .core-level-text {
     margin-top: 4px;
+}
+
+.player-speech-panel {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 6px;
+    flex: 1;
 }
 
 .player-upgrades-panel {
@@ -2517,6 +2525,20 @@ body {
 .speech-orb#orbInsight {
     background: rgba(0,0,255,0.2);
     border-color: #8888ff;
+}
+
+.speech-tab-orbs .speech-orb {
+    width: 48px;
+    height: 48px;
+}
+
+.slot-clear {
+    margin-left: 4px;
+    color: #a44;
+    cursor: pointer;
+}
+.slot-word {
+    pointer-events: none;
 }
 .speech-orb#orbInsight .orb-fill {
     background: rgba(0,0,255,0.6);


### PR DESCRIPTION
## Summary
- move Speech UI to its own sub-tab
- add large orbs for the speech tab and enlarge core diagram
- allow removing speech words with an `x` button
- remove `Insight` from available word list

## Testing
- `npm test` *(fails: `mocha` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f326cb96c832699d991584c14e056