### PR TITLE
Fix construct slot selection behavior

### DIFF
--- a/speech.js
+++ b/speech.js
@@ -608,10 +608,6 @@ function getConstructEffect(name) {
 
 function toggleConstructActive(name) {
   const def = recipes.find(r => r.name === name);
-  if (def && def.type !== 'buff') {
-    castConstruct(name);
-    return;
-  }
   const idx = speechState.activeConstructs.indexOf(name);
   if (idx >= 0) {
     speechState.activeConstructs.splice(idx, 1);


### PR DESCRIPTION
## Summary
- prevent casting constructs directly from the modal
- clicking a construct in the modal now only toggles slotting

## Testing
- `npm install` *(fails: Failed to download chrome-headless-shell)*

------
https://chatgpt.com/codex/tasks/task_e_68675bc566fc832688d8d9c73e9a8d2f