### PR TITLE
Fix floating constructs

### DIFF
--- a/style.css
+++ b/style.css
@@ -2981,7 +2981,7 @@ body.darkenshift-mode .tabsContainer button.active {
     gap: 15px;
     padding: 6px;
     margin-top: 6px;
-    overflow-y: auto;
+    overflow: visible;
     flex: 1;
     justify-content: center;
     align-items: center;


### PR DESCRIPTION
## Summary
- let construct cloud float outside of the card by disabling overflow clipping on construct card container

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686998cf4b94832693a4219a33ef3eee