### PR TITLE
Improve speech construct panel overlay

### DIFF
--- a/speech.js
+++ b/speech.js
@@ -360,8 +360,9 @@ export function initSpeech() {
   }
   const closeBtn = container.querySelector('#closeConstructBtn');
   if (closeBtn) closeBtn.addEventListener('click', toggleConstructPanel);
-  const panel = container.querySelector('#constructPanel');
+  const panel = document.getElementById('constructPanel');
   if (panel) {
+    container.parentElement.appendChild(panel);
     panel.addEventListener('pointerdown', e => {
       if (!panel.classList.contains('open')) return;
       if (e.target.closest('.word-tile')) return;
@@ -735,7 +736,7 @@ function castMurmur() {
 }
 
 function toggleConstructPanel(forceOpen) {
-  const panel = container.querySelector('#constructPanel');
+  const panel = document.getElementById('constructPanel');
   const toggle = container.querySelector('#constructToggle');
   if (!panel) return;
   const isOpen = panel.classList.contains('open');

--- a/style.css
+++ b/style.css
@@ -2346,6 +2346,7 @@ body.darkenshift-mode .tabsContainer button.active {
     flex-direction: column;
     flex: 1;
     gap: 6px;
+    position: relative;
 }
 
 .core-actions {
@@ -2459,10 +2460,11 @@ body.darkenshift-mode .tabsContainer button.active {
     flex-direction: column;
     gap: 8px;
     align-items: center;
-    margin-top: 10px;
+    margin-top: 0;
     position: relative; /* allow floating phrase clouds */
     width: 100%;
     height: 100%;
+    flex: 1;
     overflow: hidden;
     color: #e0e0f0;
     font-family: inherit;
@@ -2752,15 +2754,14 @@ body.darkenshift-mode .tabsContainer button.active {
 
 .construct-panel {
     position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
+    inset: 0;
     margin: 0;
     padding: 8px;
     box-sizing: border-box;
-    background: rgba(0, 0, 0, 0.9);
-    border-right: 1px solid #555;
+    background: linear-gradient(#11131c, #0e0f1a);
+    border: 1px solid #4a4a60;
+    box-shadow: 0 0 8px #7f7fcf;
+    backdrop-filter: blur(4px);
     display: flex;
     flex-direction: column;
     gap: 6px;


### PR DESCRIPTION
## Summary
- have the speech main area allow absolute children
- let the speech panel expand to fill vertical space
- style the construct panel with matte gradient, border, glow and blur
- reposition construct panel so it covers the whole speech tab

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861468c9a708326abb8283bcfce4941