### PR TITLE
Fix sect state persistence

### DIFF
--- a/script.js
+++ b/script.js
@@ -2673,7 +2673,8 @@ Object.entries(upgrades).map(([k, u]) => [k, u.unlocked])
     barUpgrades,
     lifeCore,
     speechState,
-    sectState
+    sectState,
+    sectTabUnlocked
   };
 
 try {
@@ -2729,6 +2730,12 @@ Object.assign(playerStats, state.playerStats || {});
 
   if (state.sectState) {
     Object.assign(sectState, state.sectState);
+  }
+
+  if (state.sectTabUnlocked ||
+      (speechState.disciples && speechState.disciples.length > 0)) {
+    sectTabUnlocked = true;
+    if (playerLexiconSubTabButton) playerLexiconSubTabButton.textContent = 'Sect';
   }
 
   if (state.barUpgrades) {


### PR DESCRIPTION
## Summary
- persist `sectTabUnlocked` on save
- restore it on load so disciples appear and move after reload

## Testing
- `npm install` *(fails: puppeteer can't download due to network restrictions)*
- `npm test` *(fails: mocha not found because install failed)*

------
https://chatgpt.com/codex/tasks/task_e_6865ece078088326960a0a11d6ec85de