### PR TITLE
Unlock Murmur Mind and bump starting capacity

### DIFF
--- a/speech.js
+++ b/speech.js
@@ -27,13 +27,13 @@ export const speechState = {
       costFunc: lvl => ({ structure: 2 * Math.pow(lvl + 1, 2) })
     }
   },
-  capacity: 1,
+  capacity: 10,
   slots: [null],
   memorySlots: 2,
-  activePhrases: ['Murmur'],
+  activePhrases: ['Murmur', 'Murmur Mind'],
   cooldowns: {},
   constructUnlocked: true,
-  savedPhrases: [],
+  savedPhrases: ['Murmur Mind'],
   xp: 0,
   level: 1,
   formUnlocked: false,


### PR DESCRIPTION
## Summary
- increase the Speech system's starting capacity to 10
- start with the `Murmur Mind` phrase available

## Testing
- `npm test` *(fails: `mocha` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68620c4f25e4832690737297dd86c7c5