### PR TITLE
Update construct panel behavior

### DIFF
--- a/speech.js
+++ b/speech.js
@@ -11,7 +11,7 @@ export const speechState = {
   },
   gains: {
     body: 0,
-    insight: 1,
+    insight: 0.2,
     will: 0
   },
   upgrades: {
@@ -223,6 +223,20 @@ export function initSpeech() {
   if (constructBtn) constructBtn.addEventListener('click', toggleConstructPanel);
   const closeBtn = container.querySelector('#closeConstructBtn');
   if (closeBtn) closeBtn.addEventListener('click', toggleConstructPanel);
+  const panel = container.querySelector('#constructPanel');
+  if (panel) {
+    panel.addEventListener('pointerdown', e => {
+      if (!panel.classList.contains('open')) return;
+      if (e.target.closest('.word-tile')) return;
+      const startX = e.clientX;
+      function up(ev) {
+        const diff = ev.clientX - startX;
+        if (diff > 50) toggleConstructPanel(false);
+        window.removeEventListener('pointerup', up);
+      }
+      window.addEventListener('pointerup', up);
+    });
+  }
   renderSlots();
   updateCastCooldown();
   renderResources();
@@ -459,11 +473,21 @@ function castMurmur() {
   updateCastCooldown();
 }
 
-function toggleConstructPanel() {
+function toggleConstructPanel(forceOpen) {
   const panel = container.querySelector('#constructPanel');
   if (!panel) return;
-  const open = panel.classList.toggle('open');
-  container.classList.toggle('construct-mode', open);
+  const isOpen = panel.classList.contains('open');
+  const shouldOpen = typeof forceOpen === 'boolean' ? forceOpen : !isOpen;
+  if (shouldOpen) {
+    panel.classList.remove('close-right');
+    panel.classList.add('open');
+    container.classList.add('construct-mode');
+  } else {
+    panel.classList.remove('open');
+    panel.classList.add('close-right');
+    container.classList.remove('construct-mode');
+    panel.addEventListener('transitionend', () => panel.classList.remove('close-right'), { once: true });
+  }
 }
 
 function savePhrase() {

--- a/style.css
+++ b/style.css
@@ -2492,18 +2492,18 @@ body {
 .construct-panel {
     position: absolute;
     top: 0;
-    right: 0;
+    left: 0;
     width: 240px;
     height: 100%;
     margin: 0;
     padding: 8px;
     box-sizing: border-box;
     background: rgba(0, 0, 0, 0.9);
-    border-left: 1px solid #555;
+    border-right: 1px solid #555;
     display: flex;
     flex-direction: column;
     gap: 6px;
-    transform: translateX(100%);
+    transform: translateX(-100%);
     opacity: 0;
     transition: transform 0.3s ease-out, opacity 0.3s ease-out;
 }
@@ -2513,8 +2513,16 @@ body {
     opacity: 1;
 }
 
+.construct-panel.close-right {
+    transform: translateX(100%);
+}
+
 .speech-panel.construct-mode .speech-orbs {
-    transform: translate(-40px, 20px);
+    position: absolute;
+    right: 8px;
+    top: 8px;
+    flex-direction: column;
+    transform: none;
 }
 
 .hotbar-phrase {


### PR DESCRIPTION
## Summary
- adjust insight regen values
- animate construct panel from the left
- allow closing by swiping right
- keep orbs visible in a vertical column while the panel is open

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68600ade7a488326ad953ff35bd5b045