### PR TITLE
UI tweaks for speech and cards

### DIFF
--- a/speech.js
+++ b/speech.js
@@ -720,6 +720,9 @@ function castPhrase(phraseArg) {
     if (castBtn) castBtn.disabled = true;
     showPhraseDetails(phrase);
     renderPhraseInfo();
+    // Clear slots after casting for easier new phrase construction
+    speechState.slots = [null];
+    renderSlots();
   } else {
     speechState.failCount += 1;
     if (!speechState.upgrades.vocalMaturity.unlocked && speechState.failCount >= 5) {
@@ -918,9 +921,10 @@ function checkUnlocks() {
     wordState.targets['Mind'] = { level: 1, xp: 0 };
     addLog('Your awareness turns inward. Target "Mind" unlocked.', 'info');
     const murmurBtn = container.querySelector('#murmurBtn');
-    if (murmurBtn) murmurBtn.textContent = 'Murmur Mind';
+    if (murmurBtn) murmurBtn.remove();
     const idx = speechState.activePhrases.indexOf('Murmur');
-    if (idx >= 0) speechState.activePhrases[idx] = 'Murmur Mind';
+    if (idx >= 0) speechState.activePhrases.splice(idx, 1);
+    if (!speechState.activePhrases.includes('Murmur Mind')) speechState.activePhrases.push('Murmur Mind');
     const spIdx = speechState.savedPhrases.indexOf('Murmur');
     if (spIdx >= 0) speechState.savedPhrases.splice(spIdx, 1);
     if (!speechState.savedPhrases.includes('Murmur Mind')) speechState.savedPhrases.push('Murmur Mind');

--- a/style.css
+++ b/style.css
@@ -4,6 +4,11 @@
     padding: 0;
     margin: 0;
     box-sizing: border-box;
+    scrollbar-width: none;
+}
+
+*::-webkit-scrollbar {
+    display: none;
 }
 
 body {
@@ -1025,12 +1030,12 @@ body {
     /*height: max-content;*/
     width: 100%;
     max-width: 120px;
-    max-height: 120px;
+    max-height: 144px; /* increased for better visibility */
 }
 
 @media (min-width: 1024px) {
     .card-wrapper {
-        max-width: 140px;
+        max-width: 168px; /* scaled up for larger layouts */
         max-height: none;
     }
     .handContainer {
@@ -2534,6 +2539,8 @@ body {
 .phrase-word {
     line-height: 1;
     display: block;
+    font-weight: bold;
+    text-shadow: 0 0 4px #000;
 }
 
 .memory-slots {


### PR DESCRIPTION
## Summary
- adjust card wrapper size so cards are taller
- hide scrollbars globally
- add text shadow to phrase cards
- clear slots after casting a phrase
- drop the Murmur button once Mind is unlocked

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6860a773cda48326ab9da4e186fb6e56