### PR TITLE
Boost gather yield bonus

### DIFF
--- a/docs/disciples.md
+++ b/docs/disciples.md
@@ -95,10 +95,10 @@ Increasing **Strength** speeds up XP gain for mining, smithing, and logging jobs
 ### Gathering Yield
 
 Proficiency does more than just award XP. For gathering tasks, every skill level
-increases the yield by **2%**, using the same logic as the game code:
+increases the yield by **5%**, using the same logic as the game code:
 
 ```javascript
-const yieldMult = 1 + 0.02 * level;
+const yieldMult = 1 + 0.05 * level;
 const gatherAmt = Math.min(cycleAmount * yieldMult, disciple.inventorySlots);
 ```
 

--- a/script.js
+++ b/script.js
@@ -1050,7 +1050,7 @@ function tickSect(delta) {
       const prog = sectState.discipleProgress[d.id];
       const skillXp = sectState.discipleSkills[d.id]?.[task] || 0;
       const lvl = getTaskSkillProgress(skillXp).level;
-      const yieldMult = 1 + 0.02 * lvl;
+      const yieldMult = 1 + 0.05 * lvl;
       const gatherAmt = Math.min(cycleAmount * yieldMult, d.inventorySlots);
       const cycleSeconds =
         baseSeconds * (gatherAmt / (cycleAmount * yieldMult));
@@ -1170,7 +1170,7 @@ function updateTaskProgressDisplay() {
         taskName === 'Gather Fruit' ? FRUIT_CYCLE_AMOUNT : PINE_LOG_CYCLE_AMOUNT;
       const skillXp = sectState.discipleSkills[d.id]?.[taskName] || 0;
       const lvl = getTaskSkillProgress(skillXp).level;
-      const yieldMult = 1 + 0.02 * lvl;
+      const yieldMult = 1 + 0.05 * lvl;
       const gatherAmt = Math.min(cycleAmount * yieldMult, d.inventorySlots);
       const cycleSeconds = baseSeconds * (gatherAmt / (cycleAmount * yieldMult));
       const phaseLength = cycleSeconds / 4;
@@ -1298,7 +1298,7 @@ function updateDiscipleGather(id, el) {
   const lvl = getTaskSkillProgress(
     sectState.discipleSkills[id]?.[task] || 0
   ).level;
-  const yieldMult = 1 + 0.02 * lvl;
+  const yieldMult = 1 + 0.05 * lvl;
   const gatherAmt = Math.min(cycleAmount * yieldMult, d?.inventorySlots || 10);
   const cycleSeconds = baseSeconds * (gatherAmt / (cycleAmount * yieldMult));
   const phaseLength = cycleSeconds / 4;
@@ -1762,7 +1762,8 @@ function buildDiscipleLifeStatsView(d) {
     const xp = skillMap[t.name] || 0;
     const prog = getTaskSkillProgress(xp);
     const row = document.createElement('div');
-    const mult = 1 + 0.02 * prog.level;
+    const isGather = t.name === 'Gather Fruit' || t.name === 'Log Pine';
+    const mult = 1 + (isGather ? 0.05 : 0.02) * prog.level;
     row.textContent = `${t.name} Lv ${prog.level} (×${mult.toFixed(2)} ${t.effect})`;
     body.appendChild(row);
   });


### PR DESCRIPTION
## Summary
- increase pine logging and fruit gathering yield gain to 5% per level
- show new yield bonus in life stats panel
- document the new gather yield improvement

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686adb5d0f808326a76422313fdc8e3a