### PR TITLE
Add disciple info view and stats

### DIFF
--- a/speech.js
+++ b/speech.js
@@ -265,7 +265,18 @@ const constructEffects = {
     const reqPower = Math.pow(1.8, targetIdx - 1);
     const chance = Math.max(0.05, Math.min(1, callPower / reqPower));
     if (Math.random() < chance) {
-      speechState.disciples.push({ id: targetIdx });
+      speechState.disciples.push({
+        id: targetIdx,
+        name: `Disciple ${targetIdx}`,
+        health: 10,
+        stamina: 10,
+        hunger: 20,
+        power: 1,
+        strength: 1,
+        dexterity: 1,
+        intelligence: 1,
+        incapacitated: false
+      });
       addLog('A new Disciple has answered your call!', 'info');
       document.dispatchEvent(
         new CustomEvent('disciple-gained', { detail: { count: speechState.disciples.length } })


### PR DESCRIPTION
## Summary
- add default disciple stats when recruited
- populate disciple list and detail panels in sect info tab
- track disciple hunger and health each day
- ensure save games upgrade existing disciples
- update upkeep display to 1 fruit per disciple per day

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_686765c17b4c8326bfb3320e3d307b8c