### PR TITLE
Implement Dexterity attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Attributes and Stats:
 
 Strength: Increases power and HP; reduces attack speed and ability accuracy.
 
-Dexterity: Enhances ability accuracy, attack speed, and critical hits; decreases ability power.
+Dexterity: Enhances ability accuracy and critical hits; each point grants +5% attack speed, –5% cast time, and +10% XP on Dexterity tasks while slightly reducing ability power.
 
 Mind: Boosts ability power; reduces HP and strength.
 
@@ -167,7 +167,7 @@ Cards in the deck but not currently drawn gain only half of this XP.
 Attribute	Effects
 
 Strength	+Damage, +HP, -Attack Speed, -Ability Accuracy
-Dexterity	+Ability Accuracy, +Attack Speed, +Critical Hit Chance, -Ability Power
+Dexterity	+Ability Accuracy, +5% Attack Speed/pt, -5% Cast Time/pt, +10% XP/pt, -Ability Power
 Mind	+Ability Power, -HP, -Strength
 Chaos	+Critical Damage, +Ability Power
 Holy	-Cooldowns

--- a/attributes.js
+++ b/attributes.js
@@ -19,6 +19,15 @@ export const attributes = {
     get hpBonus() {
       return 10 * this.points;
     }
+  },
+  Dexterity: {
+    points: 0,
+    get attackSpeedMultiplier() {
+      return 1 + 0.05 * this.points;
+    },
+    get castTimeMultiplier() {
+      return Math.max(0, 1 - 0.05 * this.points);
+    }
   }
 };
 
