### PR TITLE
Add insight regen popup

### DIFF
--- a/core.js
+++ b/core.js
@@ -1,4 +1,4 @@
-import { speechState, renderXpBar } from './speech.js';
+import { speechState, renderXpBar, openInsightRegenPopup } from './speech.js';
 
 export const coreState = {
   coreLevel: 1,
@@ -76,6 +76,7 @@ const bodyPath = `M200 140
       window.showTooltip(`Insight: ${Math.floor(orb.current)}/${orb.max}`, e.pageX + 10, e.pageY + 10);
     });
     insightOrb.addEventListener('mouseleave', window.hideTooltip);
+    insightOrb.addEventListener('click', openInsightRegenPopup);
   }
   meditateBtn.addEventListener('click', toggleMeditation);
   meditateBtn.addEventListener('mouseenter', e => {

--- a/script.js
+++ b/script.js
@@ -20,7 +20,7 @@ import {
 import {
   initStarChart
 } from "./starChart.js"; // optional star chart tab
-import { initSpeech, tickSpeech, speechState, DAY_LENGTH_SECONDS, castConstruct, createConstructCard, createConstructInfo, recipes } from "./speech.js";
+import { initSpeech, tickSpeech, speechState, DAY_LENGTH_SECONDS, castConstruct, createConstructCard, createConstructInfo, recipes, openInsightRegenPopup } from "./speech.js";
 import { Jobs, assignJob, getAvailableJobs, renderJobAssignments, renderJobCarousel } from "./jobs.js"; // job definitions
 import RateTracker from "./utils/rateTracker.js";
 import { formatNumber } from "./utils/numberFormat.js";
@@ -1208,6 +1208,9 @@ function updateSectDisplay() {
       orb.className = `sect-orb ${p.cls}`;
       orb.style.left = p.left;
       orb.style.top = p.top;
+      if (p.cls === 'insight') {
+        orb.addEventListener('click', openInsightRegenPopup);
+      }
       orbs.appendChild(orb);
     });
   }

--- a/style.css
+++ b/style.css
@@ -605,6 +605,33 @@ body.darkenshift-mode .tabsContainer button.active {
     margin: 4px;
 }
 
+.insight-regen-overlay {
+    flex-direction: column;
+    gap: 8px;
+}
+
+.insight-regen-list {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    font-size: 0.9rem;
+}
+
+.insight-row {
+    display: flex;
+    justify-content: space-between;
+}
+
+.insight-row.negative {
+    color: #ff8888;
+}
+
+.insight-total {
+    margin-top: 4px;
+    text-align: center;
+    font-weight: bold;
+}
+
 .camp-box {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
## Summary
- show insight regen details on clicking the orb
- wire up insight orb click handlers on core, speech, and sect displays
- style popup overlay for regen info

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ac96b3b548326b711ffbff0b862d3