### PR TITLE
Add endurance stat for disciples

### DIFF
--- a/script.js
+++ b/script.js
@@ -1458,7 +1458,7 @@ function renderDiscipleDetails() {
   colonyResourcesPanel.appendChild(power);
 
   const attrs = document.createElement('div');
-  attrs.innerHTML = `Strength ${d.strength}<br>Dexterity ${d.dexterity}<br>Intelligence ${d.intelligence}`;
+  attrs.innerHTML = `Strength ${d.strength}<br>Dexterity ${d.dexterity}<br>Intelligence ${d.intelligence}<br>Endurance ${d.endurance}`;
   colonyResourcesPanel.appendChild(attrs);
 }
 
@@ -3287,6 +3287,7 @@ Object.assign(playerStats, state.playerStats || {});
         if (d.power === undefined) d.power = 1;
         if (d.strength === undefined) d.strength = 1;
         if (d.dexterity === undefined) d.dexterity = 1;
+        if (d.endurance === undefined) d.endurance = 1;
         if (d.intelligence === undefined) d.intelligence = 1;
         if (d.incapacitated === undefined) d.incapacitated = false;
         if (!d.name) d.name = `Disciple ${d.id}`;

--- a/speech.js
+++ b/speech.js
@@ -274,6 +274,7 @@ const constructEffects = {
         power: 1,
         strength: 1,
         dexterity: 1,
+        endurance: 1,
         intelligence: 1,
         incapacitated: false
       });


### PR DESCRIPTION
## Summary
- ensure newly created disciples have `endurance: 1`
- initialize missing `endurance` value when loading older saves
- show Endurance in disciple detail panel

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6867e9230d348326b173b39245ece5fd