### PR TITLE
Improve sect disciple visibility

### DIFF
--- a/script.js
+++ b/script.js
@@ -956,8 +956,10 @@ function updateSectDisplay() {
 function moveDisciple(el) {
   const cont = el.parentElement;
   if (!cont) return;
-  const x = Math.random() * (cont.clientWidth - 20);
-  const y = Math.random() * (cont.clientHeight - 20);
+  const maxX = Math.max(cont.clientWidth - 20, 0);
+  const maxY = Math.max(cont.clientHeight - 20, 0);
+  const x = Math.random() * maxX;
+  const y = Math.random() * maxY;
   el.style.transform = `translate(${x}px, ${y}px)`;
 }
 

--- a/style.css
+++ b/style.css
@@ -3247,10 +3247,13 @@ body.darkenshift-mode .tabsContainer button.active {
 }
 .sect-disciple {
     position: absolute;
+    left: 0;
+    top: 0;
     width: 16px;
     height: 16px;
     border-radius: 50%;
     background: rgba(255, 255, 255, 0.9);
+    box-shadow: 0 0 8px rgba(255, 255, 255, 0.9);
     color: #000;
     display: flex;
     align-items: center;


### PR DESCRIPTION
## Summary
- clamp disciple movement to container bounds and set initial position
- ensure sect disciple elements start at top-left

## Testing
- `npm test` *(fails: `mocha: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6865f13eab048326acc9b55d210ba2bb