### PR TITLE
Improve phrase card display

### DIFF
--- a/speech.js
+++ b/speech.js
@@ -547,7 +547,11 @@ function renderPhraseInfo() {
   info.innerHTML = `<span class="info-tag">??</span> ${chanceHtml}`;
   const cap = def.capacity || 0;
   const capDisplay = container.querySelector('#capacityDisplay');
-  if (capDisplay) capDisplay.textContent = `Capacity: ${cap}/${speechState.capacity}`;
+  if (capDisplay) {
+    capDisplay.textContent = `Capacity: ${cap}/${speechState.capacity}`;
+    if (cap > speechState.capacity) capDisplay.classList.add('exceeded');
+    else capDisplay.classList.remove('exceeded');
+  }
 }
 
 function castPhrase(phraseArg) {

--- a/style.css
+++ b/style.css
@@ -2354,6 +2354,9 @@ body {
 .capacity-display {
     font-size: 0.8rem;
 }
+.capacity-display.exceeded {
+    color: #f66;
+}
 
 .speech-orbs {
     display: flex;
@@ -2510,6 +2513,7 @@ body {
 .phrase-card {
     display: flex;
     flex-direction: column;
+    min-height: 40px;
     padding: 2px 4px;
     border: 1px solid #555;
     border-radius: 4px;
@@ -2600,6 +2604,7 @@ body {
 
 .hotbar-phrase {
     font-size: 0.75rem;
+    min-height: 40px;
 }
 
 .cast-button {


### PR DESCRIPTION
## Summary
- enlarge phrase cards
- show capacity overflow in red

## Testing
- `npm test` *(fails: mocha not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68603ca0683083269ff315a6bca08b3d