### PR TITLE
Fix construct card alignment

### DIFF
--- a/style.css
+++ b/style.css
@@ -2907,7 +2907,7 @@ body.darkenshift-mode .tabsContainer button.active {
     overflow-y: auto;
     flex: 1;
     justify-content: center;
-    align-items: flex-start;
+    align-items: center;
 }
 .construct-panel .phrase-card {
     width: 80px;


### PR DESCRIPTION
## Summary
- center constructs in the speech construct panel

## Testing
- `npm test` *(fails: mocha not found)*
- `npm install` *(fails: puppeteer download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686333df72688326aeecd653b5940430