### PR TITLE
Notify sect tab on new disciple

### DIFF
--- a/script.js
+++ b/script.js
@@ -862,6 +862,7 @@ function initTabs() {
       if (playerSectPanel) playerSectPanel.style.display = 'flex';
       startDiscipleMovement();
       playerSectSubTabButton.classList.add('active');
+      playerSectSubTabButton.classList.remove('glow-notify');
       if (playerCoreSubTabButton) playerCoreSubTabButton.classList.remove('active');
       if (playerSpeechSubTabButton) playerSpeechSubTabButton.classList.remove('active');
       if (playerLexiconSubTabButton) playerLexiconSubTabButton.classList.remove('active');
@@ -1889,6 +1890,9 @@ document.addEventListener("DOMContentLoaded", () => {
       sectTabUnlocked = true;
       if (playerSectSubTabButton) playerSectSubTabButton.style.display = '';
       addLog('A presence stirs. The first disciple has heard the Calling.', 'info');
+    }
+    if (playerSectSubTabButton && !playerSectSubTabButton.classList.contains('active')) {
+      playerSectSubTabButton.classList.add('glow-notify');
     }
     updateSectDisplay();
     if (colonyInfoTabButton && colonyInfoTabButton.classList.contains('active')) {

--- a/speech.js
+++ b/speech.js
@@ -344,11 +344,13 @@ const constructEffects = {
         incapacitated: false
       });
       addLog('A new Disciple has answered your call!', 'info');
+      if (lastConstructTarget) showConstructCloud('+1', lastConstructTarget);
       document.dispatchEvent(
         new CustomEvent('disciple-gained', { detail: { count: speechState.disciples.length } })
       );
     } else {
       addLog('Your call went unanswered.', 'info');
+      if (lastConstructTarget) showConstructCloud('Failed', lastConstructTarget, 'red');
     }
   }
 };
@@ -356,6 +358,7 @@ const constructEffects = {
 let container;
 let panel;
 let selectedChanter = null;
+let lastConstructTarget = null;
 
 export function initSpeech() {
   container = document.getElementById('speechPanel');
@@ -831,6 +834,7 @@ export function castConstruct(name, el, powerMult = 1) {
     }
   }
   awardXp(def.xp || 0, def.tags || ['voice']);
+  lastConstructTarget = el;
   showConstructCloud(name, el);
   if (def.duration) {
     speechState.activeBuffs[name] = { time: def.duration, mult: powerMult };
@@ -838,6 +842,7 @@ export function castConstruct(name, el, powerMult = 1) {
     const effect = constructEffects[name];
     if (effect) effect(1 * powerMult);
   }
+  lastConstructTarget = null;
   if (def.cooldown) {
     speechState.cooldowns[name] = def.cooldown;
   }
@@ -1335,11 +1340,12 @@ export function tickSpeech(delta) {
   renderXpBar();
 }
 
-function showConstructCloud(text, target) {
+function showConstructCloud(text, target, color) {
   if (!container) return;
   const el = document.createElement('div');
   el.className = 'construct-cloud';
   el.textContent = text;
+  if (color) el.style.color = color;
   const parent = target || container;
   parent.appendChild(el);
   setTimeout(() => el.remove(), 3000);


### PR DESCRIPTION
## Summary
- highlight Sect tab until viewed when a disciple is gained
- show "+1" or "Failed" when using The Calling

## Testing
- `npm test`
- `npm run lint` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_686acfb7b4048326a9c9352b1911908b