### PR TITLE
Improve constructor card layout

### DIFF
--- a/speech.js
+++ b/speech.js
@@ -553,9 +553,15 @@ function renderConstructCards() {
   speechState.savedConstructs.forEach(c => {
     const wrapper = document.createElement('div');
     wrapper.className = 'construct-card-wrapper';
+    wrapper.dataset.name = c;
     const card = createConstructCard(c);
+    card.classList.add('collapsed');
     if (speechState.activeConstructs.includes(c)) card.classList.add('active');
-    card.addEventListener('click', () => toggleConstructActive(c));
+    card.addEventListener('click', () => {
+      toggleConstructActive(c);
+      wrapper.classList.toggle('expanded');
+      card.classList.toggle('collapsed');
+    });
     wrapper.appendChild(card);
     const timer = document.createElement('div');
     timer.className = 'cooldown-timer';
@@ -689,14 +695,23 @@ function getConstructEffect(name) {
 }
 
 function toggleConstructActive(name) {
-  const def = recipes.find(r => r.name === name);
   const idx = speechState.activeConstructs.indexOf(name);
   if (idx >= 0) {
     speechState.activeConstructs.splice(idx, 1);
   } else if (speechState.activeConstructs.length < speechState.memorySlots) {
     speechState.activeConstructs.push(name);
   }
-  renderConstructCards();
+  const slotCont = panel.querySelector('#memorySlotsDisplay');
+  if (slotCont) {
+    [...slotCont.children].forEach((slot, i) => {
+      slot.classList.toggle('filled', i < speechState.activeConstructs.length);
+    });
+  }
+  const cardEl = panel.querySelector(`.construct-card[data-name="${name}"]`);
+  if (cardEl) {
+    const active = speechState.activeConstructs.includes(name);
+    cardEl.classList.toggle('active', active);
+  }
   renderHotbar();
 }
 

--- a/style.css
+++ b/style.css
@@ -2801,6 +2801,10 @@ body.darkenshift-mode .tabsContainer button.active {
 .construct-card:hover {
     box-shadow: 0 0 6px #999;
 }
+
+.construct-card.collapsed > *:not(.construct-name) {
+    display: none;
+}
 .construct-card .construct-bar {
     position: absolute;
     bottom: 0;
@@ -2978,7 +2982,7 @@ body.darkenshift-mode .tabsContainer button.active {
 .built-constructs {
     display: flex;
     flex-wrap: wrap;
-    gap: 15px;
+    gap: 8px;
     padding: 6px;
     margin-top: 6px;
     overflow: visible;
@@ -2988,7 +2992,9 @@ body.darkenshift-mode .tabsContainer button.active {
     align-content: center;
 }
 .modal-constructor-panel .construct-card {
-    width: 80px;
+    width: 60px;
+    height: 70px;
+    font-size: 0.7rem;
 }
 
 .speech-panel.construct-mode .speech-orbs {
@@ -3537,9 +3543,9 @@ body.darkenshift-mode .tabsContainer button.active {
     display: flex;
     flex-direction: column;
     align-items: center;
-    width: 80px;
+    width: 60px;
     gap: 4px;
-    margin: 8px;
+    margin: 6px;
 }
 
 .cooldown-timer {
@@ -3551,9 +3557,17 @@ body.darkenshift-mode .tabsContainer button.active {
 .construct-info {
     font-size: 0.55rem;
     text-align: center;
-    display: flex;
+    display: none;
     flex-direction: column;
     gap: 2px;
+}
+
+.construct-card-wrapper.expanded .construct-info {
+    display: flex;
+}
+
+.construct-card-wrapper.expanded .construct-card {
+    height: auto;
 }
 
 .construct-info i {


### PR DESCRIPTION
## Summary
- reduce constructor card sizes for modal panel
- make construct info expandable
- show only names until expanded
- update JS to toggle active state without re-render

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6869a309e6f08326bd6e3648ce54efd5