### PR TITLE
Enable dev dependency install

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+puppeteer_skip_download=true

--- a/README.md
+++ b/README.md
@@ -226,15 +226,13 @@ Built in collaboration with ChatGPT & Codex.
 
 📦 Installation
 
-Install Node.js and fetch the project's dependencies:
+Install Node.js and fetch the project's dependencies. Puppeteer attempts to
+download a bundled browser during installation, which may be blocked. Skip that
+download by setting an environment variable when installing:
 
 ```bash
-npm install
+PUPPETEER_SKIP_DOWNLOAD=1 npm install
 ```
-
-> **Note**: This step requires network access to download packages. If Puppeteer's
-> bundled browser fails to download, set `PUPPETEER_SKIP_DOWNLOAD=1` before
-> running `npm install`.
 
 🧪 Testing
 


### PR DESCRIPTION
## Summary
- instruct how to install dev deps without Chrome download
- add `.npmrc` config to skip Puppeteer download

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68692ad1468c83268662bb3819fe0e9f