### PR TITLE
Add constructor UI tasks

### DIFF
--- a/.codex/tasks.md
+++ b/.codex/tasks.md
@@ -1,4 +1,3 @@
-
 ## ✅ Completed Tasks
 - Initial card draw system implemented
 - Boss and enemy ability registry with cooldown logic
@@ -274,4 +273,14 @@
 - Cards render in `renderDealerCard()`.
 - Lucide icons are used for visual consistency.
 - All UI logic is JS-based; no framework.
+
+### Constructor UI Improvements
+
+- use lucide icons for resource buttons in constructor tab instead of text labels
+  - modify `renderResourcesUI` in `speech.js`
+  - display resource amounts via tooltip on hover
+- add collapsible sections in the constructor panel separating resources from saved constructs
+  - update markup in `speech.js` around `modal-constructor-panel`
+- highlight the `#constructToggle` arrow with a tooltip explaining it toggles the panel
+- implement a "Compact" view to hide memory slots and XP meter
 

--- a/core.js
+++ b/core.js
@@ -1,4 +1,4 @@
-import { speechState } from './speech.js';
+import { speechState, renderXpBar } from './speech.js';
 
 export const coreState = {
   coreLevel: 1,
@@ -103,8 +103,12 @@ const bodyPath = `M200 140
   bodyValEl = container.querySelector('#bodyValue');
   willValEl = container.querySelector('#willValue');
   if (window.lucide) lucide.createIcons({ icons: lucide.icons });
-  window.addEventListener('speech-xp-changed', renderCore);
+  window.addEventListener('speech-xp-changed', () => {
+    renderCore();
+    renderXpBar();
+  });
   renderCore();
+  renderXpBar();
 }
 
 

--- a/index.html
+++ b/index.html
@@ -209,6 +209,20 @@
           </div>
         </div>
         <div class="player-core-panel" style="display:none;">
+          <div class="core-side-panel sidePanel">
+            <div class="vignette skills open">
+              <button class="vignette-toggle">Skills</button>
+              <div class="vignette-content">
+                <div id="voiceSkillPanel" class="speech-xp-container">
+                  <i data-lucide="mic" class="speech-icon"></i>
+                  <div class="speech-progress">
+                    <div id="voiceLevel" class="speech-level"></div>
+                    <div class="speech-xp-bar"><div class="speech-xp-fill"></div></div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
           <div class="core-main">
             <div id="coreTabContent"></div>
           </div>

--- a/speech.js
+++ b/speech.js
@@ -173,6 +173,15 @@ const resourceIcons = {
   will: 'flame'
 };
 
+const upgradeDescriptions = {
+  cohere: 'Improves insight regeneration.',
+  expandMind: 'Increase max insight by 15% each level.',
+  idleChatter: 'Bonus regen from idle disciples.',
+  capacityBoost: 'Adds one memory slot.',
+  clarividence: 'Reveals hidden constructs.',
+  vocalMaturity: 'Grants a burst of voice experience.'
+};
+
 function xpRequired(level) {
   return Math.round(50 * Math.pow(1.2, level));
 }
@@ -352,15 +361,6 @@ export function initSpeech() {
           </div>
         </div>
       </div>
-      <div class="xp-column">
-        <div class="speech-xp-container">
-          <i data-lucide="mic" class="speech-icon"></i>
-          <div class="speech-progress">
-            <div id="voiceLevel" class="speech-level"></div>
-            <div class="speech-xp-bar"><div class="speech-xp-fill"></div></div>
-          </div>
-        </div>
-      </div>
     </div>
     <div id="constructToggle" class="construct-toggle">❮</div>
     <div id="constructHotbar" class="construct-hotbar"></div>
@@ -380,7 +380,12 @@ export function initSpeech() {
     </div>
   `;
   panel = container.querySelector('#modalConstructorPanel');
-  container.querySelector('#constructToggle').addEventListener('click', togglePanel);
+  const toggleBtn = container.querySelector('#constructToggle');
+  toggleBtn.addEventListener('click', togglePanel);
+  toggleBtn.addEventListener('mouseenter', e => {
+    window.showTooltip('Toggle constructor panel', e.pageX + 10, e.pageY + 10);
+  });
+  toggleBtn.addEventListener('mouseleave', window.hideTooltip);
   panel.querySelector('#closeConstructBtn').addEventListener('click', togglePanel);
   panel.querySelector('#performConstruct').addEventListener('click', performConstruct);
   renderResourcesUI();
@@ -757,9 +762,9 @@ function renderHotbar() {
   });
 }
 
