### PR TITLE
Fix construct tab layout and naming

### DIFF
--- a/index.html
+++ b/index.html
@@ -202,17 +202,17 @@
       <div class="playerMainContainer">
         <div class="player-header">
           <div class="player-subtabs">
-            <button class="playerCoreSubTabButton active">Core</button>
-            <button class="playerSpeechSubTabButton">Constructs</button>
+            <button class="playerSpeechSubTabButton active">Construct Tab</button>
+            <button class="playerCoreSubTabButton">Core</button>
             <button class="playerLexiconSubTabButton">Lexicon</button>
           </div>
         </div>
-        <div class="player-core-panel">
+        <div class="player-core-panel" style="display:none;">
           <div class="core-main">
             <div id="coreTabContent"></div>
           </div>
         </div>
-        <div class="player-speech-panel" style="display:none;">
+        <div class="player-speech-panel">
           <div class="speech-side-panel sidePanel">
             <div class="vignette resources open">
               <button class="vignette-toggle">Resources</button>

--- a/script.js
+++ b/script.js
@@ -489,6 +489,7 @@ function setupTabHandlers() {
         refreshCore();
         showTab(playerTab);
         setActiveTabButton(playerTabButton);
+        if (playerSpeechSubTabButton) playerSpeechSubTabButton.click();
       }
     },
     {

--- a/speech.js
+++ b/speech.js
@@ -196,9 +196,10 @@ export function initSpeech() {
       </div>
     </div>
     <div id="constructToggle" class="construct-toggle">❮</div>
-    <div id="constructHotbar" class="phrase-hotbar"></div>
-    <div id="constructPanel" class="construct-panel">
+    <div id="constructHotbar" class="construct-hotbar"></div>
+    <div id="modalConstructorPanel" class="modal-constructor-panel">
       <div class="construct-header">
+        <span class="construct-title">Modal Panel Constructor</span>
         <button id="closeConstructBtn" class="cast-button">❌</button>
       </div>
       <div class="construct-tab constructor-view">
@@ -206,11 +207,11 @@ export function initSpeech() {
         <div id="resourceButtons" class="resource-buttons"></div>
         <button id="performConstruct" class="cast-button construct-button">Construct</button>
         <div id="memorySlotsDisplay" class="memory-slots"></div>
-        <div id="constructCards" class="built-phrases"></div>
+        <div id="constructCards" class="built-constructs"></div>
       </div>
     </div>
   `;
-  panel = container.querySelector('#constructPanel');
+  panel = container.querySelector('#modalConstructorPanel');
   container.querySelector('#constructToggle').addEventListener('click', togglePanel);
   panel.querySelector('#closeConstructBtn').addEventListener('click', togglePanel);
   panel.querySelector('#performConstruct').addEventListener('click', performConstruct);
@@ -346,10 +347,10 @@ function renderConstructCards() {
 
 function createConstructCard(name) {
   const card = document.createElement('div');
-  card.className = 'phrase-card';
+  card.className = 'construct-card';
   card.dataset.name = name;
   const title = document.createElement('div');
-  title.className = 'phrase-word';
+  title.className = 'construct-name';
   title.textContent = name;
   card.appendChild(title);
   const recipe = recipes.find(r => r.name === name);
@@ -427,7 +428,7 @@ function castConstruct(name, el) {
     if (r) r.current = Math.min(r.max, r.current + amt);
   }
   speechState.voiceXp += def.xp || 0;
-  showPhraseCloud(name, el);
+  showConstructCloud(name, el);
   if (def.duration) {
     speechState.activeBuffs[name] = def.duration;
   } else {
@@ -448,7 +449,7 @@ function renderHotbar() {
   bar.innerHTML = '';
   speechState.activeConstructs.forEach(c => {
     const card = createConstructCard(c);
-    card.classList.add('hotbar-phrase');
+    card.classList.add('hotbar-construct');
     card.addEventListener('click', () => castConstruct(c, card));
     bar.appendChild(card);
   });
@@ -643,7 +644,7 @@ function tickActiveConstructs(dt) {
 
 function updateCooldownOverlays() {
   if (!container) return;
-  const cards = container.querySelectorAll('.phrase-card[data-name]');
+  const cards = container.querySelectorAll('.construct-card[data-name]');
   cards.forEach(card => {
     const name = card.dataset.name;
     const def = recipes.find(r => r.name === name);
@@ -682,10 +683,10 @@ export function tickSpeech(delta) {
   renderXpBar();
 }
 
-function showPhraseCloud(text, target) {
+function showConstructCloud(text, target) {
   if (!container) return;
   const el = document.createElement('div');
-  el.className = 'phrase-cloud';
+  el.className = 'construct-cloud';
   el.textContent = text;
   const parent = target || container;
   parent.appendChild(el);

--- a/style.css
+++ b/style.css
@@ -154,6 +154,7 @@ body.darkenshift-mode .tabsContainer button.active {
     display: inline-flex;
     align-items: center;
     justify-content: center;
+    text-align: center;
 
 }
 .imaginary-subtabs button:hover {
@@ -866,11 +867,11 @@ body.darkenshift-mode .tabsContainer button.active {
     pointer-events: none;
     border-radius: 50%;
 }
-.phrase-card.onCooldown {
+.construct-card.onCooldown {
     pointer-events: none;
     opacity: 0.6;
 }
-.phrase-card .cooldown-overlay {
+.construct-card .cooldown-overlay {
     border-radius: 4px;
 }
 
@@ -1504,6 +1505,7 @@ body.darkenshift-mode .tabsContainer button.active {
     text-shadow: 0 0 6px #000;
     box-shadow: 0 0 8px rgba(212, 175, 55, 0.5);
     transition: all 0.2s;
+    text-align: center;
 }
 .upgrade-subtabs button:hover {
     box-shadow: 0 0 12px rgba(212, 175, 55, 0.8);
@@ -1861,8 +1863,8 @@ body.darkenshift-mode .tabsContainer button.active {
     animation: fogFade 7s ease-in-out;
 }
 
-/* Floating phrase effect */
-.phrase-cloud {
+/* Floating construct effect */
+.construct-cloud {
     position: absolute;
     left: 50%;
     top: 40%;
@@ -1874,7 +1876,7 @@ body.darkenshift-mode .tabsContainer button.active {
     pointer-events: none;
     animation: cloud-rise 3s ease-out forwards;
 }
-.phrase-card .phrase-cloud {
+.construct-card .construct-cloud {
     top: 0;
 }
 
@@ -2144,6 +2146,7 @@ body.darkenshift-mode .tabsContainer button.active {
     transition: all 0.2s;
     color: #e0d0ff;
     background: #4b0082;
+    text-align: center;
 }
 .player-subtabs button.active {
     background: #b76eff;
@@ -2179,6 +2182,7 @@ body.darkenshift-mode .tabsContainer button.active {
     color: #e0d0ff;
     text-shadow: 0 0 6px #000;
     transition: all 0.2s;
+    text-align: center;
 }
 
 .stats-subtabs button.active {
@@ -2473,7 +2477,7 @@ body.darkenshift-mode .tabsContainer button.active {
     gap: 8px;
     align-items: center;
     margin-top: 0;
-    position: relative; /* allow floating phrase clouds */
+    position: relative; /* allow floating construct clouds */
     width: 100%;
     height: 100%;
     flex: 1;
@@ -2712,24 +2716,25 @@ body.darkenshift-mode .tabsContainer button.active {
 }
 
 
-.phrase-hotbar {
+.construct-hotbar {
     display: flex;
     gap: 6px;
     flex-wrap: wrap;
     justify-content: center;
 }
 
-.saved-phrases {
+.saved-constructs {
     display: flex;
     gap: 4px;
     flex-wrap: wrap;
     justify-content: center;
 }
 
-.phrase-card {
+.construct-card {
     position: relative;
     display: flex;
     flex-direction: column;
+    align-items: center;
     min-height: 64px;
     padding: 4px 8px 8px;
     border: 1px solid #555;
@@ -2739,13 +2744,13 @@ body.darkenshift-mode .tabsContainer button.active {
     background: #111;
     color: #eee;
 }
-.phrase-card.active {
+.construct-card.active {
     box-shadow: 0 0 6px #ffd27d;
 }
-.phrase-card:hover {
+.construct-card:hover {
     box-shadow: 0 0 6px #999;
 }
-.phrase-card .phrase-bar {
+.construct-card .construct-bar {
     position: absolute;
     bottom: 0;
     left: 0;
@@ -2753,20 +2758,21 @@ body.darkenshift-mode .tabsContainer button.active {
     height: 3px;
     background-size: 200% 100%;
 }
-.phrase-card:hover .phrase-bar {
-    animation: phrase-bar-slide 3s linear infinite;
+.construct-card:hover .construct-bar {
+    animation: construct-bar-slide 3s linear infinite;
 }
 
-@keyframes phrase-bar-slide {
+@keyframes construct-bar-slide {
     from { background-position: 0% 0; }
     to { background-position: 100% 0; }
 }
 
-.phrase-word {
+.construct-name {
     line-height: 1;
     display: block;
     font-weight: bold;
     text-shadow: 0 0 4px #000;
+    text-align: center;
 }
 
 .memory-slots {
@@ -2789,7 +2795,7 @@ body.darkenshift-mode .tabsContainer button.active {
     box-shadow: 0 0 4px #88f;
 }
 
-.construct-panel {
+.modal-constructor-panel {
     position: absolute;
     inset: 0;
     margin: 0;
@@ -2822,12 +2828,24 @@ body.darkenshift-mode .tabsContainer button.active {
     overflow-y: auto;
 }
 
-.construct-panel.open {
+.construct-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.construct-title {
+    font-weight: bold;
+    text-align: center;
+    flex: 1;
+}
+
+.modal-constructor-panel.open {
     transform: translateX(0);
     opacity: 1;
 }
 
-.construct-panel.close-right {
+.modal-constructor-panel.close-right {
     transform: translateX(100%);
 }
 
@@ -2899,7 +2917,7 @@ body.darkenshift-mode .tabsContainer button.active {
     flex: 0 0 auto;
 }
 
-.built-phrases {
+.built-constructs {
     display: flex;
     flex-wrap: wrap;
     gap: 10px;
@@ -2907,9 +2925,9 @@ body.darkenshift-mode .tabsContainer button.active {
     overflow-y: auto;
     flex: 1;
     justify-content: center;
-    align-items: flex-start;
+    align-items: center;
 }
-.construct-panel .phrase-card {
+.modal-constructor-panel .construct-card {
     width: 80px;
 }
 
@@ -2921,7 +2939,7 @@ body.darkenshift-mode .tabsContainer button.active {
     transform: none;
 }
 
-.hotbar-phrase {
+.hotbar-construct {
     font-size: 0.75rem;
     min-height: 60px;
 }


### PR DESCRIPTION
## Summary
- rename construct panel to "modal panel constructor"
- rename phrase classes to construct equivalents
- center construct card text
- default Real tab to construct view
- ensure tab button text centers

## Testing
- `npm test` *(fails: mocha not found)*
- `npm install` *(fails: puppeteer download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686333df72688326aeecd653b5940430