### PR TITLE
Embed upgrades in construct panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -197,11 +197,6 @@
       <div id="statsEconomyContainer" class="casino-section" style="display:none;"></div>
     </div>
     <div class="playerTab">
-      <div class="playerSidePanel casino-section">
-        <h3 class="section-title">Core Stats &amp; Upgrades</h3>
-        <div id="speechGains" class="speech-gains"></div>
-        <div id="speechUpgrades" class="speech-upgrades"></div>
-      </div>
       <div class="playerMainContainer">
         <div class="player-header">
           <div class="player-subtabs">

--- a/speech.js
+++ b/speech.js
@@ -289,27 +289,36 @@ export function initSpeech() {
     <div id="phraseHotbar" class="phrase-hotbar"></div>
     <div id="constructPanel" class="construct-panel">
       <div class="construct-header">
-        <h3 class="section-title">Construct Reality</h3>
+        <div class="construct-tabs">
+          <button class="constructTabButton active">Constructor</button>
+          <button class="upgradeTabButton">Upgrades</button>
+        </div>
         <button id="closeConstructBtn" class="cast-button">❌</button>
       </div>
-      <div class="construct-top">
-        <div class="word-list" id="verbList"></div>
-        <div class="word-list" id="targetList" style="display:none"></div>
-        <div class="word-list" id="modifierList" style="display:none"></div>
-        <div class="phrase-slots" id="phraseSlots"></div>
-        <div id="capacityDisplay" class="capacity-display"></div>
-        <div class="cast-container">
-          <div class="cast-wrapper">
-            <button id="castPhraseBtn" class="cast-button"><span>Cast</span><div class="cooldown-overlay" style="--cooldown:0; display:none"></div></button>
-            <div id="castCooldownCircle" class="cast-cooldown" style="display:none"><div class="cooldown-overlay" style="--cooldown:0"></div></div>
+      <div class="construct-tab constructor-view">
+        <div class="construct-top">
+          <div class="word-list" id="verbList"></div>
+          <div class="word-list" id="targetList" style="display:none"></div>
+          <div class="word-list" id="modifierList" style="display:none"></div>
+          <div class="phrase-slots" id="phraseSlots"></div>
+          <div id="capacityDisplay" class="capacity-display"></div>
+          <div class="cast-container">
+            <div class="cast-wrapper">
+              <button id="castPhraseBtn" class="cast-button"><span>Cast</span><div class="cooldown-overlay" style="--cooldown:0; display:none"></div></button>
+              <div id="castCooldownCircle" class="cast-cooldown" style="display:none"><div class="cooldown-overlay" style="--cooldown:0"></div></div>
+            </div>
+            <div id="phraseInfo" class="phrase-info"></div>
           </div>
-          <div id="phraseInfo" class="phrase-info"></div>
+        </div>
+        <div class="construct-bottom">
+          <div id="savedPhraseCards" class="saved-phrases"></div>
+          <div id="memorySlotsDisplay" class="memory-slots"></div>
+          <div id="phraseDetails" class="phrase-info"></div>
         </div>
       </div>
-      <div class="construct-bottom">
-        <div id="savedPhraseCards" class="saved-phrases"></div>
-        <div id="memorySlotsDisplay" class="memory-slots"></div>
-        <div id="phraseDetails" class="phrase-info"></div>
+      <div class="construct-tab upgrades-view" style="display:none;">
+        <div id="speechGains" class="speech-gains"></div>
+        <div id="speechUpgrades" class="speech-upgrades"></div>
       </div>
     </div>
   `;
@@ -362,6 +371,26 @@ export function initSpeech() {
         window.removeEventListener('pointerup', up);
       }
       window.addEventListener('pointerup', up);
+    });
+  }
+
+  const constructorTabBtn = container.querySelector('.constructTabButton');
+  const upgradeTabBtn = container.querySelector('.upgradeTabButton');
+  const constructorView = container.querySelector('.constructor-view');
+  const upgradesView = container.querySelector('.upgrades-view');
+  if (constructorTabBtn && upgradeTabBtn && constructorView && upgradesView) {
+    constructorTabBtn.addEventListener('click', () => {
+      constructorView.style.display = 'flex';
+      upgradesView.style.display = 'none';
+      constructorTabBtn.classList.add('active');
+      upgradeTabBtn.classList.remove('active');
+    });
+    upgradeTabBtn.addEventListener('click', () => {
+      constructorView.style.display = 'none';
+      upgradesView.style.display = 'flex';
+      upgradeTabBtn.classList.add('active');
+      constructorTabBtn.classList.remove('active');
+      renderUpgrades();
     });
   }
   renderSlots();

--- a/style.css
+++ b/style.css
@@ -1996,14 +1996,8 @@ body {
     padding: 5px;
     height: 100vh;
 }
-.playerSidePanel {
-    flex: 1 1 20%;
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
-}
 .playerMainContainer {
-    flex: 1 1 80%;
+    flex: 1 1 100%;
     display: flex;
     flex-direction: column;
     gap: 10px;
@@ -2616,6 +2610,32 @@ body {
     margin-top: auto;
 }
 
+.construct-tabs {
+    display: flex;
+    gap: 6px;
+}
+.construct-tabs button {
+    width: 100%;
+    border: 2px solid #b76eff;
+    padding: 6px 10px;
+    border-radius: 6px;
+    font-size: 0.8rem;
+    font-weight: bold;
+    text-shadow: 0 0 6px #000;
+    transition: all 0.2s;
+    color: #e0d0ff;
+    background: #4b0082;
+}
+.construct-tabs button.active {
+    background: #b76eff;
+    color: #220000;
+    box-shadow: inset 0 0 8px #fff8c6, 0 0 12px #b76eff;
+}
+.construct-tabs button:hover {
+    box-shadow: 0 0 12px rgba(183, 110, 255, 0.8);
+    color: #fff4b3;
+}
+
 .speech-panel.construct-mode .speech-orbs {
     position: absolute;
     right: 8px;
@@ -2668,6 +2688,27 @@ body {
     flex-direction: column;
     gap: 4px;
     font-size: 0.8rem;
+}
+.speech-upgrades button {
+    padding: 6px;
+    border: 2px solid #b76eff;
+    background: #4b0082;
+    color: #e0d0ff;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 0.8rem;
+    text-shadow: 0 0 4px #000;
+    box-shadow: 0 0 6px rgba(183, 110, 255, 0.5);
+    transition: all 0.2s;
+    width: 100%;
+}
+.speech-upgrades button:hover {
+    box-shadow: 0 0 12px rgba(183, 110, 255, 0.8);
+    color: #fff4b3;
+}
+.speech-upgrades .section-title {
+    margin-top: 8px;
+    margin-bottom: 4px;
 }
 
 .secondary-resources .resource {


### PR DESCRIPTION
## Summary
- remove core upgrades sidebar from the Player tab
- place upgrades inside the Construct Reality panel
- add tab buttons to switch between Constructor and Upgrades views
- style the new tab controls and upgrade buttons
- expand Player tab main container after sidebar removal

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860a2a8aad88326b907f1cae5e4ca4e