### PR TITLE
Add disciple info subviews

### DIFF
--- a/style.css
+++ b/style.css
@@ -3750,6 +3750,19 @@ body.darkenshift-mode .tabsContainer button.active {
     margin-top: 4px;
 }
 
+.disciple-details-header {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+}
+.disciple-details-header button {
+    font-size: 0.6rem;
+    padding: 2px 4px;
+}
+.disciple-details-header button.active {
+    background: #444;
+}
+
 /* Research progress bar shown in the research panel */
 .research-progress {
     position: relative;


### PR DESCRIPTION
## Summary
- add disciple information view selector
- show selected disciple status by default
- provide placeholder casting and combat info
- style disciple info header

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ac3615a0483268d1e8892406fa60e