### PR TITLE
Display construct details in Lexicon

### DIFF
--- a/script.js
+++ b/script.js
@@ -1977,9 +1977,33 @@ function renderConstructLexicon() {
     info.appendChild(type);
     if (r.cooldown)
       info.appendChild(Object.assign(document.createElement('div'), { textContent: `Cooldown: ${r.cooldown}s` }));
-    info.appendChild(Object.assign(document.createElement('div'), { textContent: `XP: ${r.xp || 0}` }));
     if (r.tags && r.tags.length)
       info.appendChild(Object.assign(document.createElement('div'), { textContent: `Tags: ${r.tags.join(', ')}` }));
+    if (r.requirements) {
+      const reqStr = Object.entries(r.requirements)
+        .map(([k, v]) => {
+          if (k === 'voiceLevel') return `Voice Lv.${v}`;
+          return `${v} ${k}`;
+        })
+        .join(', ');
+      info.appendChild(Object.assign(document.createElement('div'), { textContent: `Unlock: ${reqStr}` }));
+    }
+    const effect = (() => {
+      if (r.name === 'The Calling') return 'call for another faithful follower';
+      if (r.name === 'Intone') return 'press repeatedly to charge';
+      if (!Object.keys(r.output).length) return null;
+      return Object.entries(r.output)
+        .map(([k, v]) => `+${v} ${k}`)
+        .join(', ');
+    })();
+    if (effect) info.appendChild(Object.assign(document.createElement('div'), { textContent: `Effect: ${effect}` }));
+    if (Object.keys(r.output).length) {
+      const outStr = Object.entries(r.output)
+        .map(([k, v]) => `+${v} ${k}`)
+        .join(', ');
+      info.appendChild(Object.assign(document.createElement('div'), { textContent: `Generates: ${outStr}` }));
+    }
+    info.appendChild(Object.assign(document.createElement('div'), { textContent: `XP: ${r.xp || 0}` }));
     wrap.appendChild(info);
     constructLexiconContainer.appendChild(wrap);
   });

--- a/style.css
+++ b/style.css
@@ -2995,6 +2995,17 @@ body.darkenshift-mode .tabsContainer button.active {
 .construct-lexicon {
     justify-content: center;
 }
+.construct-lexicon .construct-card-wrapper {
+    flex-direction: row;
+    align-items: flex-start;
+    width: auto;
+}
+.construct-lexicon .construct-info {
+    display: flex;
+    flex-direction: column;
+    text-align: left;
+    margin-left: 6px;
+}
 .modal-constructor-panel .construct-card {
     width: 60px;
     height: 70px;


### PR DESCRIPTION
## Summary
- show additional construct info in the lexicon including cooldown, tags, unlock requirements, effect and generation
- style lexicon rows so info is shown to the right of the card

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686a047c4cf48326b2cc88cbbbf05021