### PR TITLE
Introduce construct pot mechanic

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Auto-Attack: Activate automated attacks with adjustable speeds, influenced by ca
 Prestige System: Reset progress for long-term benefits, including deck reshuffling, HP refill, and stage resets.
 
 Core Meditation: Mind, Body and Soul orbs fill from Life tab activities. They no longer gain XP from mana, healing or defeats during combat.
-Speech System: Build phrases from verbs and targets to manifest effects (see docs/phrase-system.md).
+Constructs System: Combine resources to craft constructs (see docs/phrase-system.md).
 
 
 Resource Management:

--- a/docs/phrase-system.md
+++ b/docs/phrase-system.md
@@ -1,91 +1,17 @@
-# Codex Phrase Construction System
+# Construct System
 
-This document outlines the updated rules for constructing phrases in the Codex game. It reflects the refined principle:
+The phrase builder has been replaced with a simpler construct mechanic. The **Constructs** tab allows resources to be combined inside a small pot. When a valid recipe is present the *Construct* button crafts a card that can be slotted like the old phrases.
 
-> **Verbs are utterances. Targets (and Modifiers) represent intent and effect.**
-> **Murmur is free expression that grants Speech experience.**
-> **Reality is shaped only once intent is paired with capacity.**
+## Basics
 
----
+- Drag available resources into the pot and press **Construct**.
+- Recipes unlock as requirements are met.
+- Crafted cards appear below the pot and must be equipped to provide their effect.
+- Constructs may generate resources over time or provide buffs that modify production.
 
-## 1. Verb: `Murmur`
+### Starting Construct – Murmur
 
-* **No cooldown**
-* **Consumes:** 5 Insight
-* **Effect:** +1 Speech XP
-* **Unlocked at start**
-
-## 2. Unlock: Construct Reality Panel
-
-* **Unlocked at start**
-* Display the message:
-  > “You feel your words press outward. You may now construct meaning.”
-* Enables a **Construct** button that opens the panel.
-
-## 3. Construct Reality Panel
-
-* Provides an interface to build phrases from unlocked words.
-* Phrase format:
-
-```
-[ VERB ] + [ TARGET ] + ( MODIFIER )
-```
-
-* Capacity counter enforces a maximum total cost. Capacity grows with Speech Level and upgrades.
-* Saving a valid phrase places it on the main hotbar as a clickable button.
-
-### Word Costs
-
-| Type     | Capacity Cost |
-| -------- | ------------- |
-| Verb     | 1             |
-| Target   | 1–3           |
-| Modifier | 1             |
-
-## 4. Phrase Saving Rules
-
-* Requires at least one Verb and one Target.
-* The phrase must fit within current capacity and use only unlocked words.
-* Invalid phrases are blocked from saving.
-
-## 5. Main UI Hotbar
-
-* Saved phrases appear as buttons that consume resources and trigger cooldowns when clicked.
-* Cooldowns apply only to targets or modifiers – verbs like `Murmur` remain free of cooldowns.
-* The number of phrases is unlimited (screen space permitting).
-
-## 6. Example Phrases
-
-### `Murmur + Thinking`
-
-* Capacity: 3
-* Cost: 5 Insight
-* Effect: +3 Thought
-* Cooldown: based on the Thinking target
-
-### `Speak + Form + Accelerated`
-
-* Capacity: 4
-* Cost: 7 Insight, 1 Thought, 1 Body
-* Effect: +3 Structure with faster casting
-* Cooldown: 2s
-
-## Modifier Words
-
-| Modifier | Effect | Orb Cost | Cooldown | Capacity | Potency | Complexity | Unlock Condition |
-| -------- | ------ | -------- | -------- | -------- | ------- | ---------- | ---------------- |
-| Inwardly | Self-target only; small focus boost | −1 total (min 1) | No change | +0 | ×1.1 | +0.5 | Cast any phrase with Self as the target 3 times |
-| Sharply | Doubles output | +2 total | +2s | +1 | ×2 | +1.5 | Cast 3 different phrases with total orb cost ≥ 6 |
-| Persistently | Repeats once after 5 seconds | +1 total | +1s | +1 | ×1 | +1.0 | Cast the same phrase 3 times in a row |
-
-## 7. Speech Level Scaling
-
-| Level | Unlock                              |
-| ----- | ----------------------------------- |
-| 1     | Speech XP bar visible               |
-| 2     | Construct Reality panel             |
-| 3     | +1 Capacity                         |
-| 4     | Unlock Modifier slot                |
-| 5     | Unlock Memory Slot system           |
-| 6     | Unlock new Verb: `Speak`            |
-
+- Unlocked from the start.
+- Costs: 2 Insight
+- Produces: 1 Sound and 1 Voice XP
+- When slotted, Murmur converts Insight into Sound automatically.

