### PR TITLE
Improve construct card layout

### DIFF
--- a/speech.js
+++ b/speech.js
@@ -541,14 +541,32 @@ function createConstructInfo(name) {
   if (!recipe) return null;
   const info = document.createElement('div');
   info.className = 'construct-info';
-  const effect = document.createElement('div');
-  effect.className = 'construct-effect';
-  effect.textContent = `${Object.entries(recipe.output).map(([k,v]) => `${v} ${k}`).join(', ')}`;
+  if (Object.keys(recipe.output).length) {
+    const effect = document.createElement('div');
+    effect.className = 'construct-effect';
+    effect.textContent = `Effect: ${Object.entries(recipe.output)
+      .map(([k, v]) => `+${v} ${k}`)
+      .join(', ')}`;
+    info.appendChild(effect);
+  }
   const cost = document.createElement('div');
   cost.className = 'construct-cost';
-  cost.textContent = `${Object.entries(recipe.input).map(([k,v]) => `${v} ${k}`).join(', ')}`;
-  info.appendChild(effect);
+  cost.textContent = `Cost: ${Object.entries(recipe.input)
+    .map(([k, v]) => `${v} ${k}`)
+    .join(', ')}`;
   info.appendChild(cost);
+  if (recipe.duration) {
+    const dur = document.createElement('div');
+    dur.className = 'construct-duration';
+    dur.textContent = `Duration: ${recipe.duration}s`;
+    info.appendChild(dur);
+  }
+  if (recipe.cooldown) {
+    const cd = document.createElement('div');
+    cd.className = 'construct-cooldown';
+    cd.textContent = `Cooldown: ${recipe.cooldown}s`;
+    info.appendChild(cd);
+  }
   return info;
 }
 

--- a/style.css
+++ b/style.css
@@ -2930,7 +2930,7 @@ body.darkenshift-mode .tabsContainer button.active {
 .built-constructs {
     display: flex;
     flex-wrap: wrap;
-    gap: 10px;
+    gap: 15px;
     padding: 6px;
     margin-top: 6px;
     overflow-y: auto;
@@ -3324,14 +3324,19 @@ body.darkenshift-mode .tabsContainer button.active {
     font-size: 0.55rem;
     text-align: center;
 }
+.construct-duration,
+.construct-cooldown {
+    font-size: 0.55rem;
+    text-align: center;
+}
 
 .construct-card-wrapper {
     display: flex;
     flex-direction: column;
     align-items: center;
-    width: 60px;
-    gap: 2px;
-    margin: 4px;
+    width: 80px;
+    gap: 4px;
+    margin: 8px;
 }
 
 .cooldown-timer {


### PR DESCRIPTION
## Summary
- make construct cards in speech panel easier to read
- center them with more space between
- show effect, cost, duration, and cooldown below each card

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865f2f2019c8326a08b309008ea9d85