### PR TITLE
Ensure Murmur construct is available from start

### DIFF
--- a/speech.js
+++ b/speech.js
@@ -33,8 +33,8 @@ export const speechState = {
   voiceXp: 0,
   voiceLevel: 1,
   memorySlots: 2,
-  activeConstructs: [],
-  savedConstructs: [],
+  activeConstructs: ['Murmur'],
+  savedConstructs: ['Murmur'],
   buffs: {},
   constructUnlocked: true,
   pot: []


### PR DESCRIPTION
## Summary
- unlock the Murmur construct by default so it's visible at game start

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6862d3f1fe608326812b8851ee07c39b