### PR TITLE
Refactor codex panel layout

### DIFF
--- a/speech.js
+++ b/speech.js
@@ -211,14 +211,18 @@ function phraseGradient(phrase) {
 function createPhraseCard(phrase) {
   const card = document.createElement('div');
   card.className = 'phrase-card';
-  card.style.background = phraseGradient(phrase);
+  card.style.background = '#111';
   phrase.split(' ').forEach(w => {
     const line = document.createElement('div');
     line.className = 'phrase-word';
     line.textContent = w;
-    line.style.color = '#000';
+    line.style.color = '#eee';
     card.appendChild(line);
   });
+  const bar = document.createElement('div');
+  bar.className = 'phrase-bar';
+  bar.style.background = phraseGradient(phrase);
+  card.appendChild(bar);
   return card;
 }
 
@@ -295,21 +299,23 @@ export function initSpeech() {
         <button id="closeConstructBtn" class="cast-button">❌</button>
       </div>
       <div class="construct-tab constructor-view">
-        <div class="construct-top">
+        <div class="phrase-constructor">
+          <h3 class="section-title">Phrase Constructor</h3>
           <div class="word-list" id="verbList"></div>
           <div class="word-list" id="targetList" style="display:none"></div>
           <div class="word-list" id="modifierList" style="display:none"></div>
           <div class="phrase-slots" id="phraseSlots"></div>
           <div id="capacityDisplay" class="capacity-display"></div>
-          <div class="cast-container">
-            <div class="cast-wrapper">
-              <button id="castPhraseBtn" class="cast-button"><span>Cast</span><div class="cooldown-overlay" style="--cooldown:0; display:none"></div></button>
-              <div id="castCooldownCircle" class="cast-cooldown" style="display:none"><div class="cooldown-overlay" style="--cooldown:0"></div></div>
-            </div>
-            <div id="phraseInfo" class="phrase-info"></div>
+          <div class="cast-wrapper">
+            <button id="castPhraseBtn" class="cast-button"><span>Attempt Creation</span><div class="cooldown-overlay" style="--cooldown:0; display:none"></div></button>
+            <div id="castCooldownCircle" class="cast-cooldown" style="display:none"><div class="cooldown-overlay" style="--cooldown:0"></div></div>
           </div>
         </div>
-        <div class="construct-bottom">
+        <div class="phrase-output">
+          <div id="phraseInfo" class="phrase-info"></div>
+        </div>
+        <div class="built-phrases">
+          <h3 class="section-title">Built Phrases</h3>
           <div id="savedPhraseCards" class="saved-phrases"></div>
           <div id="memorySlotsDisplay" class="memory-slots"></div>
           <div id="phraseDetails" class="phrase-info"></div>

--- a/style.css
+++ b/style.css
@@ -2684,18 +2684,39 @@ body.darkenshift-mode .tabsContainer button.active {
 }
 
 .phrase-card {
+    position: relative;
     display: flex;
     flex-direction: column;
     min-height: 64px;
-    padding: 4px 8px;
+    padding: 4px 8px 8px;
     border: 1px solid #555;
     border-radius: 4px;
     font-size: 1.08rem;
     cursor: pointer;
-    background: #222;
+    background: #111;
+    color: #eee;
 }
 .phrase-card.active {
     box-shadow: 0 0 6px #ffd27d;
+}
+.phrase-card:hover {
+    box-shadow: 0 0 6px #999;
+}
+.phrase-card .phrase-bar {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: 3px;
+    background-size: 200% 100%;
+}
+.phrase-card:hover .phrase-bar {
+    animation: phrase-bar-slide 3s linear infinite;
+}
+
+@keyframes phrase-bar-slide {
+    from { background-position: 0% 0; }
+    to { background-position: 100% 0; }
 }
 
 .phrase-word {
@@ -2803,6 +2824,33 @@ body.darkenshift-mode .tabsContainer button.active {
 .construct-tabs button:hover {
     box-shadow: 0 0 12px rgba(183, 110, 255, 0.8);
     color: #fff4b3;
+}
+
+.phrase-constructor {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 8px;
+}
+
+.phrase-output {
+    border-top: 1px solid #555;
+    background: rgba(255,255,255,0.05);
+    padding: 6px;
+    margin-top: 4px;
+}
+
+.built-phrases {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 6px;
+    overflow-y: auto;
+}
+.built-phrases .saved-phrases {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(80px, 1fr));
+    gap: 6px;
 }
 
 .speech-panel.construct-mode .speech-orbs {


### PR DESCRIPTION
## Summary
- restructure construct panel into vertical sections
- rename `Cast` button to `Attempt Creation`
- update phrase tile style with bottom gradient

## Testing
- `npm test` *(fails: `mocha` not found)*
- `npm install` *(fails: puppeteer download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686140886c6083268d15a465ffe3c731