### PR TITLE
Fix insight regen after loading save

### DIFF
--- a/script.js
+++ b/script.js
@@ -2926,13 +2926,17 @@ Object.assign(playerStats, state.playerStats || {});
     Object.assign(lifeCore, state.lifeCore);
   }
 
-  if (state.speechState) {
-    const { upgrades: savedUpgrades, ...restSpeech } = state.speechState;
-    Object.assign(speechState, restSpeech);
-    if (speechState.weather && speechState.weather.days !== undefined) {
-      speechState.weather.duration = speechState.weather.days;
-      delete speechState.weather.days;
-    }
+    if (state.speechState) {
+      const { upgrades: savedUpgrades, ...restSpeech } = state.speechState;
+      Object.assign(speechState, restSpeech);
+      // ensure the insight orb and resource reference the same object
+      if (speechState.orbs && speechState.orbs.insight) {
+        speechState.resources.insight = speechState.orbs.insight;
+      }
+      if (speechState.weather && speechState.weather.days !== undefined) {
+        speechState.weather.duration = speechState.weather.days;
+        delete speechState.weather.days;
+      }
     if (savedUpgrades) {
       Object.entries(savedUpgrades).forEach(([name, data]) => {
         if (speechState.upgrades[name]) {

--- a/speech.js
+++ b/speech.js
@@ -896,6 +896,11 @@ function renderGains() {
 }
 
 function tickActiveConstructs(dt) {
+  // apply effects for any constructs that are slotted in memory
+  speechState.activeConstructs.forEach(name => {
+    const effect = constructEffects[name];
+    if (effect) effect(dt);
+  });
   for (const name of Object.keys(speechState.activeBuffs)) {
     const effect = constructEffects[name];
     if (effect) effect(dt);


### PR DESCRIPTION
## Summary
- maintain the shared object between `orbs.insight` and `resources.insight` when restoring saved games

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867415fb28c8326a162bc3e266b4386