### PR TITLE
Fix disciple attribute docs

### DIFF
--- a/docs/disciples.md
+++ b/docs/disciples.md
@@ -82,6 +82,18 @@ export function intelligenceXpMultiplier(task) {
 
 Increasing **Strength** speeds up XP gain for mining, smithing, and logging jobs. **Dexterity** now boosts XP for woodcutting and gathering, while **Intelligence** grants extra XP when chanting or researching. **Endurance** continues to help disciples learn faster when building or defending.
 
+## Attribute Point Effects
+
+Beyond improving XP gain, each attribute provides passive bonuses based on the
+number of points invested:
+
+- **Strength** – increases melee damage by 5% per point and grants one extra
+  inventory slot for every 2 points.
+- **Endurance** – raises maximum stamina by 5% per point, improves stamina
+  regeneration by 1% per point and adds 10&nbsp;HP per point.
+- **Dexterity** – speeds up attack animations by 5% per point.
+- **Intelligence** – boosts the potency of constructs by 3% per point.
+
 ## XP Gain Rates
 
 Each task provides a small amount of skill XP whenever a work cycle is completed. The base cycle lengths are derived from constants in `script.js`:

--- a/script.js
+++ b/script.js
@@ -1639,7 +1639,9 @@ function buildDiscipleStatusView(d) {
     {
       label: 'Strength',
       value: d.strength,
-      effect: `Melee Damage ×${(1 + 0.05 * (d.strength - 1)).toFixed(2)}`,
+      effect:
+        `Melee Damage ×${(1 + 0.05 * (d.strength - 1)).toFixed(2)}, ` +
+        `+${Math.floor((d.strength - 1) / 2)} Inventory Slots`,
       skills: 'Log Pine, Mining & Smithing'
     },
     {
@@ -1657,7 +1659,10 @@ function buildDiscipleStatusView(d) {
     {
       label: 'Endurance',
       value: d.endurance,
-      effect: `Stamina ×${(1 + 0.05 * (d.endurance - 1)).toFixed(2)}`,
+      effect:
+        `Stamina ×${(1 + 0.05 * (d.endurance - 1)).toFixed(2)}, ` +
+        `Regen ×${(1 + 0.01 * (d.endurance - 1)).toFixed(2)}, ` +
+        `+${10 * (d.endurance - 1)} HP`,
       skills: 'Building, Defending & Combat'
     }
   ];


### PR DESCRIPTION
## Summary
- document passive bonuses from attribute points
- display disciple attribute effects including inventory slots and regen

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686ad3704f08832690a10d3a5871c5fd