### PR TITLE
Fix disciple spawning loop

### DIFF
--- a/speech.js
+++ b/speech.js
@@ -465,7 +465,12 @@ function performConstruct() {
 function addConstruct(name) {
   if (!speechState.savedConstructs.includes(name)) {
     speechState.savedConstructs.push(name);
-    if (speechState.activeConstructs.length < speechState.memorySlots) {
+    const def = recipes.find(r => r.name === name);
+    if (
+      def &&
+      def.type === 'buff' &&
+      speechState.activeConstructs.length < speechState.memorySlots
+    ) {
       speechState.activeConstructs.push(name);
     }
   }
@@ -602,6 +607,11 @@ function getConstructEffect(name) {
 }
 
 function toggleConstructActive(name) {
+  const def = recipes.find(r => r.name === name);
+  if (def && def.type !== 'buff') {
+    castConstruct(name);
+    return;
+  }
   const idx = speechState.activeConstructs.indexOf(name);
   if (idx >= 0) {
     speechState.activeConstructs.splice(idx, 1);


### PR DESCRIPTION
## Summary
- prevent newly unlocked constructs from automatically filling memory slots unless they're buffs
- treat non-buff constructs as one-off casts when clicked

## Testing
- `npm test` *(fails: mocha not found)*
- `npm install` *(fails: could not download Chrome due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68674d556cec8326a8b7166528aa0288