### PR TITLE
Adjust sect task layout and disciple movement

### DIFF
--- a/script.js
+++ b/script.js
@@ -672,6 +672,7 @@ function initTabs() {
       if (sectTabUnlocked) {
         if (playerSectPanel) playerSectPanel.style.display = 'flex';
         if (playerLexiconPanel) playerLexiconPanel.style.display = 'none';
+        startDiscipleMovement();
       } else {
         if (playerLexiconPanel) playerLexiconPanel.style.display = 'flex';
         if (playerSectPanel) playerSectPanel.style.display = 'none';

--- a/style.css
+++ b/style.css
@@ -3205,6 +3205,7 @@ body.darkenshift-mode .tabsContainer button.active {
     display: flex;
     flex-direction: column;
     gap: 6px;
+    align-items: flex-start;
 }
 .sect-disciples {
     text-align: center;
@@ -3266,7 +3267,13 @@ body.darkenshift-mode .tabsContainer button.active {
     padding: 4px;
 }
 .sect-task button {
-    margin-left: auto;
+    margin-left: 0;
+    background: #2e7d32;
+    color: #fff;
+}
+#sectTaskPanel .sect-task {
+    width: 20%;
+    font-size: 0.75rem;
 }
 .sect-task .task-icon {
     width: 16px;


### PR DESCRIPTION
## Summary
- ensure disciple movement restarts when Sect panel is opened
- left-align and narrow the sect task panel
- style the gather fruit button green

## Testing
- `npm test` *(fails: `mocha` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865e4e7513883268553dd2cc432c06a