### PR TITLE
Improve construct panel layout and calling info

### DIFF
--- a/speech.js
+++ b/speech.js
@@ -547,7 +547,20 @@ function createConstructInfo(name) {
   if (!recipe) return null;
   const info = document.createElement('div');
   info.className = 'construct-info';
-  if (Object.keys(recipe.output).length) {
+  if (name === 'The Calling') {
+    const effect = document.createElement('div');
+    effect.className = 'construct-effect';
+    effect.textContent = 'Effect: call for another faithful follower';
+    info.appendChild(effect);
+    const callPower = speechState.constructPotency['The Calling'] || 1;
+    const targetIdx = speechState.disciples.length + 1;
+    const reqPower = Math.pow(1.8, targetIdx - 1);
+    const chance = Math.max(0.05, Math.min(1, callPower / reqPower));
+    const chanceEl = document.createElement('div');
+    chanceEl.className = 'construct-chance';
+    chanceEl.textContent = `Chance: ${(chance * 100).toFixed(0)}%`;
+    info.appendChild(chanceEl);
+  } else if (Object.keys(recipe.output).length) {
     const effect = document.createElement('div');
     effect.className = 'construct-effect';
     effect.textContent = `Effect: ${Object.entries(recipe.output)
@@ -578,7 +591,11 @@ function createConstructInfo(name) {
 
 function getConstructEffect(name) {
   const recipe = recipes.find(r => r.name === name);
-  if (!recipe || !Object.keys(recipe.output).length) return null;
+  if (!recipe) return null;
+  if (name === 'The Calling') {
+    return 'call for another faithful follower';
+  }
+  if (!Object.keys(recipe.output).length) return null;
   return Object.entries(recipe.output)
     .map(([k, v]) => `+${v} ${k}`)
     .join(', ');

--- a/style.css
+++ b/style.css
@@ -2852,6 +2852,7 @@ body.darkenshift-mode .tabsContainer button.active {
     display: flex;
     flex-direction: column;
     overflow-y: auto;
+    align-items: center; /* center construct cards */
 }
 
 .construct-header {
@@ -3446,7 +3447,8 @@ body.darkenshift-mode .tabsContainer button.active {
     text-align: center;
 }
 .construct-duration,
-.construct-cooldown {
+.construct-cooldown,
+.construct-chance {
     font-size: 0.55rem;
     text-align: center;
 }


### PR DESCRIPTION
## Summary
- center construct card list within the sliding panel
- display chance of recruiting with The Calling
- expose effect text for The Calling

## Testing
- `npm test` *(fails: mocha not found)*
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_68674108e4188326abb559bc283e52e0