### PR TITLE
Update colony layout with icon tabs

### DIFF
--- a/index.html
+++ b/index.html
@@ -238,22 +238,24 @@
           <div id="tagGuide" class="tags-guide"></div>
         </div>
         <div class="player-sect-panel" style="display:none;">
-          <div id="sectDisciplesContainer" class="sect-disciples-container">
-            <div id="sectDisciples" class="sect-disciples"></div>
-            <div id="sectResources" class="sect-resources"></div>
-            <div id="sectUpkeep" class="sect-upkeep"></div>
-            <div class="sect-orbs" id="sectOrbs"></div>
-            <div id="sectBasket" class="sect-basket"></div>
+          <div class="colony-tabs">
+            <button id="colonyTasksTabBtn">👤</button>
+            <button id="colonyInfoTabBtn">ℹ️</button>
+            <button id="colonyResourcesTabBtn">🍎</button>
           </div>
-          <div class="colony-container">
-            <div class="colony-tabs">
-              <button id="colonyTasksTabBtn">Tasks</button>
-              <button id="colonyInfoTabBtn">Info</button>
-              <button id="colonyResourcesTabBtn">Resources</button>
+          <div class="colony-main">
+            <div id="sectDisciplesContainer" class="sect-disciples-container">
+              <div id="sectDisciples" class="sect-disciples"></div>
+              <div id="sectResources" class="sect-resources"></div>
+              <div id="sectUpkeep" class="sect-upkeep"></div>
+              <div class="sect-orbs" id="sectOrbs"></div>
+              <div id="sectBasket" class="sect-basket"></div>
             </div>
-            <div id="colonyTasksPanel" class="colony-panel"></div>
-            <div id="colonyInfoPanel" class="colony-panel" style="display:none;"></div>
-            <div id="colonyResourcesPanel" class="colony-panel" style="display:none;"></div>
+            <div class="colony-side">
+              <div id="colonyTasksPanel" class="colony-panel"></div>
+              <div id="colonyInfoPanel" class="colony-panel" style="display:none;"></div>
+              <div id="colonyResourcesPanel" class="colony-panel" style="display:none;"></div>
+            </div>
           </div>
         </div>
       </div>

--- a/style.css
+++ b/style.css
@@ -3206,7 +3206,7 @@ body.darkenshift-mode .tabsContainer button.active {
     flex: 1;
     gap: 6px;
     padding: 6px;
-    overflow-y: auto;
+    overflow: hidden;
 }
 .sect-disciples-container {
     flex: 1;
@@ -3232,11 +3232,26 @@ body.darkenshift-mode .tabsContainer button.active {
 .colony-tabs {
     display: flex;
     gap: 2px;
+    margin-bottom: 6px;
 }
 .colony-tabs button {
+    width: 32px;
+    height: 32px;
+    padding: 2px;
+    font-size: 1rem;
+}
+
+.colony-main {
     flex: 1;
-    padding: 4px 6px;
-    font-size: 0.5rem;
+    display: flex;
+    gap: 6px;
+}
+
+.colony-side {
+    width: 200px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
 }
 .colony-panel {
     flex: 1;
@@ -3349,7 +3364,7 @@ body.darkenshift-mode .tabsContainer button.active {
     transition: transform 3s;
 }
 #colonyTasksPanel .task-entry {
-    width: 20%;
+    width: 100%;
     font-size: 0.75rem;
 }
 @keyframes sectPulse {


### PR DESCRIPTION
## Summary
- reorganize colony management interface
- show icons for Tasks, Info and Resources above the map
- display the colony panels beside the disciples map

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686723a30fc48326bbb29ca6fbd7a90a