### PR TITLE
Fix construct hotbar layout and starting insight drain

### DIFF
--- a/speech.js
+++ b/speech.js
@@ -66,7 +66,7 @@ export const speechState = {
   seasonTimer: 0,
   weather: null,
   insightRegenBase: 0,
-  activeConstructs: ['Murmur'],
+  activeConstructs: [],
   savedConstructs: ['Murmur'],
   activeBuffs: {},
   cooldowns: {},
@@ -576,6 +576,14 @@ function createConstructInfo(name) {
   return info;
 }
 
+function getConstructEffect(name) {
+  const recipe = recipes.find(r => r.name === name);
+  if (!recipe || !Object.keys(recipe.output).length) return null;
+  return Object.entries(recipe.output)
+    .map(([k, v]) => `+${v} ${k}`)
+    .join(', ');
+}
+
 function toggleConstructActive(name) {
   const idx = speechState.activeConstructs.indexOf(name);
   if (idx >= 0) {
@@ -632,10 +640,20 @@ function renderHotbar() {
   if (!bar) return;
   bar.innerHTML = '';
   speechState.activeConstructs.forEach(c => {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'construct-card-wrapper';
     const card = createConstructCard(c);
     card.classList.add('hotbar-construct');
     card.addEventListener('click', () => castConstruct(c, card));
-    bar.appendChild(card);
+    wrapper.appendChild(card);
+    const effectText = getConstructEffect(c);
+    if (effectText) {
+      const eff = document.createElement('div');
+      eff.className = 'construct-effect';
+      eff.textContent = effectText;
+      wrapper.appendChild(eff);
+    }
+    bar.appendChild(wrapper);
   });
 }
 

--- a/style.css
+++ b/style.css
@@ -2726,6 +2726,18 @@ body.darkenshift-mode .tabsContainer button.active {
     flex-wrap: wrap;
     justify-content: center;
 }
+.construct-hotbar .construct-card-wrapper {
+    margin: 4px;
+    width: 80px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 4px;
+}
+.construct-hotbar .construct-effect {
+    font-size: 0.55rem;
+    text-align: center;
+}
 
 .saved-constructs {
     display: flex;


### PR DESCRIPTION
## Summary
- prevent Murmur from draining Insight by default
- center construct hotbar cards and show effect text

## Testing
- `npm test` *(fails: mocha: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866c9395d0c8326876068b261d1c869