### PR TITLE
Display disciple bonuses

### DIFF
--- a/script.js
+++ b/script.js
@@ -1535,6 +1535,9 @@ function renderDiscipleDetails() {
     return;
   }
 
+  const container = document.createElement('div');
+  container.className = 'disciple-details';
+
   const stats = [
     { label: 'Health', color: '#a33', value: d.health, max: 10 },
     { label: 'Stamina', color: '#cc3', value: d.stamina, max: 10 },
@@ -1552,16 +1555,33 @@ function renderDiscipleDetails() {
     fill.style.width = `${(s.value / s.max) * 100}%`;
     bar.appendChild(fill);
     wrapper.appendChild(bar);
-    colonyResourcesPanel.appendChild(wrapper);
+    container.appendChild(wrapper);
   });
 
   const power = document.createElement('div');
   power.textContent = `Construct Power: ${d.power}`;
-  colonyResourcesPanel.appendChild(power);
+  container.appendChild(power);
 
   const attrs = document.createElement('div');
   attrs.innerHTML = `Strength ${d.strength}<br>Dexterity ${d.dexterity}<br>Intelligence ${d.intelligence}<br>Endurance ${d.endurance}`;
-  colonyResourcesPanel.appendChild(attrs);
+  container.appendChild(attrs);
+
+  const bonuses = document.createElement('div');
+  bonuses.className = 'disciple-bonus-list';
+
+  const skillMap = sectState.discipleSkills[d.id] || {};
+  const tasks = ['Gather Fruit', 'Log Pine', 'Building', 'Research', 'Chant'];
+  tasks.forEach(t => {
+    const xp = skillMap[t] || 0;
+    const lvl = getTaskSkillProgress(xp).level;
+    const mult = 1 + 0.02 * lvl;
+    const row = document.createElement('div');
+    row.textContent = `${t}: ×${mult.toFixed(2)}`;
+    bonuses.appendChild(row);
+  });
+
+  container.appendChild(bonuses);
+  colonyResourcesPanel.appendChild(container);
 }
 
 function triggerOrbFlash() {

--- a/style.css
+++ b/style.css
@@ -3616,6 +3616,27 @@ body.darkenshift-mode .tabsContainer button.active {
     transition: width 0.3s ease;
 }
 
+/* Compact disciple info panel */
+.disciple-details {
+    font-size: 0.65rem;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+.disciple-details .disciple-progress {
+    width: 100px;
+    height: 8px;
+}
+.disciple-details .disciple-progress-label {
+    font-size: 0.55rem;
+}
+.disciple-bonus-list {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    margin-top: 4px;
+}
+
 /* Research progress bar shown in the research panel */
 .research-progress {
     position: relative;


### PR DESCRIPTION
## Summary
- add disciple bonus and progress UI in colony resources panel
- style disciple info with reduced fonts and bar sizes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686941abc50483269d29912efc44292b