### PR TITLE
Implement Mind target and improved speech constructor

### DIFF
--- a/style.css
+++ b/style.css
@@ -2500,6 +2500,28 @@ body {
     justify-content: center;
 }
 
+.saved-phrases {
+    display: flex;
+    gap: 4px;
+    flex-wrap: wrap;
+    justify-content: center;
+}
+
+.saved-phrase-card {
+    display: flex;
+    flex-direction: column;
+    padding: 2px 4px;
+    background: #222;
+    border: 1px solid #555;
+    border-radius: 4px;
+    font-size: 0.7rem;
+    cursor: pointer;
+}
+
+.saved-phrase-word {
+    line-height: 1;
+}
+
 .construct-panel {
     position: absolute;
     top: 0;


### PR DESCRIPTION
## Summary
- add `Mind` target data
- unlock Mind at speech level 2
- generate Thought when using Mind in a phrase
- highlight construct toggle when unlocking words
- automatically extend phrase slots as capacity grows
- show saved phrases as cards inside the constructor panel

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68602a0832a4832691ba6591da34255c