### PR TITLE
Fix construct panel layout and mobile drag

### DIFF
--- a/speech.js
+++ b/speech.js
@@ -176,8 +176,8 @@ export function initSpeech() {
     </div>
     <div class="murmur-controls">
       <button id="murmurBtn" class="cast-button">Murmur</button>
-      <button id="constructBtn" class="cast-button" style="display:none">Construct</button>
     </div>
+    <div id="constructToggle" class="construct-toggle" style="display:none">❮</div>
     <div id="phraseHotbar" class="phrase-hotbar"></div>
     <div id="constructPanel" class="construct-panel">
       <div class="construct-header">
@@ -222,8 +222,20 @@ export function initSpeech() {
   if (saveBtn) saveBtn.addEventListener('click', savePhrase);
   const murmurBtn = container.querySelector('#murmurBtn');
   if (murmurBtn) murmurBtn.addEventListener('click', castMurmur);
-  const constructBtn = container.querySelector('#constructBtn');
-  if (constructBtn) constructBtn.addEventListener('click', toggleConstructPanel);
+  const constructToggle = container.querySelector('#constructToggle');
+  if (constructToggle) {
+    constructToggle.addEventListener('click', () => toggleConstructPanel());
+    constructToggle.addEventListener('pointerdown', e => {
+      const start = e.clientX;
+      function up(ev) {
+        const diff = start - ev.clientX;
+        if (diff > 30) toggleConstructPanel(true);
+        if (diff < -30) toggleConstructPanel(false);
+        window.removeEventListener('pointerup', up);
+      }
+      window.addEventListener('pointerup', up);
+    });
+  }
   const closeBtn = container.querySelector('#closeConstructBtn');
   if (closeBtn) closeBtn.addEventListener('click', toggleConstructPanel);
   const panel = container.querySelector('#constructPanel');
@@ -498,6 +510,7 @@ function castMurmur() {
 
 function toggleConstructPanel(forceOpen) {
   const panel = container.querySelector('#constructPanel');
+  const toggle = container.querySelector('#constructToggle');
   if (!panel) return;
   const isOpen = panel.classList.contains('open');
   const shouldOpen = typeof forceOpen === 'boolean' ? forceOpen : !isOpen;
@@ -505,10 +518,12 @@ function toggleConstructPanel(forceOpen) {
     panel.classList.remove('close-right');
     panel.classList.add('open');
     container.classList.add('construct-mode');
+    if (toggle) toggle.textContent = '❯';
   } else {
     panel.classList.remove('open');
     panel.classList.add('close-right');
     container.classList.remove('construct-mode');
+    if (toggle) toggle.textContent = '❮';
     panel.addEventListener('transitionend', () => panel.classList.remove('close-right'), { once: true });
   }
 }
@@ -607,8 +622,9 @@ function renderXpBar() {
 function checkUnlocks() {
   if (!speechState.constructUnlocked && speechState.level >= 2) {
     speechState.constructUnlocked = true;
-    const btn = container.querySelector('#constructBtn');
-    if (btn) btn.style.display = 'inline-block';
+    const toggle = container.querySelector('#constructToggle');
+    if (toggle) toggle.style.display = 'block';
+    toggleConstructPanel(true);
     addLog('You feel your words press outward. You may now construct meaning.', 'info');
   }
   if (speechState.level >= 3) {

--- a/style.css
+++ b/style.css
@@ -2181,7 +2181,7 @@ body {
 .player-speech-panel {
     display: flex;
     flex-direction: column;
-    align-items: center;
+    align-items: stretch;
     gap: 6px;
     flex: 1;
 }
@@ -2312,6 +2312,9 @@ body {
     align-items: center;
     margin-top: 10px;
     position: relative; /* allow floating phrase clouds */
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
 }
 
 .speech-xp-container {
@@ -2404,6 +2407,7 @@ body {
     border-radius: 4px;
     cursor: grab;
     user-select: none;
+    touch-action: none;
     font-size: 0.8rem;
 }
 .word-tile.verb {
@@ -2503,7 +2507,7 @@ body {
     display: flex;
     flex-direction: column;
     gap: 6px;
-    transform: translateX(-100%);
+    transform: translateX(100%);
     opacity: 0;
     transition: transform 0.3s ease-out, opacity 0.3s ease-out;
     z-index: 10;
@@ -2516,6 +2520,21 @@ body {
 
 .construct-panel.close-right {
     transform: translateX(100%);
+}
+
+.construct-toggle {
+    position: absolute;
+    top: 50%;
+    right: 0;
+    transform: translateY(-50%);
+    background: #222;
+    border: 1px solid #555;
+    border-right: none;
+    border-radius: 6px 0 0 6px;
+    padding: 4px 6px;
+    cursor: pointer;
+    user-select: none;
+    z-index: 11;
 }
 
 .speech-panel.construct-mode .speech-orbs {


### PR DESCRIPTION
## Summary
- make speech panel stretch full width
- allow dragging word tiles on mobile
- auto-open Construct panel on unlock
- add slide toggle arrow for Construct panel
- adjust styles for sliding from right

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686014a4682c832696ee5b72cd1009da