### PR TITLE
Improve construct panel UI

### DIFF
--- a/speech.js
+++ b/speech.js
@@ -441,7 +441,14 @@ function addResourceToPot(name) {
 function renderPot() {
   const pot = container.querySelector('#constructPot');
   if (!pot) return;
-  pot.textContent = speechState.pot.length ? speechState.pot.join(' + ') : '⚗️';
+  if (speechState.pot.length) {
+    pot.innerHTML = speechState.pot
+      .map(r => `<i data-lucide="${resourceIcons[r] || 'package'}"></i>`)
+      .join(' ');
+    if (window.lucide) lucide.createIcons({ icons: lucide.icons });
+  } else {
+    pot.textContent = '⚗️';
+  }
   updateConstructButtonValidity();
   renderConstructRequirements();
 }
@@ -661,17 +668,28 @@ function renderChantDisciples() {
   const cont = panel.querySelector('#constructDisciples');
   if (!cont) return;
   cont.innerHTML = '';
-  speechState.disciples.forEach(d => {
+  const chanters = speechState.disciples.filter(
+    d => sectState.discipleTasks[d.id] === 'Chant'
+  );
+  const available = chanters.filter(d => !sectState.chantAssignments[d.id]);
+  const header = document.createElement('div');
+  header.className = 'chant-header';
+  header.textContent = `Chanters ${available.length}/${chanters.length}`;
+  cont.appendChild(header);
+  const list = document.createElement('div');
+  list.className = 'chant-orbs';
+  available.forEach(d => {
     const div = document.createElement('div');
     div.className = 'chant-disciple';
-    div.textContent = d.name;
+    div.textContent = d.id;
     if (selectedChanter === d.id) div.classList.add('selected');
     div.addEventListener('click', () => {
       selectedChanter = selectedChanter === d.id ? null : d.id;
       renderChantDisciples();
     });
-    cont.appendChild(div);
+    list.appendChild(div);
   });
+  cont.appendChild(list);
 }
 
 function createConstructInfo(name) {

--- a/style.css
+++ b/style.css
@@ -2285,10 +2285,10 @@ body.darkenshift-mode .tabsContainer button.active {
     display: flex;
     flex-direction: column;
     gap: 8px;
-    font-size: 0.65rem;
-    min-width: 160px;
-    flex: 0 0 20%;
-    max-width: 20%;
+    font-size: 0.52rem; /* reduced by ~20% */
+    min-width: 128px; /* reduced by ~20% */
+    flex: 0 0 16%;
+    max-width: 16%;
     color: var(--core-text);
 }
 .core-resources, .core-upgrades {
@@ -2861,6 +2861,7 @@ body.darkenshift-mode .tabsContainer button.active {
     inset: 0;
     margin: 0;
     padding: 8px;
+    font-size: 0.8rem;
     box-sizing: border-box;
     background: linear-gradient(#11131c, #0e0f1a);
     border: 1px solid #4a4a60;
@@ -3007,24 +3008,38 @@ body.darkenshift-mode .tabsContainer button.active {
 }
 
 .construct-disciples {
-    width: 120px;
+    width: 96px; /* reduced by ~20% */
     display: flex;
     flex-direction: column;
+    align-items: center;
+    gap: 2px;
+}
+
+.chant-header {
+    font-size: 0.7rem;
+    text-align: center;
+}
+
+.chant-orbs {
+    display: flex;
     gap: 4px;
+    flex-wrap: wrap;
+    justify-content: center;
 }
 
 .chant-disciple {
-    border: 1px solid #555;
-    background: #222;
-    padding: 4px;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.9);
+    box-shadow: 0 0 4px rgba(255, 255, 255, 0.9);
     cursor: pointer;
-    text-align: center;
-    font-size: 0.7rem;
+    font-size: 0;
 }
 
 .chant-disciple.selected {
     background: #88f;
-    color: #000;
+    box-shadow: 0 0 6px #88f;
 }
 
 .construct-assignment {


### PR DESCRIPTION
## Summary
- shrink side panel content instead of construct cards
- show recipe icons in construct pot
- show available chanters as orb icons with header

## Testing
- `npm test` *(fails: mocha not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6869e54819d8832682e42e407b2fdc7e