### PR TITLE
Add research mechanics and chanting hall

### DIFF
--- a/index.html
+++ b/index.html
@@ -245,6 +245,7 @@
                 <button id="colonyInfoTabBtn">ℹ️</button>
                 <button id="colonyResourcesTabBtn">🍎</button>
                 <button id="colonyBuildTabBtn" style="display:none;">🏠</button>
+                <button id="colonyResearchTabBtn" style="display:none;">🔬</button>
               </div>
               <div id="sectDisciplesContainer" class="sect-disciples-container">
                 <div class="sect-orbs" id="sectOrbs"></div>
@@ -261,6 +262,7 @@
                 <div id="sectUpkeep" class="sect-upkeep"></div>
               </div>
               <div id="colonyBuildPanel" class="colony-panel" style="display:none;"></div>
+              <div id="colonyResearchPanel" class="colony-panel" style="display:none;"></div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- allow disciples to research using insight and earn research points
- unlock research tab after gaining points
- add Chanting Hall building and Chant task
- reduce construct potency for chanting automation

## Testing
- `npm test` *(fails: mocha not found)*
- `npm install` *(fails: cannot download Chrome for puppeteer)*

------
https://chatgpt.com/codex/tasks/task_e_6867bba3f54483268e2c3977fb3c7a71