### PR TITLE
Add memory slots and gradient phrase cards

### DIFF
--- a/style.css
+++ b/style.css
@@ -2507,19 +2507,42 @@ body {
     justify-content: center;
 }
 
-.saved-phrase-card {
+.phrase-card {
     display: flex;
     flex-direction: column;
     padding: 2px 4px;
-    background: #222;
     border: 1px solid #555;
     border-radius: 4px;
     font-size: 0.7rem;
     cursor: pointer;
+    background: #222;
+}
+.phrase-card.active {
+    box-shadow: 0 0 6px #ffd27d;
 }
 
-.saved-phrase-word {
+.phrase-word {
     line-height: 1;
+}
+
+.memory-slots {
+    display: flex;
+    gap: 4px;
+    justify-content: center;
+    margin-bottom: 4px;
+}
+
+.memory-slot {
+    width: 10px;
+    height: 10px;
+    border: 1px solid #555;
+    background: #222;
+    border-radius: 2px;
+}
+
+.memory-slot.filled {
+    background: #88f;
+    box-shadow: 0 0 4px #88f;
 }
 
 .construct-panel {
@@ -2640,8 +2663,12 @@ body {
     left: 0;
     height: 100%;
     width: 0%;
-    background: #789;
 }
+.resource-fill.insight { background: #88f; }
+.resource-fill.thought { background: #4466aa; }
+.resource-fill.structure { background: #a97b5d; }
+.resource-fill.body { background: #f66; }
+.resource-fill.will { background: #a060ff; }
 
 .resource-text {
     font-size: 0.7rem;


### PR DESCRIPTION
## Summary
- convert saved phrases to gradient cards
- add memory slot system with activation glow
- colorize resource bars and word tiles
- auto-replace Murmur with Murmur Mind on unlock

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_686033eaede88326b87bdb354fddb21f