### PR TITLE
Update colony layout with icon tabs

### DIFF
--- a/index.html
+++ b/index.html
@@ -238,22 +238,23 @@
           <div id="tagGuide" class="tags-guide"></div>
         </div>
         <div class="player-sect-panel" style="display:none;">
-          <div id="sectDisciplesContainer" class="sect-disciples-container">
-            <div id="sectDisciples" class="sect-disciples"></div>
-            <div id="sectResources" class="sect-resources"></div>
-            <div id="sectUpkeep" class="sect-upkeep"></div>
-            <div class="sect-orbs" id="sectOrbs"></div>
-            <div id="sectBasket" class="sect-basket"></div>
+          <div class="colony-tabs">
+            <button id="colonyTasksTabBtn">👤</button>
+            <button id="colonyResourcesTabBtn">🍎</button>
           </div>
-          <div class="colony-container">
-            <div class="colony-tabs">
-              <button id="colonyTasksTabBtn">Tasks</button>
-              <button id="colonyInfoTabBtn">Info</button>
-              <button id="colonyResourcesTabBtn">Resources</button>
+          <div class="colony-main">
+            <div id="sectDisciplesContainer" class="sect-disciples-container">
+              <div id="sectDisciples" class="sect-disciples"></div>
+              <div id="sectResources" class="sect-resources"></div>
+              <div id="sectUpkeep" class="sect-upkeep"></div>
+              <div class="sect-orbs" id="sectOrbs"></div>
+              <div id="sectBasket" class="sect-basket"></div>
             </div>
-            <div id="colonyTasksPanel" class="colony-panel"></div>
-            <div id="colonyInfoPanel" class="colony-panel" style="display:none;"></div>
-            <div id="colonyResourcesPanel" class="colony-panel" style="display:none;"></div>
+            <div class="colony-side">
+              <div id="colonyTasksPanel" class="colony-panel"></div>
+              <div id="colonyInfoPanel" class="colony-panel"></div>
+              <div id="colonyResourcesPanel" class="colony-panel" style="display:none;"></div>
+            </div>
           </div>
         </div>
       </div>

--- a/script.js
+++ b/script.js
@@ -448,9 +448,9 @@ let colonyTasksPanel;
 let colonyInfoPanel;
 let colonyResourcesPanel;
 let colonyTasksTabButton;
-let colonyInfoTabButton;
 let colonyResourcesTabButton;
 let sectDisciplesContainer;
+let selectedDiscipleId = null;
 const sectDiscipleEls = {};
 const discipleGatherPhase = {};
 let discipleMoveInterval;
