### PR TITLE
Disable auto-casting for Murmur

### DIFF
--- a/docs/phrase-system.md
+++ b/docs/phrase-system.md
@@ -15,7 +15,7 @@ The phrase builder has been replaced with a simpler construct mechanic. The **Co
 - Unlocked from the start.
 - Costs: 25 Insight
 - Produces: 1 Sound and 1 Voice XP
-- When slotted, Murmur converts Insight into Sound automatically.
+- When activated, Murmur converts 1 Insight into 1 Sound.
 - Your Sound resource can hold up to 200.
 
 ### Invocation Summary

--- a/speech.js
+++ b/speech.js
@@ -919,11 +919,8 @@ function renderGains() {
 }
 
 function tickActiveConstructs(dt) {
-  // apply effects for any constructs that are slotted in memory
-  speechState.activeConstructs.forEach(name => {
-    const effect = constructEffects[name];
-    if (effect) effect(dt);
-  });
+  // Constructs no longer auto-cast when slotted. Only active buffs
+  // from previously cast constructs are processed each tick.
   for (const name of Object.keys(speechState.activeBuffs)) {
     const effect = constructEffects[name];
     if (effect) effect(dt);


### PR DESCRIPTION
## Summary
- update docs to state Murmur only acts when cast
- remove automatic casting of slotted constructs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68675d77d3c8832680ed48f217059ba7