### PR TITLE
Fix Murmur removal on Mind unlock

### DIFF
--- a/speech.js
+++ b/speech.js
@@ -925,15 +925,8 @@ function checkUnlocks() {
     addLog('Your awareness turns inward. Target "Mind" unlocked.', 'info');
     const murmurBtn = container.querySelector('#murmurBtn');
     if (murmurBtn) murmurBtn.remove();
-    const idx = speechState.activePhrases.indexOf('Murmur');
-    if (idx >= 0) speechState.activePhrases.splice(idx, 1);
     if (!speechState.activePhrases.includes('Murmur Mind')) speechState.activePhrases.push('Murmur Mind');
-    const spIdx = speechState.savedPhrases.indexOf('Murmur');
-    if (spIdx >= 0) speechState.savedPhrases.splice(spIdx, 1);
     if (!speechState.savedPhrases.includes('Murmur Mind')) speechState.savedPhrases.push('Murmur Mind');
-    const verbIdx = words.verbs.indexOf('Murmur');
-    if (verbIdx >= 0) words.verbs.splice(verbIdx, 1);
-    delete wordState.verbs['Murmur'];
     speechState.capacity += 1;
     renderSlots();
     renderHotbar();


### PR DESCRIPTION
## Summary
- keep `Murmur` verb and related phrases when unlocking Mind

## Testing
- `npm test` *(fails: `mocha` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860bc460d2c8326be0b230524f9a5d9