### PR TITLE
Fix constructor unlock check

### DIFF
--- a/speech.js
+++ b/speech.js
@@ -1,4 +1,6 @@
 import addLog from './log.js';
+
+const FORM_UNLOCK_THOUGHT_REQ = 15;
 export const speechState = {
   orbs: {
     body: { current: 0, max: 10 },
@@ -634,7 +636,8 @@ function checkUnlocks() {
     speechState.slots.push(null);
     renderSlots();
   }
-  if (!speechState.formUnlocked && speechState.resources.thought.current >= 15) {
+  const thought = speechState.resources.thought.current;
+  if (!speechState.formUnlocked && Math.floor(thought + 1e-6) >= FORM_UNLOCK_THOUGHT_REQ) {
     speechState.formUnlocked = true;
     if (!words.targets.includes('Form')) {
       words.targets.push('Form');


### PR DESCRIPTION
## Summary
- prevent floating point rounding from blocking the Form unlock in the speech system

## Testing
- `npm test --silent` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860211e046c8326a2f81ebffdd2c9f1