### PR TITLE
Revamp disciple task info panel

### DIFF
--- a/style.css
+++ b/style.css
@@ -3534,5 +3534,37 @@ body.darkenshift-mode .tabsContainer button.active {
   .sect-disciple { width: 3px; height: 3px; font-size: 0; }
   .sect-basket { width: 6px; height: 4px; }
   .sect-shack { width: 8px; height: 6px; }
-  #colonyTasksPanel .task-entry { width: 100%; flex-direction: column; gap: 4px; }
+#colonyTasksPanel .task-entry { width: 100%; flex-direction: column; gap: 4px; }
+}
+
+.disciple-skill-list {
+    display: flex;
+    flex-direction: column;
+    flex-wrap: wrap;
+    align-content: flex-start;
+    height: 100%;
+    gap: 6px;
+}
+.disciple-skill-option {
+    display: flex;
+    flex-direction: column;
+    width: 120px;
+    cursor: pointer;
+}
+.disciple-skill-label { font-size: 0.75rem; }
+.disciple-skill-progress {
+    position: relative;
+    width: 100%;
+    height: 8px;
+    background: #222;
+    border: 1px solid #555;
+    border-radius: 4px;
+    overflow: hidden;
+}
+.disciple-skill-progress-fill {
+    position: absolute;
+    top: 0; left: 0; bottom: 0;
+    width: 0%;
+    background: #6b5b95;
+    transition: width 0.3s ease;
 }


### PR DESCRIPTION
## Summary
- add progression helpers for disciple tasks
- redesign colony info panel to show just task options with level progress
- style disciple task options and progress bars

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_68675d2f6c3483269a6d1bf935e2de53