### PR TITLE
Implement disciple calling and potency system

### DIFF
--- a/docs/phrase-system.md
+++ b/docs/phrase-system.md
@@ -8,6 +8,7 @@ The phrase builder has been replaced with a simpler construct mechanic. The **Co
 - Recipes unlock as requirements are met.
 - Crafted cards appear below the pot and must be equipped to provide their effect.
 - Constructs may generate resources over time or provide buffs that modify production.
+- Each construct has a **Potency** starting at 1.0. Voice level-ups increase all potencies by 5%.
 
 ### Starting Construct – Murmur
 
@@ -15,6 +16,7 @@ The phrase builder has been replaced with a simpler construct mechanic. The **Co
 - Costs: 25 Insight
 - Produces: 1 Sound and 1 Voice XP
 - When slotted, Murmur converts Insight into Sound automatically.
+- Your Sound resource can hold up to 200.
 
 ### Invocation Summary
 
@@ -25,5 +27,7 @@ The phrase builder has been replaced with a simpler construct mechanic. The **Co
 | **Clarity Pulse**    | Thought + Insight         | 2 Insight + 1 Thought | 30s      | Buff        | +1% Sound & Insight regen/sec for 30s                 |
 | **Symbol Seed**      | Sound + Thought           | 2 Sound + 2 Thought   | 10s      | Generator   | After 10s of draining, produces +1 Structure          |
 | **Mental Construct** | Thought + Insight + Sound | 30 Insight + 5 Sound  | 60s      | Buff        | Auto-cast any construct in slots for 60 seconds if possible, checking each second |
+| **Calling**         | —                         | 200 Sound            | 5m       | Action      | Attempts to recruit a Disciple based on Calling potency |
 
 *Using **Echo of Mind** now requires accumulating 1500 Insight in addition to reaching Voice Level 3.*
+*Voice skill levels follow an exponential XP curve starting at 50 XP with a 1.2× increase per level.*


### PR DESCRIPTION
## Summary
- add potency tracking for constructs and disciple system
- implement exponential skill progression and voice level bonuses
- add Calling construct to recruit disciples
- raise Sound capacity to 200
- document new potency and Calling construct

## Testing
- `npm test` *(fails: mocha not found)*
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_6865bccaa988832683b36c02d670c78c