### PR TITLE
Fix constructor slot logic and improve phrase UI

### DIFF
--- a/style.css
+++ b/style.css
@@ -2513,11 +2513,11 @@ body {
 .phrase-card {
     display: flex;
     flex-direction: column;
-    min-height: 48px;
-    padding: 2px 6px;
+    min-height: 64px;
+    padding: 4px 8px;
     border: 1px solid #555;
     border-radius: 4px;
-    font-size: 1rem;
+    font-size: 1.2rem;
     cursor: pointer;
     background: #222;
 }
@@ -2592,6 +2592,16 @@ body {
     cursor: pointer;
     user-select: none;
     z-index: 11;
+}
+
+.construct-top, .construct-bottom {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.construct-bottom {
+    margin-top: auto;
 }
 
 .speech-panel.construct-mode .speech-orbs {


### PR DESCRIPTION
## Summary
- tune constructor slot count based on placed words rather than capacity
- reorganize construct panel layout into top and bottom sections
- increase phrase card size and font
- display phrase details after discovery
- ensure `Murmur` card is replaced with `Murmur Mind`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6860435d0bf08326a270f8e6550e5e6c