### PR TITLE
Improve construct panel and mobile drag

### DIFF
--- a/speech.js
+++ b/speech.js
@@ -147,11 +147,14 @@ function addWordXp(word, amt) {
 }
 
 let container;
+let pointerDrag = null;
 function attachWordListeners() {
   if (!container) return;
   container.querySelectorAll('.word-tile').forEach(t => {
     t.removeEventListener('dragstart', onDrag);
     t.addEventListener('dragstart', onDrag);
+    t.removeEventListener('pointerdown', onTilePointerDown);
+    t.addEventListener('pointerdown', onTilePointerDown);
   });
 }
 
@@ -258,6 +261,26 @@ function onDrop(e) {
   if (idx === 0 && type !== 'verb') return;
   speechState.slots[idx] = word;
   renderSlots();
+}
+
+function onTilePointerDown(e) {
+  e.preventDefault();
+  pointerDrag = { word: e.currentTarget.dataset.word, type: e.currentTarget.dataset.type };
+  window.addEventListener('pointerup', onTilePointerUp, { once: true });
+}
+
+function onTilePointerUp(e) {
+  if (!pointerDrag) return;
+  const el = document.elementFromPoint(e.clientX, e.clientY);
+  const slot = el && el.closest('.phrase-slot');
+  if (slot) {
+    const idx = Number(slot.dataset.index);
+    if (!(idx === 0 && pointerDrag.type !== 'verb')) {
+      speechState.slots[idx] = pointerDrag.word;
+      renderSlots();
+    }
+  }
+  pointerDrag = null;
 }
 
 function onSlotClick(e) {

--- a/style.css
+++ b/style.css
@@ -2493,7 +2493,7 @@ body {
     position: absolute;
     top: 0;
     left: 0;
-    width: 240px;
+    width: 100%;
     height: 100%;
     margin: 0;
     padding: 8px;
@@ -2506,6 +2506,7 @@ body {
     transform: translateX(-100%);
     opacity: 0;
     transition: transform 0.3s ease-out, opacity 0.3s ease-out;
+    z-index: 10;
 }
 
 .construct-panel.open {


### PR DESCRIPTION
## Summary
- make the Construct Reality panel take the whole tab
- enable word drag support on mobile devices

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_68600fe62ce8832689bbed9eafa5279e