### PR TITLE
Add speech lexicon tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -204,6 +204,7 @@
           <div class="player-subtabs">
             <button class="playerCoreSubTabButton active">Core</button>
             <button class="playerSpeechSubTabButton">Speech</button>
+            <button class="playerLexiconSubTabButton">Lexicon</button>
           </div>
         </div>
         <div class="player-core-panel">
@@ -230,6 +231,9 @@
             <div id="speechPanel" class="speech-panel"></div>
             <div id="speechGains" class="speech-gains"></div>
           </div>
+        </div>
+        <div class="player-lexicon-panel" style="display:none;">
+          <div id="tagGuide" class="tags-guide"></div>
         </div>
       </div>
     </div>

--- a/script.js
+++ b/script.js
@@ -20,7 +20,7 @@ import {
 import {
   initStarChart
 } from "./starChart.js"; // optional star chart tab
-import { initSpeech, tickSpeech } from "./speech.js";
+import { initSpeech, tickSpeech, renderTagGuide } from "./speech.js";
 import { Jobs, assignJob, getAvailableJobs, renderJobAssignments, renderJobCarousel } from "./jobs.js"; // job definitions
 import RateTracker from "./utils/rateTracker.js";
 import { formatNumber } from "./utils/numberFormat.js";
@@ -421,6 +421,8 @@ let playerCoreSubTabButton;
 let playerCorePanel;
 let playerSpeechSubTabButton;
 let playerSpeechPanel;
+let playerLexiconSubTabButton;
+let playerLexiconPanel;
 let statsOverviewSubTabButton;
 let statsEconomySubTabButton;
 let statsOverviewContainer;
@@ -572,6 +574,8 @@ function initTabs() {
   playerCorePanel = document.querySelector(".player-core-panel");
   playerSpeechSubTabButton = document.querySelector('.playerSpeechSubTabButton');
   playerSpeechPanel = document.querySelector('.player-speech-panel');
+  playerLexiconSubTabButton = document.querySelector('.playerLexiconSubTabButton');
+  playerLexiconPanel = document.querySelector('.player-lexicon-panel');
   statsOverviewSubTabButton = document.querySelector('.statsOverviewSubTabButton');
   statsEconomySubTabButton = document.querySelector('.statsEconomySubTabButton');
   statsOverviewContainer = document.getElementById('statsOverviewContainer');
@@ -625,15 +629,29 @@ function initTabs() {
     playerCoreSubTabButton.addEventListener("click", () => {
       if (playerCorePanel) playerCorePanel.style.display = "flex";
       if (playerSpeechPanel) playerSpeechPanel.style.display = "none";
+      if (playerLexiconPanel) playerLexiconPanel.style.display = 'none';
       playerCoreSubTabButton.classList.add("active");
       if (playerSpeechSubTabButton) playerSpeechSubTabButton.classList.remove("active");
+      if (playerLexiconSubTabButton) playerLexiconSubTabButton.classList.remove('active');
     });
   if (playerSpeechSubTabButton)
     playerSpeechSubTabButton.addEventListener('click', () => {
       if (playerCorePanel) playerCorePanel.style.display = 'none';
       if (playerSpeechPanel) playerSpeechPanel.style.display = 'flex';
+      if (playerLexiconPanel) playerLexiconPanel.style.display = 'none';
       playerSpeechSubTabButton.classList.add('active');
       if (playerCoreSubTabButton) playerCoreSubTabButton.classList.remove('active');
+      if (playerLexiconSubTabButton) playerLexiconSubTabButton.classList.remove('active');
+    });
+  if (playerLexiconSubTabButton)
+    playerLexiconSubTabButton.addEventListener('click', () => {
+      if (playerCorePanel) playerCorePanel.style.display = 'none';
+      if (playerSpeechPanel) playerSpeechPanel.style.display = 'none';
+      if (playerLexiconPanel) playerLexiconPanel.style.display = 'flex';
+      playerLexiconSubTabButton.classList.add('active');
+      if (playerCoreSubTabButton) playerCoreSubTabButton.classList.remove('active');
+      if (playerSpeechSubTabButton) playerSpeechSubTabButton.classList.remove('active');
+      if (typeof renderTagGuide === 'function') renderTagGuide();
     });
   if (statsOverviewSubTabButton)
     statsOverviewSubTabButton.addEventListener('click', () => {

--- a/style.css
+++ b/style.css
@@ -3067,6 +3067,42 @@ body.darkenshift-mode .tabsContainer button.active {
     height: 48px;
 }
 
+.playerLexiconSubTabButton {
+    background: linear-gradient(60deg, #32a852, #145c2c, #32a852);
+    background-size: 200% 100%;
+    border-color: #32a852;
+    box-shadow: 0 0 8px rgba(50, 168, 82, 0.5);
+    color: #e0ffe0;
+}
+.playerLexiconSubTabButton.active {
+    background: #32a852;
+    box-shadow: inset 0 0 8px #fff8c6, 0 0 12px #32a852;
+    color: #220000;
+}
+
+.player-lexicon-panel {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    gap: 6px;
+    padding: 6px;
+    overflow-y: auto;
+}
+
+.tags-guide table {
+    border-collapse: collapse;
+    width: 100%;
+}
+.tags-guide th,
+.tags-guide td {
+    border: 1px solid #888;
+    padding: 4px;
+    font-size: 0.8rem;
+}
+.tags-guide th {
+    background: #222;
+}
+
 .slot-clear {
     margin-left: 4px;
     color: #a44;


### PR DESCRIPTION
## Summary
- add Lexicon subtab next to Speech to show tags and combos
- render table of words and tag rule effects
- style lexicon UI

## Testing
- `npx mocha` *(fails: requires puppeteer download)*

------
https://chatgpt.com/codex/tasks/task_e_6861fbf7eef48326b07b0ef183a59018