### PR TITLE
Fix calling construct unlock

### DIFF
--- a/speech.js
+++ b/speech.js
@@ -946,7 +946,7 @@ export function tickSpeech(delta) {
   if (call && !call.unlocked && speechState.resources.sound.current >= 100) {
     call.unlocked = true;
     addLog('Calling construct unlocked!', 'info');
-    renderConstructCards();
+    addConstruct('Calling');
   }
   tickActiveConstructs(dt);
   updateCooldownOverlays();


### PR DESCRIPTION
## Summary
- ensure the Calling recipe is added to saved constructs when unlocked

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6865d81a8ff08326b693b527079af8e7