### PR TITLE
Add Idle Chatter construct upgrade

### DIFF
--- a/script.js
+++ b/script.js
@@ -159,7 +159,7 @@ const systems = {
   manaUnlocked: false
 };
 
-const sectState = {
+export const sectState = {
   fruits: 0,
   discipleTasks: {}, // map disciple id -> current task
   taskTimers: { gatherFruits: 0 }


### PR DESCRIPTION
## Summary
- export `sectState` to share disciple task data
- allow speech system to access `sectState`
- add new `idleChatter` upgrade
- show Idle Chatter button in upgrades panel
- boost insight regen based on idle disciples

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866b05c9bdc8326b2bba21362b10126