--- a/docs/sliding-panel.md
+++ b/docs/sliding-panel.md
@@ -1,6 +1,6 @@
 # Construct Reality Sliding Panel
 
-This document describes the user interface layout and entrance animation for the **Construct Reality** panel. It supplements `phrase-system.md` with guidance for implementing the new freeform phrase builder and animated panel.
+This document describes the user interface layout and entrance animation for the **Construct Reality** panel. It supplements `phrase-system.md` with guidance for the new pot based construct interface.
 
 ---
 
@@ -13,20 +13,12 @@ This document describes the user interface layout and entrance animation for the
   1. **Header**
      * `Construct Reality` title
      * `Close` button (❌)
-  2. **Phrase Builder Row**
-     * Horizontal list where words can be placed in any order
-     * Scrollable if the phrase exceeds the visible width
-  3. **Capacity Meter**
-     * Shows current capacity usage, e.g. `🧠 ▮▮▮▯▯ (3 / 5)`
-  4. **Word Tile Bank**
-     * Grouped subsections for **Verbs**, **Targets**, and **Modifiers**
-     * Clicking a tile adds it to the row; clicking a tile in the row removes it
-  5. **Etched Phrases**
-     * Scrollable list on the right side of the panel displaying saved phrases
-     * Each entry includes an `Equip` or `Cast` button and shows a tooltip with effect details
-  6. **Action Buttons**
-     * `Save Phrase` (enabled only when the phrase is valid)
-     * `Clear Phrase`
+  2. **Construct Pot**
+     * Displays the resources placed inside.
+  3. **Resource Buttons**
+     * Shows each unlocked resource that can be added to the pot.
+  4. **Construct Cards**
+     * Completed constructs appear here and can be slotted for use.
 
 ## Entrance Animation
 

--- a/index.html
+++ b/index.html
@@ -203,7 +203,7 @@
         <div class="player-header">
           <div class="player-subtabs">
             <button class="playerCoreSubTabButton active">Core</button>
-            <button class="playerSpeechSubTabButton">Speech</button>
+            <button class="playerSpeechSubTabButton">Constructs</button>
             <button class="playerLexiconSubTabButton">Lexicon</button>
           </div>
         </div>

--- a/script.js
+++ b/script.js
@@ -20,7 +20,7 @@ import {
 import {
   initStarChart
 } from "./starChart.js"; // optional star chart tab
-import { initSpeech, tickSpeech, renderTagGuide } from "./speech.js";
+import { initSpeech, tickSpeech } from "./speech.js";
 import { Jobs, assignJob, getAvailableJobs, renderJobAssignments, renderJobCarousel } from "./jobs.js"; // job definitions
 import RateTracker from "./utils/rateTracker.js";
 import { formatNumber } from "./utils/numberFormat.js";
@@ -651,7 +651,6 @@ function initTabs() {
       playerLexiconSubTabButton.classList.add('active');
       if (playerCoreSubTabButton) playerCoreSubTabButton.classList.remove('active');
       if (playerSpeechSubTabButton) playerSpeechSubTabButton.classList.remove('active');
-      if (typeof renderTagGuide === 'function') renderTagGuide();
     });
   if (statsOverviewSubTabButton)
     statsOverviewSubTabButton.addEventListener('click', () => {

--- a/style.css
+++ b/style.css
@@ -3114,3 +3114,7 @@ body.darkenshift-mode .tabsContainer button.active {
 .speech-orb#orbInsight .orb-fill {
     background: rgba(0,0,255,0.6);
 }
+
+.construct-pot { text-align:center; font-size:2rem; margin:8px 0; }
+.resource-buttons { display:flex; flex-wrap:wrap; gap:4px; justify-content:center; }
+


### PR DESCRIPTION
## Summary
- rename Speech tab to Constructs in the UI
- document the new construct system
- rework `speech.js` to handle construct crafting via a pot
- adjust sliding panel docs
- restore orbs and upgrades alongside the new pot system

## Testing
- `npm test` *(fails: `mocha` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862c12129088326af5edc37b6cf62a1