### PR TITLE
Fix chanter display update

### DIFF
--- a/script.js
+++ b/script.js
@@ -1388,6 +1388,10 @@ function renderColonyInfo() {
       renderColonyTasks();
       renderColonyInfo();
       updateSectDisplay();
+      // Ensure constructor panel reflects new chanter assignments
+      if (typeof renderChantDisciples === 'function') {
+        renderChantDisciples();
+      }
     });
 
     taskList.appendChild(option);


### PR DESCRIPTION
## Summary
- update `renderColonyInfo` task selector to refresh available chanters list when tasks change

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ad3f5e0b88326a9aacadf161b9187