### PR TITLE
Implement modifier words system

### DIFF
--- a/docs/phrase-system.md
+++ b/docs/phrase-system.md
@@ -70,6 +70,14 @@ This document outlines the updated rules for constructing phrases in the Codex g
 * Effect: +3 Structure with faster casting
 * Cooldown: 2s
 
+## Modifier Words
+
+| Modifier | Effect | Orb Cost | Cooldown | Capacity | Potency | Complexity | Unlock Condition |
+| -------- | ------ | -------- | -------- | -------- | ------- | ---------- | ---------------- |
+| Inwardly | Self-target only; small focus boost | −1 total (min 1) | No change | +0 | ×1.1 | +0.5 | Cast any phrase with Self as the target 3 times |
+| Sharply | Doubles output | +2 total | +2s | +1 | ×2 | +1.5 | Cast 3 different phrases with total orb cost ≥ 6 |
+| Persistently | Repeats once after 5 seconds | +1 total | +1s | +1 | ×1 | +1.0 | Cast the same phrase 3 times in a row |
+
 ## 7. Speech Level Scaling
 
 | Level | Unlock                              |

--- a/style.css
+++ b/style.css
@@ -2418,6 +2418,10 @@ body {
     background: #322;
     border-color: #755;
 }
+.word-tile.modifier {
+    background: #232;
+    border-color: #575;
+}
 
 .phrase-slots {
     display: flex;
@@ -2463,6 +2467,9 @@ body {
 }
 .phrase-slot.target-slot {
     background: rgba(51,34,34,0.4);
+}
+.phrase-slot.modifier-slot {
+    background: rgba(34,51,34,0.4);
 }
 .phrase-slot.filled {
     cursor: pointer;


### PR DESCRIPTION
## Summary
- add modifier words: Inwardly, Sharply and Persistently
- update phrase builder UI and slots for modifiers
- implement modifier unlock logic and dynamic phrase calculations
- style modifier tiles and slots
- document modifier word effects

## Testing
- `node -c speech.js`
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_686021022d508326b0e366cfd35837d0