### PR TITLE
Fix upgrade cost load

### DIFF
--- a/script.js
+++ b/script.js
@@ -2714,7 +2714,17 @@ Object.assign(playerStats, state.playerStats || {});
   }
 
   if (state.speechState) {
-    Object.assign(speechState, state.speechState);
+    const { upgrades: savedUpgrades, ...restSpeech } = state.speechState;
+    Object.assign(speechState, restSpeech);
+    if (savedUpgrades) {
+      Object.entries(savedUpgrades).forEach(([name, data]) => {
+        if (speechState.upgrades[name]) {
+          Object.assign(speechState.upgrades[name], data);
+        } else {
+          speechState.upgrades[name] = data;
+        }
+      });
+    }
   }
 
   if (state.sectState) {


### PR DESCRIPTION
## Summary
- fix speech upgrade cost calculation after loading saves

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6865e8591d0c83268464db6732b58bab