### PR TITLE
Show disciple task progress

### DIFF
--- a/style.css
+++ b/style.css
@@ -3238,6 +3238,40 @@ body.darkenshift-mode .tabsContainer button.active {
     border: 1px solid #555;
     padding: 4px;
 }
+.disciple-task-info {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+}
+.disciple-progress {
+    position: relative;
+    width: 80px;
+    height: 6px;
+    background: #222;
+    border: 1px solid #555;
+    border-radius: 4px;
+    overflow: hidden;
+}
+.disciple-progress-fill {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: 0%;
+    background: #6b5b95;
+    transition: width 0.3s ease;
+}
+.disciple-progress-label {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    font-size: 0.6rem;
+    color: #fff;
+    pointer-events: none;
+    white-space: nowrap;
+}
 .sect-disciples {
     text-align: center;
     margin-bottom: 4px;


### PR DESCRIPTION
## Summary
- track individual disciple gather progress in `sectState`
- add UI elements to display task progress bars per disciple
- update `tickSect` to update per-disciple progress and fruit gains
- style progress bar for disciples

## Testing
- `npm test` *(fails: mocha not found)*
- `npm run lint` *(fails: missing ESLint packages)*

------
https://chatgpt.com/codex/tasks/task_e_6866adeedbb083268e5ad6226878783a