### PR TITLE
Add Mnemonic Rhythm construct

### DIFF
--- a/docs/phrase-system.md
+++ b/docs/phrase-system.md
@@ -27,6 +27,7 @@ The phrase builder has been replaced with a simpler construct mechanic. The **Co
 | **Clarity Pulse**    | Thought + Insight         | 20 Thought + 50 Sound                   | 30s      | Single-cast, Buff, Duration        | Gain 1% Insight per s *(Unlocks at Mind Lv.2, 1700 Insight)* |
 | **Symbol Seed**      | Sound + Thought           | Drains 1 Thought per second                   | 30s      | Duration, Generator, Drain         | Gain 0.1 Structure per thought drained *(Unlocks at Mind Lv.3, 2000 Insight)* |
 | **Intone**           | —                         | None                                          | 30s      | Buff                               | Press repeatedly to charge; 1.2× Insight at 5 presses, 1.5× at 10, 2× at 15 for 30s *(Unlocked after Murmur ×10)* |
+| **Mnemonic Rhythm**  | —                         | 50 Sound               | 30s      | Buff                               | Grants ×2 XP to other constructs for 3s; +0.2× per potency point *(Unlocked after Murmur ×3 in a row)* |
 | **Mental Construct** | Thought + Insight + Sound | 10 Thought + 10 Structure + 1000 Insight      | 10s      | Single-cast                        | Gain 0.1 elemental essence based on season *(Unlocks at Voice Lv.5 & Mind Lv.5, 2300 Insight)* |
 | **The Calling**     | —                         | 200 Sound                                    | 5m       | Action                               | Attempts to recruit a Disciple based on Calling potency |
 

--- a/style.css
+++ b/style.css
@@ -937,6 +937,29 @@ body.darkenshift-mode .tabsContainer button.active {
     font-size: 0.8rem;
     pointer-events: none;
 }
+.mnemonic-bar {
+    position: absolute;
+    left: 0;
+    bottom: 0;
+    width: 100%;
+    height: 4px;
+    background: #333;
+}
+.mnemonic-bar-fill {
+    width: 0%;
+    height: 100%;
+    background: #ffd27d;
+}
+.mnemonic-beats {
+    position: absolute;
+    top: 2px;
+    right: 2px;
+    font-size: 0.8rem;
+    pointer-events: none;
+}
+.construct-card.mnemonic-active {
+    box-shadow: 0 0 6px #ffd27d;
+}
 .mult-badge {
     margin-left: 4px;
 }


### PR DESCRIPTION
## Summary
- add Mnemonic Rhythm construct for bonus XP
- tweak Intone cooldown logic to apply only when fully charged
- show Mnemonic Rhythm UI
- document Mnemonic Rhythm in phrase-system guide

## Testing
- `npm test --silent` *(fails: mocha not found)*
- `npm run lint --silent` *(fails: cannot find '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686c4cb7da3c8326b56f05ac3611d912