### PR TITLE
Implement Endurance attribute bonuses

### DIFF
--- a/attributes.js
+++ b/attributes.js
@@ -7,6 +7,18 @@ export const attributes = {
     get inventorySlots() {
       return Math.floor(this.points / 2);
     }
+  },
+  Endurance: {
+    points: 0,
+    get staminaMultiplier() {
+      return 1 + 0.05 * this.points;
+    },
+    get staminaRegenMultiplier() {
+      return 1 + 0.01 * this.points;
+    },
+    get hpBonus() {
+      return 10 * this.points;
+    }
   }
 };
 
@@ -17,4 +29,13 @@ export function addStrength(points = 1) {
 export function strengthXpMultiplier(task) {
   const affected = ['Woodcutting', 'Log Pine', 'Mining', 'Smithing'];
   return affected.includes(task) ? 1 + attributes.Strength.points * 0.1 : 1;
+}
+
+export function addEndurance(points = 1) {
+  attributes.Endurance.points += points;
+}
+
+export function enduranceXpMultiplier(task) {
+  const affected = ['Building', 'Defending', 'Combat'];
+  return affected.includes(task) ? 1 + attributes.Endurance.points * 0.1 : 1;
 }

--- a/script.js
+++ b/script.js
@@ -26,7 +26,7 @@ import RateTracker from "./utils/rateTracker.js";
 import { formatNumber } from "./utils/numberFormat.js";
 import { runAnimation } from "./utils/animation.js";
 import { initCore, refreshCore } from './core.js';
-import { attributes, strengthXpMultiplier } from './attributes.js';
+import { attributes, strengthXpMultiplier, enduranceXpMultiplier } from './attributes.js';
 import { createOverlay } from './ui/overlay.js';
 import { showRestartScreen } from './ui/restartOverlay.js';
 import { calculateKillXp, XP_EFFICIENCY } from './utils/xp.js';
@@ -1025,7 +1025,7 @@ function tickSect(delta) {
             'Chant': 0
           };
         }
-        const mult = strengthXpMultiplier(task);
+        const mult = strengthXpMultiplier(task) * enduranceXpMultiplier(task);
         sectState.discipleSkills[d.id][task] += cycles * mult;
         updateSectDisplay();
       }

--- a/test/endurance.attribute.test.cjs
+++ b/test/endurance.attribute.test.cjs
@@ -1,0 +1,22 @@
+const { expect } = require('chai');
+
+describe('🛡️ Endurance attribute', () => {
+  const mod = require('../attributes.js');
+
+  it('scales stamina, regen, and HP', () => {
+    mod.attributes.Endurance.points = 2;
+    expect(mod.attributes.Endurance.staminaMultiplier).to.equal(1 + 0.05 * 2);
+    expect(mod.attributes.Endurance.staminaRegenMultiplier).to.equal(1 + 0.01 * 2);
+    expect(mod.attributes.Endurance.hpBonus).to.equal(20);
+  });
+
+  it('provides XP bonus for certain skills', () => {
+    mod.attributes.Endurance.points = 3;
+    expect(mod.enduranceXpMultiplier('Building')).to.equal(1 + 0.1 * 3);
+  });
+
+  it('does not affect unrelated skills', () => {
+    mod.attributes.Endurance.points = 5;
+    expect(mod.enduranceXpMultiplier('Gather Fruit')).to.equal(1);
+  });
+});


### PR DESCRIPTION
## Summary
- expand `attributes.js` with new Endurance stat
- apply Endurance XP multiplier when disciples gain task XP
- add unit tests for Endurance

## Testing
- `npm test --silent` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_686887c0e9f88326ba803913e6052051