### PR TITLE
Fix phrase casting and adjust UI

### DIFF
--- a/speech.js
+++ b/speech.js
@@ -328,7 +328,7 @@ export function initSpeech() {
   createSlots();
   attachWordListeners();
   const castBtn = container.querySelector('#castPhraseBtn');
-  castBtn.addEventListener('click', castPhrase);
+  castBtn.addEventListener('click', () => castPhrase());
   castBtn.addEventListener('mouseenter', e => {
     const wordsArr = speechState.slots.filter(Boolean);
     if (wordsArr.length < 1) return;

--- a/style.css
+++ b/style.css
@@ -2653,7 +2653,7 @@ body {
 
 .hotbar-phrase {
     font-size: 0.75rem;
-    min-height: 40px;
+    min-height: 60px;
 }
 
 .cast-button {


### PR DESCRIPTION
## Summary
- enlarge phrase cards in the hotbar so they're easier to see
- ensure constructor's Cast button calls `castPhrase` correctly

## Testing
- `npm test` *(fails: `mocha` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860aacff01083269cabe61708ffcda3