### PR TITLE
Fix phrase card display and unlock logic

### DIFF
--- a/speech.js
+++ b/speech.js
@@ -528,15 +528,18 @@ function renderSlots() {
 function renderPhraseInfo() {
   if (!container) return;
   const info = container.querySelector('#phraseInfo');
+  const castBtn = container.querySelector('#castPhraseBtn');
   if (!info) return;
   const wordsArr = speechState.slots.filter(Boolean);
   if (wordsArr.length < 1) {
     info.textContent = '';
+    if (castBtn) castBtn.disabled = true;
     return;
   }
   const def = buildPhraseDef(wordsArr);
   if (!def) {
     info.textContent = '';
+    if (castBtn) castBtn.disabled = true;
     return;
   }
   const complexity = (def.complexity.verb || 0) + (def.complexity.target || 0) + (def.complexity.modifier || 0);
@@ -552,6 +555,7 @@ function renderPhraseInfo() {
     if (cap > speechState.capacity) capDisplay.classList.add('exceeded');
     else capDisplay.classList.remove('exceeded');
   }
+  if (castBtn) castBtn.disabled = cap > speechState.capacity;
 }
 
 function castPhrase(phraseArg) {
@@ -641,6 +645,9 @@ function castPhrase(phraseArg) {
     } else if (wordsArr.includes('Persistently')) {
       setTimeout(() => castPhrase(phrase), 5000);
     }
+    const castBtn = container.querySelector('#castPhraseBtn');
+    if (castBtn) castBtn.disabled = true;
+    showPhraseDetails(phrase);
   } else {
     speechState.failCount += 1;
     if (!speechState.upgrades.vocalMaturity.unlocked && speechState.failCount >= 5) {
@@ -653,7 +660,7 @@ function castPhrase(phraseArg) {
   }
   renderOrbs();
   renderResources();
-  renderPhraseInfo();
+  if (!success) renderPhraseInfo();
   updateCastCooldown();
   checkUnlocks();
 }
@@ -842,6 +849,10 @@ function checkUnlocks() {
     if (murmurBtn) murmurBtn.textContent = 'Murmur Mind';
     const idx = speechState.activePhrases.indexOf('Murmur');
     if (idx >= 0) speechState.activePhrases[idx] = 'Murmur Mind';
+    speechState.capacity += 1;
+    renderSlots();
+    renderHotbar();
+    renderSavedPhraseCards();
     glowConstructToggle();
     renderLists();
   }

--- a/style.css
+++ b/style.css
@@ -2513,11 +2513,11 @@ body {
 .phrase-card {
     display: flex;
     flex-direction: column;
-    min-height: 40px;
-    padding: 2px 4px;
+    min-height: 48px;
+    padding: 2px 6px;
     border: 1px solid #555;
     border-radius: 4px;
-    font-size: 0.7rem;
+    font-size: 1rem;
     cursor: pointer;
     background: #222;
 }


### PR DESCRIPTION
## Summary
- enlarge phrase card size and font
- disable cast button and show details on successful cast
- bump capacity when unlocking **Mind** target

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68603f99686483269a49d1d31073ecc3