### PR TITLE
Save lifecore state and update Calling construct

### DIFF
--- a/script.js
+++ b/script.js
@@ -165,6 +165,8 @@ const sectState = {
   taskTimers: { gatherFruits: 0 }
 };
 
+const lifeCore = { real: false };
+
 const barUpgrades = {
   damage: { level: 0, progress: 0, points: 0, multiplier: 1 },
   maxHp: { level: 0, progress: 0, points: 0, multiplier: 1 }
@@ -2617,7 +2619,8 @@ Object.entries(upgrades).map(([k, u]) => [k, u.unlocked])
     unlockedJokers: unlockedJokers.map(j => j.id),
     playerStats,
     worldProgress,
-    barUpgrades
+    barUpgrades,
+    lifeCore
   };
 
 try {
@@ -2651,6 +2654,10 @@ Object.assign(playerStats, state.playerStats || {});
       if (!worldProgress[id]) worldProgress[id] = data;
       else Object.assign(worldProgress[id], data);
     });
+  }
+
+  if (state.lifeCore) {
+    Object.assign(lifeCore, state.lifeCore);
   }
 
   if (state.barUpgrades) {

--- a/speech.js
+++ b/speech.js
@@ -128,11 +128,12 @@ const recipes = [
   },
   {
     name: 'Calling',
-    input: { sound: 200 },
+    input: { sound: 100 },
     output: {},
     xp: 0,
     tags: ['voice'],
-    unlocked: true,
+    unlocked: false,
+    requirements: { sound: 100 },
     cooldown: 300
   }
 ];
@@ -940,6 +941,12 @@ export function tickSpeech(delta) {
   if (!speechState.upgrades.clarividence.unlocked && ins.current >= 50) {
     speechState.upgrades.clarividence.unlocked = true;
     renderUpgrades();
+  }
+  const call = recipes.find(r => r.name === 'Calling');
+  if (call && !call.unlocked && speechState.resources.sound.current >= 100) {
+    call.unlocked = true;
+    addLog('Calling construct unlocked!', 'info');
+    renderConstructCards();
   }
   tickActiveConstructs(dt);
   updateCooldownOverlays();


### PR DESCRIPTION
## Summary
- track new `lifeCore` object with `real` flag
- persist `lifeCore` in save data
- require only 100 sound for `Calling` construct and unlock it dynamically

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865cd3b8d288326978fd910dfbfb6c8