### PR TITLE
Implement speech side panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -212,10 +212,24 @@
           </div>
         </div>
         <div class="player-speech-panel" style="display:none;">
-          <div id="speechPanel" class="speech-panel"></div>
-          <div id="secondaryResources" class="secondary-resources"></div>
-          <div id="speechGains" class="speech-gains"></div>
-          <div id="speechUpgrades" class="speech-upgrades"></div>
+          <div class="speech-side-panel sidePanel">
+            <div class="vignette resources open">
+              <button class="vignette-toggle">Resources</button>
+              <div class="vignette-content">
+                <div id="secondaryResources" class="secondary-resources"></div>
+              </div>
+            </div>
+            <div class="vignette upgrades">
+              <button class="vignette-toggle">Upgrades</button>
+              <div class="vignette-content">
+                <div id="speechUpgrades" class="speech-upgrades"></div>
+              </div>
+            </div>
+          </div>
+          <div class="speech-main">
+            <div id="speechPanel" class="speech-panel"></div>
+            <div id="speechGains" class="speech-gains"></div>
+          </div>
         </div>
       </div>
     </div>

--- a/style.css
+++ b/style.css
@@ -2224,6 +2224,36 @@ body.darkenshift-mode .tabsContainer button.active {
     padding: 8px;
     box-shadow: 0 0 10px var(--core-glow);
 }
+
+.core-side-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    font-size: 0.8rem;
+    min-width: 160px;
+}
+.speech-side-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    font-size: 0.8rem;
+    min-width: 160px;
+}
+.core-resources, .core-upgrades {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: 4px;
+}
+.core-resources .resource-entry {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+}
+.core-resources .resource-entry i {
+    width: 16px;
+    height: 16px;
+}
 #coreTabContent {
     display: flex;
     flex-direction: column;
@@ -2287,9 +2317,9 @@ body.darkenshift-mode .tabsContainer button.active {
 
 .player-speech-panel {
     display: flex;
-    flex-direction: column;
-    align-items: stretch;
-    gap: 6px;
+    flex-direction: row;
+    align-items: flex-start;
+    gap: 8px;
     flex: 1;
 }
 
@@ -2306,6 +2336,12 @@ body.darkenshift-mode .tabsContainer button.active {
     align-items: center;
     gap: 6px;
     flex: 1;
+}
+.speech-main {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    gap: 6px;
 }
 
 .core-actions {


### PR DESCRIPTION
## Summary
- relocate collapsible resources/upgrades panel to the speech tab
- remove unused core panel resource code
- update resource icon for structure to use brick wall
- style speech panel layout with new side panel

## Testing
- `npm test` *(fails: mocha not found)*
- `npm run lint` *(fails: missing @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_6861373b25ac8326b82bf20d2a389095