### PR TITLE
Update construct UI alignment and upgrade

### DIFF
--- a/speech.js
+++ b/speech.js
@@ -499,7 +499,7 @@ function renderResources() {
     const header = document.createElement('div');
     header.className = 'resource-text';
     const icon = document.createElement('i');
-    icon.dataset.lucide = 'package';
+    icon.dataset.lucide = resourceIcons[key] || 'package';
     const name = document.createElement('span');
     name.className = 'resource-name';
     name.textContent = key.charAt(0).toUpperCase() + key.slice(1);
@@ -562,7 +562,7 @@ function purchaseUpgrade(name) {
   } else if (name === 'capacityBoost') {
     speechState.memorySlots += 1;
   } else if (name === 'expandMind') {
-    speechState.orbs.insight.max += 10;
+    speechState.orbs.insight.max = Math.round(speechState.orbs.insight.max * 1.15);
   }
   renderUpgrades();
   renderGains();

--- a/style.css
+++ b/style.css
@@ -2901,17 +2901,13 @@ body.darkenshift-mode .tabsContainer button.active {
 
 .built-phrases {
     display: flex;
-    flex-direction: column;
-    gap: 6px;
+    flex-wrap: wrap;
+    gap: 10px;
     padding: 6px;
     overflow-y: auto;
     flex: 1;
-    align-items: center;
-}
-.built-phrases .saved-phrases {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(80px, 1fr));
-    gap: 6px;
+    justify-content: center;
+    align-items: flex-start;
 }
 .construct-panel .phrase-card {
     width: 80px;
@@ -3180,6 +3176,7 @@ body.darkenshift-mode .tabsContainer button.active {
     align-items: center;
     width: 80px;
     gap: 2px;
+    margin: 4px;
 }
 
 .construct-info {


### PR DESCRIPTION
## Summary
- align construct cards in a centered, wrapping row layout
- give cards extra margin for breathing room
- use construct resource icons on resource bars
- make Expand Mind increase max insight by 15%

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862fca7eea48326b26134b37d447c8b