### PR TITLE
Add sect info tab and disciple skill selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -242,6 +242,7 @@
             <div id="colonyMap" class="colony-map">
               <div class="colony-tabs">
                 <button id="colonyTasksTabBtn">👤</button>
+                <button id="colonyInfoTabBtn">ℹ️</button>
                 <button id="colonyResourcesTabBtn">🍎</button>
               </div>
               <div id="sectDisciplesContainer" class="sect-disciples-container">

--- a/style.css
+++ b/style.css
@@ -3298,6 +3298,9 @@ body.darkenshift-mode .tabsContainer button.active {
 .task-entry.selected {
     background: #333;
 }
+.disciple-task-name {
+    min-width: 80px;
+}
 .disciple-task-info {
     flex: 1;
     display: flex;


### PR DESCRIPTION
## Summary
- add new sect info tab button
- track disciple skills and increment with task cycles
- update sect management UI to show current task and let tasks be changed from info panel

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68674b2cbc0883268f852e4a11564ce1