### PR TITLE
Fix sect resources tab

### DIFF
--- a/script.js
+++ b/script.js
@@ -631,6 +631,7 @@ function showColonyTab(name) {
     colonyInfoPanel.style.display = 'none';
     colonyResourcesPanel.style.display = 'flex';
     colonyBuildPanel.style.display = 'none';
+    renderColonyResources();
     if (colonyTasksTabButton) colonyTasksTabButton.classList.remove('active');
     if (colonyInfoTabButton) colonyInfoTabButton.classList.remove('active');
     if (colonyResourcesTabButton) colonyResourcesTabButton.classList.add('active');

--- a/style.css
+++ b/style.css
@@ -3247,7 +3247,7 @@ body.darkenshift-mode .tabsContainer button.active {
     width: 24px;
     height: 24px;
     padding: 2px;
-    font-size: 1rem;
+    font-size: 0.75rem;
     background: none;
     border: none;
     color: inherit;
@@ -3286,6 +3286,7 @@ body.darkenshift-mode .tabsContainer button.active {
     display: none;
     flex-direction: column;
     gap: 6px;
+    font-size: 0.75rem;
 }
 .task-entry {
     display: flex;


### PR DESCRIPTION
## Summary
- show resources correctly when switching between sect views
- standardize fonts across sect panels to a small size

## Testing
- `npm test` *(fails: mocha not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6867bab2f72083268dba7f939c4d5782