### PR TITLE
Improve mobile sect view

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
   <script src="https://unpkg.com/lucide@latest"></script>
   <title>Page Title</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <script src="pixi.min.js"></script>
 
   <!-- And the GlowFilter plugin: -->

--- a/script.js
+++ b/script.js
@@ -889,11 +889,18 @@ function updateSectDisplay() {
   const orbs = document.getElementById('sectOrbs');
   if (orbs) {
     orbs.innerHTML = '';
-    const positions = [
-      { cls: 'insight', left: '50%', top: '5%' },
-      { cls: 'body', left: '15%', top: '70%' },
-      { cls: 'will', left: '85%', top: '70%' }
-    ];
+    const mobile = window.innerWidth <= 600;
+    const positions = mobile
+      ? [
+          { cls: 'insight', left: '50%', top: '10%' },
+          { cls: 'body', left: '20%', top: '70%' },
+          { cls: 'will', left: '80%', top: '70%' }
+        ]
+      : [
+          { cls: 'insight', left: '50%', top: '5%' },
+          { cls: 'body', left: '15%', top: '70%' },
+          { cls: 'will', left: '85%', top: '70%' }
+        ];
     positions.forEach(p => {
       const orb = document.createElement('div');
       orb.className = `sect-orb ${p.cls}`;
@@ -980,10 +987,30 @@ function moveDisciple(el) {
   el.style.transform = `translate(${x}px, ${y}px)`;
 }
 
+function moveDiscipleGather(el) {
+  const cont = el.parentElement;
+  if (!cont) return;
+  const gatherX = Math.random() * Math.max(cont.clientWidth - 20, 0);
+  const gatherY = Math.random() * Math.max(cont.clientHeight - 40, 0) * 0.5;
+  el.style.transform = `translate(${gatherX}px, ${gatherY}px)`;
+  setTimeout(() => {
+    const basket = document.getElementById('sectBasket');
+    if (!basket) return;
+    const bx = basket.offsetLeft + basket.offsetWidth / 2 - 8;
+    const by = basket.offsetTop + basket.offsetHeight / 2 - 8;
+    el.style.transform = `translate(${bx}px, ${by}px)`;
+  }, 1500);
+}
+
 function startDiscipleMovement() {
   if (discipleMoveInterval) return;
   discipleMoveInterval = setInterval(() => {
-    Object.values(sectDiscipleEls).forEach(moveDisciple);
+    const assigned = sectState.disciplesAssigned.gatherFruits;
+    speechState.disciples.forEach((d, idx) => {
+      const el = sectDiscipleEls[d.id];
+      if (!el) return;
+      if (idx < assigned) moveDiscipleGather(el); else moveDisciple(el);
+    });
   }, 3000);
 }
 

--- a/style.css
+++ b/style.css
@@ -3425,3 +3425,11 @@ body.darkenshift-mode .tabsContainer button.active {
 .season-banner.winter { background: #3399ff; }
 .season-banner .weather-icon { margin-left: 4px; }
 
+/* Mobile adjustments */
+@media (max-width: 600px) {
+  .sect-orb { width: 30px; height: 30px; }
+  .disciple-orb { width: 12px; height: 12px; }
+  .sect-disciple { width: 12px; height: 12px; font-size: 8px; }
+  .sect-basket { width: 20px; height: 15px; }
+  #sectTaskPanel .sect-task { width: 100%; flex-direction: column; gap: 4px; }
+}


### PR DESCRIPTION
## Summary
- add viewport meta tag for proper scaling
- add mobile CSS rules to scale orbs, basket, disciples, and tasks
- adjust orb positions on mobile
- animate disciples to gather fruits and return to the basket

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68667083be34832694784558369dd923