### PR TITLE
Fix speech modal layout

### DIFF
--- a/speech.js
+++ b/speech.js
@@ -381,6 +381,7 @@ export function initSpeech() {
   const constructorView = constructPanel.querySelector('.constructor-view');
   if (constructorView) {
     constructorView.style.display = 'flex';
+    constructorView.style.flexDirection = 'column';
   }
   renderSlots();
   updateCastCooldown();

--- a/style.css
+++ b/style.css
@@ -2239,8 +2239,8 @@ body.darkenshift-mode .tabsContainer button.active {
     gap: 8px;
     font-size: 0.8rem;
     min-width: 160px;
-    flex: 0 0 33%;
-    max-width: 33%;
+    flex: 0 0 25%;
+    max-width: 25%;
     color: var(--core-text);
 }
 .core-resources, .core-upgrades {
@@ -2764,11 +2764,25 @@ body.darkenshift-mode .tabsContainer button.active {
     backdrop-filter: blur(4px);
     display: flex;
     flex-direction: column;
+    height: 100%;
     gap: 6px;
     transform: translateX(100%);
     opacity: 0;
     transition: transform 0.3s ease-out, opacity 0.3s ease-out;
     z-index: 10;
+}
+
+.construct-tab {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+}
+
+.constructor-view {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    overflow-y: auto;
 }
 
 .construct-panel.open {
@@ -2836,6 +2850,8 @@ body.darkenshift-mode .tabsContainer button.active {
     flex-direction: column;
     gap: 6px;
     padding: 8px;
+    flex: 1;
+    overflow-y: auto;
 }
 
 .phrase-output {
@@ -2843,6 +2859,7 @@ body.darkenshift-mode .tabsContainer button.active {
     background: rgba(255,255,255,0.05);
     padding: 6px;
     margin-top: 4px;
+    flex: 0 0 auto;
 }
 
 .built-phrases {
@@ -2851,6 +2868,7 @@ body.darkenshift-mode .tabsContainer button.active {
     gap: 6px;
     padding: 6px;
     overflow-y: auto;
+    flex: 1;
 }
 .built-phrases .saved-phrases {
     display: grid;


### PR DESCRIPTION
## Summary
- shrink speech side panel to 25%
- make speech construct modal fill vertical space
- stack modal elements vertically

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_68615c79a35c83269758094b6bdc3d76