### PR TITLE
Persist building and research unlocks

### DIFF
--- a/script.js
+++ b/script.js
@@ -1854,6 +1854,9 @@ document.addEventListener("DOMContentLoaded", () => {
   if (systems.researchUnlocked && colonyResearchTabButton) {
     colonyResearchTabButton.style.display = '';
   }
+  if (systems.buildingUnlocked && colonyBuildTabButton) {
+    colonyBuildTabButton.style.display = '';
+  }
   updateSectDisplay();
   initVignetteToggles();
   if (window.lucide) lucide.createIcons({ icons: lucide.icons });
@@ -3519,7 +3522,13 @@ Object.entries(upgrades).map(([k, u]) => [k, u.unlocked])
     lifeCore,
     speechState,
     sectState,
-    sectTabUnlocked
+    sectTabUnlocked,
+    systems: {
+      manaUnlocked: systems.manaUnlocked,
+      buildingUnlocked: systems.buildingUnlocked,
+      researchUnlocked: systems.researchUnlocked,
+      chantingHallUnlocked: systems.chantingHallUnlocked
+    }
   };
 
 try {
@@ -3545,8 +3554,12 @@ const state = JSON.parse(json);
   upgradePowerPurchased = state.upgradePowerPurchased || 0;
   lastCashOutPoints = state.lastCashOutPoints || 0;
   Object.assign(stats, state.stats || {});
-systems.manaUnlocked = (state.stats && state.stats.maxMana > 0);
-Object.assign(stageData, state.stageData || {});
+  if (state.systems) {
+    Object.assign(systems, state.systems);
+  } else {
+    systems.manaUnlocked = (state.stats && state.stats.maxMana > 0);
+  }
+  Object.assign(stageData, state.stageData || {});
 Object.assign(playerStats, state.playerStats || {});
   if (state.worldProgress) {
     Object.entries(state.worldProgress).forEach(([id, data]) => {


### PR DESCRIPTION
## Summary
- save `systems` flags to preserve tab unlock state
- restore `systems` from save on load
- ensure build tab shows if it was unlocked previously

## Testing
- `npm test`
- `npm run lint` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_686acb5f68188326ac612f317a034b95