### PR TITLE
Update constructs UI and cooldown logic

### DIFF
--- a/style.css
+++ b/style.css
@@ -866,6 +866,13 @@ body.darkenshift-mode .tabsContainer button.active {
     pointer-events: none;
     border-radius: 50%;
 }
+.phrase-card.onCooldown {
+    pointer-events: none;
+    opacity: 0.6;
+}
+.phrase-card .cooldown-overlay {
+    border-radius: 4px;
+}
 
 .dCard_ability.green {
     background: #d0f0d0;
@@ -1866,6 +1873,9 @@ body.darkenshift-mode .tabsContainer button.active {
     text-shadow: 0 0 8px #fff;
     pointer-events: none;
     animation: cloud-rise 3s ease-out forwards;
+}
+.phrase-card .phrase-cloud {
+    top: 0;
 }
 
 @keyframes cloud-rise {
@@ -2896,6 +2906,7 @@ body.darkenshift-mode .tabsContainer button.active {
     padding: 6px;
     overflow-y: auto;
     flex: 1;
+    align-items: center;
 }
 .built-phrases .saved-phrases {
     display: grid;
@@ -3086,9 +3097,9 @@ body.darkenshift-mode .tabsContainer button.active {
 }
 
 .speech-orb#orbInsight {
-    background: rgba(0,0,255,0.2);
-    border-color: #8888ff;
-    color: #8888ff;
+    background: rgba(127,217,255,0.2);
+    border-color: #7fd9ff;
+    color: #7fd9ff;
 }
 
 .speech-tab-orbs .speech-orb {
@@ -3141,7 +3152,7 @@ body.darkenshift-mode .tabsContainer button.active {
     pointer-events: none;
 }
 .speech-orb#orbInsight .orb-fill {
-    background: rgba(0,0,255,0.6);
+    background: rgba(127,217,255,0.6);
 }
 
 .construct-pot { text-align:center; font-size:2rem; margin:8px 0; }
@@ -3180,6 +3191,23 @@ body.darkenshift-mode .tabsContainer button.active {
 }
 
 .construct-info i {
+    width: 12px;
+    height: 12px;
+}
+
+.construct-icons {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2px;
+    font-size: 0.65rem;
+}
+.construct-icons .icon-row {
+    display: flex;
+    gap: 4px;
+    align-items: center;
+}
+.construct-icons i {
     width: 12px;
     height: 12px;
 }


### PR DESCRIPTION
## Summary
- sync Insight orb color with resource bar
- center construct cards container
- show cooldown overlay on construct cards and disable interaction while on cooldown
- move floating text origin to top of card when constructs are cast
- display resource icons inside construct cards and remove icons from info panel

## Testing
- `npm test --silent` *(fails: mocha not found)*
- `npm run lint --silent` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6862e2d99798832687c7d2a517f334c5