@@ -38,4 +47,13 @@ export function addEndurance(points = 1) {
 export function enduranceXpMultiplier(task) {
   const affected = ['Building', 'Defending', 'Combat'];
   return affected.includes(task) ? 1 + attributes.Endurance.points * 0.1 : 1;
+}
+
+export function addDexterity(points = 1) {
+  attributes.Dexterity.points += points;
+}
+
+export function dexterityXpMultiplier(task) {
+  const affected = ['Gather Fruit', 'Log Pine'];
+  return affected.includes(task) ? 1 + attributes.Dexterity.points * 0.1 : 1;
 }

--- a/script.js
+++ b/script.js
@@ -26,7 +26,7 @@ import RateTracker from "./utils/rateTracker.js";
 import { formatNumber } from "./utils/numberFormat.js";
 import { runAnimation } from "./utils/animation.js";
 import { initCore, refreshCore } from './core.js';
-import { attributes, strengthXpMultiplier, enduranceXpMultiplier } from './attributes.js';
+import { attributes, strengthXpMultiplier, enduranceXpMultiplier, dexterityXpMultiplier } from './attributes.js';
 import { createOverlay } from './ui/overlay.js';
 import { showRestartScreen } from './ui/restartOverlay.js';
 import { calculateKillXp, XP_EFFICIENCY } from './utils/xp.js';
@@ -1002,8 +1002,9 @@ function tickSect(delta) {
     if (task === 'Gather Fruit' || task === 'Log Pine') {
       if (!sectState.discipleProgress[d.id]) sectState.discipleProgress[d.id] = 0;
       sectState.discipleProgress[d.id] += dt;
-      const cycleSeconds = task === 'Gather Fruit' ? FRUIT_CYCLE_SECONDS : PINE_LOG_CYCLE_SECONDS;
+      const baseSeconds = task === 'Gather Fruit' ? FRUIT_CYCLE_SECONDS : PINE_LOG_CYCLE_SECONDS;
       const cycleAmount = task === 'Gather Fruit' ? FRUIT_CYCLE_AMOUNT : PINE_LOG_CYCLE_AMOUNT;
+      const cycleSeconds = baseSeconds / (1 + 0.05 * d.dexterity);
       if (sectState.discipleProgress[d.id] >= cycleSeconds) {
         const cycles = Math.floor(sectState.discipleProgress[d.id] / cycleSeconds);
         sectState.discipleProgress[d.id] -= cycles * cycleSeconds;
@@ -1025,7 +1026,7 @@ function tickSect(delta) {
             'Chant': 0
           };
         }
-        const mult = strengthXpMultiplier(task) * enduranceXpMultiplier(task);
+        const mult = strengthXpMultiplier(task) * enduranceXpMultiplier(task) * dexterityXpMultiplier(task);
         sectState.discipleSkills[d.id][task] += cycles * mult;
         updateSectDisplay();
       }
@@ -1053,8 +1054,9 @@ function tickSect(delta) {
     } else if (task === 'Chant') {
       if (!sectState.discipleProgress[d.id]) sectState.discipleProgress[d.id] = 0;
       sectState.discipleProgress[d.id] += dt;
-      if (sectState.discipleProgress[d.id] >= 3) {
-        sectState.discipleProgress[d.id] -= 3;
+      const castSeconds = 3 / (1 + 0.05 * d.dexterity);
+      if (sectState.discipleProgress[d.id] >= castSeconds) {
+        sectState.discipleProgress[d.id] -= castSeconds;
         const constructs = speechState.activeConstructs;
         if (constructs.length > 0) {
           const idx = Math.floor(Math.random() * constructs.length);
@@ -1062,7 +1064,8 @@ function tickSect(delta) {
           const lvl = getTaskSkillProgress(xp).level;
           const pot = 0.5 * (1 + 0.02 * lvl);
           castConstruct(constructs[idx], null, pot);
-          sectState.discipleSkills[d.id]['Chant'] = xp + 1;
+          const gain = 1 * dexterityXpMultiplier('Chant');
+          sectState.discipleSkills[d.id]['Chant'] = xp + gain;
         }
       }
       const spend = Math.min(speechState.resources.insight.current, dt);
@@ -1102,8 +1105,8 @@ function updateTaskProgressDisplay() {
     const taskName = sectState.discipleTasks[d.id] || 'Idle';
     if (taskName === 'Gather Fruit' || taskName === 'Log Pine') {
       const progress = sectState.discipleProgress[d.id] || 0;
-      const cycleSeconds =
-        taskName === 'Gather Fruit' ? FRUIT_CYCLE_SECONDS : PINE_LOG_CYCLE_SECONDS;
+      const baseSeconds = taskName === 'Gather Fruit' ? FRUIT_CYCLE_SECONDS : PINE_LOG_CYCLE_SECONDS;
+      const cycleSeconds = baseSeconds / (1 + 0.05 * d.dexterity);
       const phaseLength = cycleSeconds / 4;
       const phase = Math.floor(progress / phaseLength) % 4;
       const pct = ((progress % phaseLength) / phaseLength) * 100;

--- a/test/dexterity.attribute.test.cjs
+++ b/test/dexterity.attribute.test.cjs
@@ -1,0 +1,21 @@
+const { expect } = require('chai');
+
+describe('🏃 Dexterity attribute', () => {
+  const mod = require('../attributes.js');
+
+  it('scales attack speed and cast time', () => {
+    mod.attributes.Dexterity.points = 2;
+    expect(mod.attributes.Dexterity.attackSpeedMultiplier).to.equal(1 + 0.05 * 2);
+    expect(mod.attributes.Dexterity.castTimeMultiplier).to.equal(1 - 0.05 * 2);
+  });
+
+  it('provides XP bonus for dexterity tasks', () => {
+    mod.attributes.Dexterity.points = 3;
+    expect(mod.dexterityXpMultiplier('Gather Fruit')).to.equal(1 + 0.1 * 3);
+  });
+
+  it('does not affect unrelated skills', () => {
+    mod.attributes.Dexterity.points = 4;
+    expect(mod.dexterityXpMultiplier('Research')).to.equal(1);
+  });
+});


### PR DESCRIPTION
## Summary
- define Dexterity attribute with attack speed and cast time bonuses
- award extra XP on Dexterity tasks
- apply Dexterity speed to disciple tasks
- document Dexterity effects
- add tests for Dexterity attribute

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_68692596963083269a3d87f72fe1fcc0