### PR TITLE
Implement skill based XP and upgrade feedback

### DIFF
--- a/docs/phrase-system.md
+++ b/docs/phrase-system.md
@@ -21,9 +21,9 @@ The phrase builder has been replaced with a simpler construct mechanic. The **Co
 | Invocation           | Recipe (to Discover)      | Cost to Use           | Cooldown | Type        | Effect Summary                                        |
 | -------------------- | ------------------------- | --------------------- | -------- | ----------- | ----------------------------------------------------- |
 | **Murmur**           | —                         | 25 Insight            | 0s       | Generator   | +1 Sound, +1 Voice XP                                 |
-| **Echo of Mind**     | Sound + Insight           | 4 Insight             | 5s       | Generator   | +1 Thought over 5s (decaying) *(Requires Voice Lv.3 to use)* |
+| **Echo of Mind**     | Sound + Insight           | 4 Insight             | 5s       | Generator   | +1 Thought over 5s (decaying) *(Requires Voice Lv.3 and 1500 Insight to use)* |
 | **Clarity Pulse**    | Thought + Insight         | 2 Insight + 1 Thought | 30s      | Buff        | +1% Sound & Insight regen/sec for 30s                 |
 | **Symbol Seed**      | Sound + Thought           | 2 Sound + 2 Thought   | 10s      | Generator   | After 10s of draining, produces +1 Structure          |
 | **Mental Construct** | Thought + Insight + Sound | 30 Insight + 5 Sound  | 60s      | Buff        | Auto-cast any construct in slots for 60 seconds if possible, checking each second |
 
-*Crafting **Echo of Mind** additionally requires accumulating 1500 Insight and reaching Voice Level 3.*
+*Using **Echo of Mind** now requires accumulating 1500 Insight in addition to reaching Voice Level 3.*

--- a/style.css
+++ b/style.css
@@ -3025,6 +3025,12 @@ body.darkenshift-mode .tabsContainer button.active {
     width: 12px;
     height: 12px;
 }
+.speech-upgrades .cost-missing {
+    color: #ff6b6b;
+}
+.speech-upgrades button.unaffordable {
+    opacity: 0.6;
+}
 .speech-upgrades .upg-info {
     display: flex;
     gap: 4px;


### PR DESCRIPTION
## Summary
- add skills system with `voice` and `mind`
- award XP based on tags and unlock extra slot at Mind Lv1
- show missing upgrade resources in red
- require 1500 Insight to use Echo of Mind
- document new Echo of Mind requirement

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_686466344be48326b410bbbc6e564505