-function renderXpBar() {
-  const barFill = container.querySelector('.speech-xp-fill');
-  const lvlEl = container.querySelector('#voiceLevel');
+export function renderXpBar() {
+  const barFill = document.querySelector('#voiceSkillPanel .speech-xp-fill');
+  const lvlEl = document.getElementById('voiceLevel');
   if (!barFill || !lvlEl) return;
   const skill = speechState.skills.voice;
   const prog = getSkillProgress(skill.xp);
@@ -958,13 +963,6 @@ export function renderUpgrades() {
   const panelUp = document.getElementById('speechUpgrades');
   if (!panelUp) return;
   panelUp.innerHTML = '';
-  const addSection = title => {
-    const h = document.createElement('h4');
-    h.className = 'section-title';
-    h.textContent = title;
-    panelUp.appendChild(h);
-  };
-  addSection('Core Upgrades');
   const coreGroup = document.createElement('div');
   coreGroup.className = 'upgrade-group';
   panelUp.appendChild(coreGroup);
@@ -989,8 +987,14 @@ export function renderUpgrades() {
     }
     const affordable = canAfford(cost);
     btn.classList.toggle('unaffordable', !affordable);
-    btn.innerHTML = `<span class="upg-info"><span class="upg-name">${name}</span><span class="upgrade-level">Lv.${up.level}</span></span>${costHtml}`;
-    btn.addEventListener('click', () => purchaseUpgrade(name));
+    btn.innerHTML = `<span class="upg-info"><span class="upg-name">${name}</span><span class="upgrade-level">Lv.${up.level}</span></span><div class="detail"><div class="cost">${costHtml}</div><div class="desc">${upgradeDescriptions[name] || ''}</div></div>`;
+    btn.addEventListener('click', () => {
+      if (!btn.classList.contains('expanded')) {
+        btn.classList.add('expanded');
+        return;
+      }
+      purchaseUpgrade(name);
+    });
     coreGroup.appendChild(btn);
   });
   if (speechState.upgrades.clarividence.unlocked && speechState.upgrades.clarividence.level === 0) {
@@ -998,9 +1002,15 @@ export function renderUpgrades() {
     btn.dataset.upgrade = 'clarividence';
     const cost = getUpgradeCost('clarividence');
     const cls = speechState.orbs.insight.current >= cost ? '' : 'cost-missing';
-    btn.innerHTML = `<span class="upg-info"><span class="upg-name">clarividence</span></span><span class="icon-row"><span class="${cls}"><i data-lucide="${resourceIcons.insight}"></i> ${cost}</span></span>`;
+    btn.innerHTML = `<span class="upg-info"><span class="upg-name">clarividence</span><span class="upgrade-level">Lv.0</span></span><div class="detail"><div class="cost"><span class="icon-row"><span class="${cls}"><i data-lucide="${resourceIcons.insight}"></i> ${cost}</span></span></div><div class="desc">${upgradeDescriptions.clarividence}</div></div>`;
     btn.classList.toggle('unaffordable', !canAfford(cost));
-    btn.addEventListener('click', () => purchaseUpgrade('clarividence'));
+    btn.addEventListener('click', () => {
+      if (!btn.classList.contains('expanded')) {
+        btn.classList.add('expanded');
+        return;
+      }
+      purchaseUpgrade('clarividence');
+    });
     coreGroup.appendChild(btn);
   }
   if (speechState.upgrades.vocalMaturity.unlocked || speechState.failCount >= 5) {
@@ -1011,9 +1021,15 @@ export function renderUpgrades() {
     btn.dataset.upgrade = 'vocalMaturity';
     const cost = getUpgradeCost('vocalMaturity');
     const cls = speechState.orbs.insight.current >= cost ? '' : 'cost-missing';
-    btn.innerHTML = `<span class="icon-row"><span class="${cls}"><i data-lucide="${resourceIcons.insight}"></i> ${cost}</span></span>`;
+    btn.innerHTML = `<span class="upg-info"><span class="upg-name">vocalMaturity</span><span class="upgrade-level">Lv.${speechState.upgrades.vocalMaturity.level}</span></span><div class="detail"><div class="cost"><span class="icon-row"><span class="${cls}"><i data-lucide="${resourceIcons.insight}"></i> ${cost}</span></span></div><div class="desc">${upgradeDescriptions.vocalMaturity}</div></div>`;
     btn.classList.toggle('unaffordable', !canAfford(cost));
-    btn.addEventListener('click', () => purchaseUpgrade('vocalMaturity'));
+    btn.addEventListener('click', () => {
+      if (!btn.classList.contains('expanded')) {
+        btn.classList.add('expanded');
+        return;
+      }
+      purchaseUpgrade('vocalMaturity');
+    });
     vocal.appendChild(btn);
   }
 }

--- a/style.css
+++ b/style.css
@@ -2285,10 +2285,10 @@ body.darkenshift-mode .tabsContainer button.active {
     display: flex;
     flex-direction: column;
     gap: 8px;
-    font-size: 0.75rem;
+    font-size: 0.65rem;
     min-width: 160px;
-    flex: 0 0 25%;
-    max-width: 25%;
+    flex: 0 0 20%;
+    max-width: 20%;
     color: var(--core-text);
 }
 .core-resources, .core-upgrades {
@@ -3060,6 +3060,21 @@ body.darkenshift-mode .tabsContainer button.active {
     align-items: center;
     justify-content: space-between;
     gap: 4px;
+}
+.speech-upgrades button .detail {
+    display: none;
+    flex-direction: column;
+    gap: 2px;
+    font-size: 0.7em;
+    width: 100%;
+    text-align: left;
+}
+.speech-upgrades button.expanded {
+    flex-direction: column;
+    align-items: flex-start;
+}
+.speech-upgrades button.expanded .detail {
+    display: flex;
 }
 .speech-upgrades button:hover {
     box-shadow: 0 0 12px rgba(183, 110, 255, 0.8);


### PR DESCRIPTION
## Summary
- add new tasks describing improvements for the constructor tab UI
- refine upgrade display and side panels

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_68689685826883268112dda20b407075