### PR TITLE
Improve disciple attribute distribution

### DIFF
--- a/discipleAttributes.js
+++ b/discipleAttributes.js
@@ -1,0 +1,18 @@
+export function generateDiscipleAttributes() {
+  const attrs = ['strength', 'dexterity', 'endurance', 'intelligence'];
+  const result = { strength: 0, dexterity: 0, endurance: 0, intelligence: 0 };
+  const points = Math.floor(Math.random() * 3) + 3; // 3-5 total
+  for (let i = 0; i < points; i++) {
+    const weights = attrs.map(a => 1 / Math.pow(result[a] + 1, 2));
+    const sum = weights.reduce((a, b) => a + b, 0);
+    let r = Math.random() * sum;
+    for (let j = 0; j < attrs.length; j++) {
+      r -= weights[j];
+      if (r <= 0) {
+        result[attrs[j]] += 1;
+        break;
+      }
+    }
+  }
+  return result;
+}

--- a/docs/disciples.md
+++ b/docs/disciples.md
@@ -30,6 +30,11 @@ if (Array.isArray(speechState.disciples)) {
 }
 ```
 
+Newly recruited disciples receive **3–5 additional attribute points**. These
+extra points are distributed across Strength, Dexterity, Endurance and
+Intelligence with diminishing chances to stack points on the same attribute.
+Gaining three points in a single stat is therefore possible but uncommon.
+
 ## Task Proficiency
 
 Disciples gain skill experience (XP) for the task they are performing. XP follows an exponential curve where the XP required for each level is `50 × 1.2^level`:

--- a/speech.js
+++ b/speech.js
@@ -1,6 +1,7 @@
 import addLog from './log.js';
 import { coreState, refreshCore } from './core.js';
 import { sectState } from './script.js';
+import { generateDiscipleAttributes } from './discipleAttributes.js';
 
 // Core state for the Constructs system. Orbs and upgrades from the
 // previous speech implementation remain intact.
@@ -317,6 +318,7 @@ const constructEffects = {
     const reqPower = Math.pow(1.8, targetIdx - 1);
     const chance = Math.max(0.05, Math.min(1, callPower / reqPower));
     if (Math.random() < chance) {
+      const bonus = generateDiscipleAttributes();
       speechState.disciples.push({
         id: targetIdx,
         name: `Disciple ${targetIdx}`,
@@ -324,10 +326,10 @@ const constructEffects = {
         stamina: 10,
         hunger: 20,
         power: 1,
-        strength: 1,
-        dexterity: 1,
-        endurance: 1,
-        intelligence: 1,
+        strength: 1 + bonus.strength,
+        dexterity: 1 + bonus.dexterity,
+        endurance: 1 + bonus.endurance,
+        intelligence: 1 + bonus.intelligence,
         incapacitated: false
       });
       addLog('A new Disciple has answered your call!', 'info');

--- a/test/disciple.distribution.test.cjs
+++ b/test/disciple.distribution.test.cjs
@@ -1,0 +1,27 @@
+const { expect } = require('chai');
+const { generateDiscipleAttributes } = require('../discipleAttributes.js');
+
+describe('🧍 Disciple attribute distribution', () => {
+  it('allocates between 3 and 5 points total', () => {
+    for (let i = 0; i < 50; i++) {
+      const dist = generateDiscipleAttributes();
+      const total =
+        dist.strength + dist.dexterity + dist.endurance + dist.intelligence;
+      expect(total).to.be.at.least(3).and.at.most(5);
+    }
+  });
+
+  it('rarely gives 3 points in one stat', () => {
+    let triples = 0;
+    const runs = 500;
+    for (let i = 0; i < runs; i++) {
+      const d = generateDiscipleAttributes();
+      if (
+        Math.max(d.strength, d.dexterity, d.endurance, d.intelligence) >= 3
+      ) {
+        triples++;
+      }
+    }
+    expect(triples).to.be.below(runs * 0.1);
+  });
+});


### PR DESCRIPTION
## Summary
- add `generateDiscipleAttributes` helper and unit tests
- call attribute generator when recruiting disciples
- document starting attribute distribution

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6869a248d5fc83268fe562f189271da4