### PR TITLE
Improve Sect tab visuals and controls

### DIFF
--- a/script.js
+++ b/script.js
@@ -918,14 +918,14 @@ function updateSectDisplay() {
     icon.style.color = 'green';
     row.appendChild(icon);
     const info = document.createElement('div');
-    info.innerHTML = '<strong>Gather Fruit</strong><br><em>Fruits of the wild void, nourishing the thought-body. Without them, your disciples will fade.</em>';
+    info.textContent = 'Gather Fruit';
     row.appendChild(info);
     const assignedLabel = document.createElement('div');
     assignedLabel.textContent = `Assigned: ${assigned}`;
     row.appendChild(assignedLabel);
-    const btn = document.createElement('button');
-    btn.textContent = 'Assign to Gather Fruits';
-    btn.addEventListener('click', () => {
+    const addBtn = document.createElement('button');
+    addBtn.textContent = 'Add Disciple';
+    addBtn.addEventListener('click', () => {
       const total = speechState.disciples.length;
       const assigned = sectState.disciplesAssigned.gatherFruits;
       if (assigned < total) {
@@ -933,7 +933,18 @@ function updateSectDisplay() {
         updateSectDisplay();
       }
     });
-    row.appendChild(btn);
+    row.appendChild(addBtn);
+
+    const removeBtn = document.createElement('button');
+    removeBtn.textContent = 'Remove Disciple';
+    removeBtn.addEventListener('click', () => {
+      const assigned = sectState.disciplesAssigned.gatherFruits;
+      if (assigned > 0) {
+        sectState.disciplesAssigned.gatherFruits -= 1;
+        updateSectDisplay();
+      }
+    });
+    row.appendChild(removeBtn);
     const fruits = document.createElement('div');
     fruits.textContent = `Fruits: ${sectState.fruits}`;
     row.appendChild(fruits);

--- a/style.css
+++ b/style.css
@@ -3217,8 +3217,8 @@ body.darkenshift-mode .tabsContainer button.active {
 }
 .disciple-orb {
     position: absolute;
-    width: 12px;
-    height: 12px;
+    width: 16px;
+    height: 16px;
     border-radius: 50%;
     background: rgba(255, 255, 255, 0.9);
     box-shadow: 0 0 6px rgba(255, 255, 255, 0.9);
@@ -3226,8 +3226,8 @@ body.darkenshift-mode .tabsContainer button.active {
 }
 .sect-orb {
     position: absolute;
-    width: 30px;
-    height: 30px;
+    width: 50px;
+    height: 50px;
     border-radius: 50%;
     opacity: 0.9;
     box-shadow: 0 0 6px rgba(255, 255, 255, 0.8);
@@ -3270,6 +3270,7 @@ body.darkenshift-mode .tabsContainer button.active {
     margin-left: 0;
     background: #2e7d32;
     color: #fff;
+    width: 100%;
 }
 #sectTaskPanel .sect-task {
     width: 20%;


### PR DESCRIPTION
## Summary
- enlarge orb visuals in the Sect tab
- widen task buttons and remove gather fruit flavor text
- allow adding and removing disciples

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6865ee992814832680077fb1e2455876