@@ -575,9 +575,19 @@ function showTab(tab) {
 
 function showColonyTab(name) {
   if (!colonyTasksPanel || !colonyInfoPanel || !colonyResourcesPanel) return;
-  colonyTasksPanel.style.display = name === 'tasks' ? 'flex' : 'none';
-  colonyInfoPanel.style.display = name === 'info' ? 'flex' : 'none';
-  colonyResourcesPanel.style.display = name === 'resources' ? 'flex' : 'none';
+  if (name === 'tasks') {
+    colonyTasksPanel.style.display = 'flex';
+    colonyInfoPanel.style.display = 'flex';
+    colonyResourcesPanel.style.display = 'none';
+    if (colonyTasksTabButton) colonyTasksTabButton.classList.add('active');
+    if (colonyResourcesTabButton) colonyResourcesTabButton.classList.remove('active');
+  } else if (name === 'resources') {
+    colonyTasksPanel.style.display = 'none';
+    colonyInfoPanel.style.display = 'none';
+    colonyResourcesPanel.style.display = 'flex';
+    if (colonyTasksTabButton) colonyTasksTabButton.classList.remove('active');
+    if (colonyResourcesTabButton) colonyResourcesTabButton.classList.add('active');
+  }
 }
 
 
@@ -625,7 +635,6 @@ function initTabs() {
   colonyInfoPanel = document.getElementById('colonyInfoPanel');
   colonyResourcesPanel = document.getElementById('colonyResourcesPanel');
   colonyTasksTabButton = document.getElementById('colonyTasksTabBtn');
-  colonyInfoTabButton = document.getElementById('colonyInfoTabBtn');
   colonyResourcesTabButton = document.getElementById('colonyResourcesTabBtn');
   statsOverviewSubTabButton = document.querySelector('.statsOverviewSubTabButton');
   statsEconomySubTabButton = document.querySelector('.statsEconomySubTabButton');
@@ -634,7 +643,6 @@ function initTabs() {
   setupTabHandlers();
 
   if (colonyTasksTabButton) colonyTasksTabButton.addEventListener('click', () => showColonyTab('tasks'));
-  if (colonyInfoTabButton) colonyInfoTabButton.addEventListener('click', () => showColonyTab('info'));
   if (colonyResourcesTabButton) colonyResourcesTabButton.addEventListener('click', () => showColonyTab('resources'));
 
 
@@ -1062,6 +1070,13 @@ function renderColonyTasks() {
   speechState.disciples.forEach(d => {
     const row = document.createElement('div');
     row.className = 'task-entry';
+    if (d.id === selectedDiscipleId) row.classList.add('selected');
+    row.addEventListener('click', e => {
+      if (e.target.tagName === 'SELECT') return;
+      selectedDiscipleId = d.id;
+      renderColonyTasks();
+      renderColonyInfo();
+    });
     const label = document.createElement('div');
     label.textContent = `Disciple #${d.id}`;
     const select = document.createElement('select');
@@ -1102,22 +1117,23 @@ function renderColonyTasks() {
 
 function renderColonyInfo() {
   colonyInfoPanel.innerHTML = '';
-  speechState.disciples.forEach(d => {
-    const details = document.createElement('details');
-    const summary = document.createElement('summary');
-    summary.textContent = `Disciple #${d.id}`;
-    details.appendChild(summary);
-    const task = document.createElement('div');
-    task.textContent = `Current Task: ${sectState.discipleTasks[d.id] || 'Idle'}`;
-    const power = document.createElement('div');
-    power.textContent = 'Invoke Power: 1.00';
-    const stamina = document.createElement('div');
-    stamina.textContent = 'Stamina: 100/100';
-    details.appendChild(task);
-    details.appendChild(power);
-    details.appendChild(stamina);
-    colonyInfoPanel.appendChild(details);
-  });
+  const d = speechState.disciples.find(x => x.id === selectedDiscipleId);
+  if (!d) {
+    colonyInfoPanel.textContent = 'Select a disciple';
+    return;
+  }
+  const header = document.createElement('div');
+  header.textContent = `Disciple #${d.id}`;
+  const task = document.createElement('div');
+  task.textContent = `Current Task: ${sectState.discipleTasks[d.id] || 'Idle'}`;
+  const power = document.createElement('div');
+  power.textContent = 'Invoke Power: 1.00';
+  const stamina = document.createElement('div');
+  stamina.textContent = 'Stamina: 100/100';
+  colonyInfoPanel.appendChild(header);
+  colonyInfoPanel.appendChild(task);
+  colonyInfoPanel.appendChild(power);
+  colonyInfoPanel.appendChild(stamina);
 }
 
 function renderColonyResources() {

--- a/style.css
+++ b/style.css
@@ -3206,7 +3206,7 @@ body.darkenshift-mode .tabsContainer button.active {
     flex: 1;
     gap: 6px;
     padding: 6px;
-    overflow-y: auto;
+    overflow: hidden;
 }
 .sect-disciples-container {
     flex: 1;
@@ -3232,11 +3232,28 @@ body.darkenshift-mode .tabsContainer button.active {
 .colony-tabs {
     display: flex;
     gap: 2px;
+    margin-bottom: 6px;
 }
 .colony-tabs button {
+    width: 32px;
+    height: 32px;
+    padding: 2px;
+    font-size: 1rem;
+}
+.colony-tabs button.active {
+    background: #444;
+}
+
+.colony-main {
     flex: 1;
-    padding: 4px 6px;
-    font-size: 0.5rem;
+    display: flex;
+    gap: 6px;
+}
+
+.colony-side {
+    width: 380px;
+    display: flex;
+    gap: 6px;
 }
 .colony-panel {
     flex: 1;
@@ -3254,6 +3271,9 @@ body.darkenshift-mode .tabsContainer button.active {
     gap: 6px;
     border: 1px solid #555;
     padding: 4px;
+}
+.task-entry.selected {
+    background: #333;
 }
 .disciple-task-info {
     flex: 1;
@@ -3349,7 +3369,7 @@ body.darkenshift-mode .tabsContainer button.active {
     transition: transform 3s;
 }
 #colonyTasksPanel .task-entry {
-    width: 20%;
+    width: 100%;
     font-size: 0.75rem;
 }
 @keyframes sectPulse {


### PR DESCRIPTION
## Summary
- reorganize colony management interface
- show only two icons for Sect Management and Resources
- display tasks and info panels side-by-side with selectable disciples

## Testing
- `npm install` *(with `PUPPETEER_SKIP_DOWNLOAD=1`)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686723a30fc48326bbb29ca6fbd7a90a