### PR TITLE
Update constructor panel layout

### DIFF
--- a/speech.js
+++ b/speech.js
@@ -382,15 +382,19 @@ export function initSpeech() {
         <button id="closeConstructBtn" class="cast-button">❌</button>
       </div>
       <div class="construct-tab constructor-view">
-        <div class="construct-left">
+        <div class="constructor-container">
           <div id="constructPot" class="construct-pot">⚗️</div>
           <div id="resourceButtons" class="resource-buttons"></div>
           <button id="performConstruct" class="cast-button construct-button">Construct</button>
-          <div id="memorySlotsDisplay" class="memory-slots"></div>
           <div id="constructRequirements" class="construct-requirements"></div>
+        </div>
+        <div class="card-construct-container">
+          <div class="slots-and-disciples">
+            <div id="memorySlotsDisplay" class="memory-slots"></div>
+            <div id="constructDisciples" class="construct-disciples"></div>
+          </div>
           <div id="constructCards" class="built-constructs"></div>
         </div>
-        <div id="constructDisciples" class="construct-disciples"></div>
       </div>
     </div>
   `;

--- a/style.css
+++ b/style.css
@@ -3014,11 +3014,26 @@ body.darkenshift-mode .tabsContainer button.active {
 }
 
 
-.construct-left {
+.constructor-container {
+    flex: 0 0 auto;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.card-construct-container {
     flex: 1;
     display: flex;
     flex-direction: column;
     align-items: center;
+    gap: 6px;
+}
+
+.slots-and-disciples {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    justify-content: center;
 }
 
 .construct-disciples {


### PR DESCRIPTION
## Summary
- refactor modal constructor markup to use two containers
- style new containers for layout

## Testing
- `npm test`
- `npm run lint` *(fails: many errors)*

------
https://chatgpt.com/codex/tasks/task_e_686ac55a931c832681496aa895cda426