### PR TITLE
Restore colony map layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -243,12 +243,14 @@
             <button id="colonyResourcesTabBtn">🍎</button>
           </div>
           <div class="colony-main">
-            <div id="sectDisciplesContainer" class="sect-disciples-container">
-              <div id="sectDisciples" class="sect-disciples"></div>
-              <div id="sectResources" class="sect-resources"></div>
-              <div id="sectUpkeep" class="sect-upkeep"></div>
-              <div class="sect-orbs" id="sectOrbs"></div>
-              <div id="sectBasket" class="sect-basket"></div>
+            <div id="colonyMap" class="colony-map">
+              <div id="sectDisciplesContainer" class="sect-disciples-container">
+                <div id="sectDisciples" class="sect-disciples"></div>
+                <div id="sectResources" class="sect-resources"></div>
+                <div id="sectUpkeep" class="sect-upkeep"></div>
+                <div class="sect-orbs" id="sectOrbs"></div>
+                <div id="sectBasket" class="sect-basket"></div>
+              </div>
             </div>
             <div class="colony-side">
               <div id="colonyTasksPanel" class="colony-panel"></div>

--- a/style.css
+++ b/style.css
@@ -3247,13 +3247,21 @@ body.darkenshift-mode .tabsContainer button.active {
 .colony-main {
     flex: 1;
     display: flex;
+    flex-direction: column;
     gap: 6px;
 }
 
+.colony-map {
+    flex: 1;
+    width: 100%;
+    display: flex;
+}
+
 .colony-side {
-    width: 380px;
+    width: 100%;
     display: flex;
     gap: 6px;
+    flex: 1;
 }
 .colony-panel {
     flex: 1;


### PR DESCRIPTION
## Summary
- make the colony map fill the upper half of the sect panel
- keep the management panels below in a two-column row

## Testing
- `npm test` *(fails: `mocha` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867366bfa348326a672fb130bfc1555