### PR TITLE
Fix construct naming and card size

### DIFF
--- a/docs/phrase-system.md
+++ b/docs/phrase-system.md
@@ -27,7 +27,7 @@ The phrase builder has been replaced with a simpler construct mechanic. The **Co
 | **Clarity Pulse**    | Thought + Insight         | 2 Insight + 1 Thought | 30s      | Buff        | +1% Sound & Insight regen/sec for 30s                 |
 | **Symbol Seed**      | Sound + Thought           | 2 Sound + 2 Thought   | 10s      | Generator   | After 10s of draining, produces +1 Structure          |
 | **Mental Construct** | Thought + Insight + Sound | 30 Insight + 5 Sound  | 60s      | Buff        | Auto-cast any construct in slots for 60 seconds if possible, checking each second |
-| **Calling**         | —                         | 200 Sound            | 5m       | Action      | Attempts to recruit a Disciple based on Calling potency |
+| **The Calling**     | —                         | 200 Sound            | 5m       | Action      | Attempts to recruit a Disciple based on Calling potency |
 
 *Using **Echo of Mind** now requires accumulating 1500 Insight in addition to reaching Voice Level 3.*
 *Voice skill levels follow an exponential XP curve starting at 50 XP with a 1.2× increase per level.*

--- a/speech.js
+++ b/speech.js
@@ -133,7 +133,7 @@ const recipes = [
     cooldown: 60
   },
   {
-    name: 'Calling',
+    name: 'The Calling',
     input: { sound: 100 },
     output: {},
     xp: 0,
@@ -259,8 +259,8 @@ const constructEffects = {
         if (effect) effect(dt);
       });
   },
-  'Calling'() {
-    const callPower = speechState.constructPotency['Calling'] || 1;
+  'The Calling'() {
+    const callPower = speechState.constructPotency['The Calling'] || 1;
     const targetIdx = speechState.disciples.length + 1;
     const reqPower = Math.pow(1.8, targetIdx - 1);
     const chance = Math.max(0.05, Math.min(1, callPower / reqPower));
@@ -996,11 +996,11 @@ export function tickSpeech(delta) {
     speechState.upgrades.clarividence.unlocked = true;
     renderUpgrades();
   }
-  const call = recipes.find(r => r.name === 'Calling');
+  const call = recipes.find(r => r.name === 'The Calling');
   if (call && !call.unlocked && speechState.resources.sound.current >= 100) {
     call.unlocked = true;
-    addLog('Calling construct unlocked!', 'info');
-    addConstruct('Calling');
+    addLog('The Calling construct unlocked!', 'info');
+    addConstruct('The Calling');
   }
   tickActiveConstructs(dt);
   updateCooldownOverlays();

--- a/style.css
+++ b/style.css
@@ -2754,6 +2754,7 @@ body.darkenshift-mode .tabsContainer button.active {
     display: flex;
     flex-direction: column;
     align-items: center;
+    width: 80px;
     min-height: 48px;
     padding: 3px 6px 6px;
     border: 1px solid #555;
@@ -2954,7 +2955,7 @@ body.darkenshift-mode .tabsContainer button.active {
     align-items: center;
 }
 .modal-constructor-panel .construct-card {
-    width: 60px;
+    width: 80px;
 }
 
 .speech-panel.construct-mode .speech-orbs {


### PR DESCRIPTION
## Summary
- rename the Calling construct to **The Calling**
- standardize construct card widths in CSS
- document the updated name in phrase-system guide

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_68673fbc3b90832684b770ac1a5f7e89