### PR TITLE
Fix insight regen clamp

### DIFF
--- a/speech.js
+++ b/speech.js
@@ -7,7 +7,8 @@ import { sectState } from './script.js';
 // Insight regeneration constants
 // Tweaked to provide a faster early-game ramp while still tapering off
 // as Insight approaches its maximum value.
-const R_MAX = 0.5;      // cap per-second regen
+// Allow a higher maximum insight regeneration rate.
+const R_MAX = 6;        // cap per-second regen
 const MIDPOINT = 1000;  // inflection point of logistic curve
 const K = 150;          // controls steepness of taper
 


### PR DESCRIPTION
## Summary
- increase the insight regen cap from `0.5` to `6`

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_686889fa149083268e7168f9f1234f99