### PR TITLE
Fix lucide icon reference

### DIFF
--- a/speech.js
+++ b/speech.js
@@ -171,7 +171,7 @@ const resourceIcons = {
   insight: 'star',
   sound: 'volume-2',
   thought: 'activity',
-  structure: 'cube',
+  structure: 'box',
   body: 'heart',
   will: 'flame'
 };


### PR DESCRIPTION
## Summary
- use `box` icon for resource structure

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ac609569c83269db0aa67c1a33025