### PR TITLE
Remove start Murmur button and card cleanup

### DIFF
--- a/speech.js
+++ b/speech.js
@@ -290,9 +290,6 @@ export function initSpeech() {
         <div class="speech-xp-bar"><div class="speech-xp-fill"></div></div>
       </div>
     </div>
-    <div class="murmur-controls">
-      <button id="murmurBtn" class="cast-button">Murmur</button>
-    </div>
     <div id="constructToggle" class="construct-toggle" style="display:none">❮</div>
     <div id="phraseHotbar" class="phrase-hotbar"></div>
     <div id="constructPanel" class="construct-panel">
@@ -947,6 +944,10 @@ function checkUnlocks() {
     renderLists();
     renderResources();
     renderSlots();
+    speechState.activePhrases = speechState.activePhrases.filter(p => p !== 'Murmur');
+    speechState.savedPhrases = speechState.savedPhrases.filter(p => p !== 'Murmur');
+    renderHotbar();
+    renderSavedPhraseCards();
     speechState.upgrades.capacityBoost.unlocked = true;
     renderUpgrades();
   }

--- a/style.css
+++ b/style.css
@@ -2669,11 +2669,6 @@ body.darkenshift-mode .tabsContainer button.active {
     align-items: center;
 }
 
-.murmur-controls {
-    display: flex;
-    gap: 6px;
-    justify-content: center;
-}
 
 .phrase-hotbar {
     display: flex;


### PR DESCRIPTION
## Summary
- remove Murmur button from speech panel markup and unused style
- drop "Murmur" card once Form unlock occurs

## Testing
- `npm test` *(fails: mocha not found because Puppeteer download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6861aa59e4648326a6259f0f024f48c5