### PR TITLE
Fix chanter removal logic

### DIFF
--- a/script.js
+++ b/script.js
@@ -1415,8 +1415,15 @@ function renderColonyInfo() {
     option.appendChild(bar);
 
     option.addEventListener('click', () => {
+      const prev = sectState.discipleTasks[d.id];
       sectState.discipleTasks[d.id] = t;
       discipleGatherPhase[d.id] = -1;
+      if (prev === 'Chant' && t !== 'Chant') {
+        delete sectState.chantAssignments[d.id];
+        if (typeof renderConstructCards === 'function') {
+          renderConstructCards();
+        }
+      }
       renderColonyTasks();
       renderColonyInfo();
       updateSectDisplay();

--- a/speech.js
+++ b/speech.js
@@ -627,6 +627,10 @@ function renderConstructCards() {
         selectedChanter = null;
         renderChantDisciples();
         renderConstructCards();
+      } else if (assignedId) {
+        delete sectState.chantAssignments[assignedId];
+        renderChantDisciples();
+        renderConstructCards();
       }
     });
     wrapper.appendChild(assign);


### PR DESCRIPTION
## Summary
- remove chant assignment when disciple leaves Chant task
- allow unassigning a chanter from a construct

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ada1d574c8326a8de06f3e16c8b3b