### PR TITLE
Fix insight regen display

### DIFF
--- a/script.js
+++ b/script.js
@@ -3676,6 +3676,7 @@ function gameLoop(currentTime) {
 const rawDelta = currentTime - lastFrameTime;
 lastFrameTime = currentTime;
 const deltaTime = rawDelta * timeScale;
+const startInsight = speechState.resources.insight.current;
 
 if (currentEnemy) {
     currentEnemy.tick(deltaTime);
@@ -3760,6 +3761,11 @@ if (currentEnemy) {
   tickBarProgress(deltaTime);
   tickSpeech(deltaTime);
   tickSect(deltaTime);
+  const dtSeconds = deltaTime / 1000;
+  speechState.gains.insight =
+    dtSeconds > 0
+      ? (speechState.resources.insight.current - startInsight) / dtSeconds
+      : 0;
   requestAnimationFrame(gameLoop);
 }
 

--- a/speech.js
+++ b/speech.js
@@ -1304,7 +1304,6 @@ export function tickSpeech(delta) {
   }
   tickActiveConstructs(dt);
   ins.current = Math.min(ins.max, Math.max(0, ins.current));
-  speechState.gains.insight = (ins.current - startInsight) / dt;
   updateCooldownOverlays();
   updateIntoneUI();
   renderOrbs();


### PR DESCRIPTION
## Summary
- compute insight gain after all game logic to show net regen
- remove old gain calculation in `tickSpeech`

## Testing
- `npm test`
- `npm run lint` *(fails: many style errors)*

------
https://chatgpt.com/codex/tasks/task_e_686ac64afe0883268c01080340e0de39