### PR TITLE
Implement chant verb and UI updates

### DIFF
--- a/style.css
+++ b/style.css
@@ -2523,6 +2523,7 @@ body {
 
 .phrase-word {
     line-height: 1;
+    display: block;
 }
 
 .memory-slots {


### PR DESCRIPTION
## Summary
- add `Chant` verb and unlock at speech level 8
- enforce verb+target requirement and prevent using Chant with Persistently
- auto-save successful phrases and hide Murmur button when Murmur card appears
- improve phrase card layout and gradient
- show body and will orbs only after gaining resources
- move detailed phrase info to card panel

## Testing
- `npm test` *(fails: `mocha` not found)*
- `npm run lint` *(fails: cannot find package `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_686038fba74c832685c9c86f48fb0eeb