### PR TITLE
Improve construct cards

### DIFF
--- a/docs/phrase-system.md
+++ b/docs/phrase-system.md
@@ -37,3 +37,15 @@ The phrase builder has been replaced with a simpler construct mechanic. The **Co
 ### Upgrades
 
 - **Sound Expansion** – costs 25 Sound for the first level and increases your maximum Sound by 25. The second level costs 50 Sound and grants an additional construct slot. Each further level costs 4 more Sound than the last.
+
+### Card Border Glows
+
+When a construct card is hovered or selected in the **Lexicon** or **Construct** tab, its border glows to match its element:
+
+- **Murmur** – Metallic Grey
+- **Echo of Mind** – Violet
+- **Clarity Pulse** – Sky Blue
+- **Symbol Seed** – Violet
+- **Intone** – Sky Blue
+- **Mental Construct** – Amber
+- **Mnemonic Rhythm** – Gold

--- a/speech.js
+++ b/speech.js
@@ -269,6 +269,16 @@ export const constructEffectText = {
   'The Calling': 'Attempts to recruit a Disciple based on Calling potency'
 };
 
+export const constructColors = {
+  'Murmur': '#b0b0b0', // Metallic Grey
+  'Echo of Mind': '#8a2be2', // Violet
+  'Clarity Pulse': '#87ceeb', // Sky Blue
+  'Symbol Seed': '#8a2be2', // Violet
+  'Intone': '#87ceeb', // Sky Blue
+  'Mental Construct': '#ffbf00', // Amber
+  'Mnemonic Rhythm': '#ffd700' // Gold
+};
+
 function xpRequired(level) {
   return Math.round(50 * Math.pow(1.2, level));
 }
@@ -735,6 +745,8 @@ export function createConstructCard(name) {
   const card = document.createElement('div');
   card.className = 'construct-card';
   card.dataset.name = name;
+  const color = constructColors[name];
+  if (color) card.style.setProperty('--element-color', color);
   const title = document.createElement('div');
   title.className = 'construct-name';
   title.textContent = name;

--- a/style.css
+++ b/style.css
@@ -958,7 +958,7 @@ body.darkenshift-mode .tabsContainer button.active {
     pointer-events: none;
 }
 .construct-card.mnemonic-active {
-    box-shadow: 0 0 6px #ffd27d;
+    box-shadow: 0 0 6px var(--element-color, #ffd27d);
 }
 .mult-badge {
     margin-left: 4px;
@@ -2857,17 +2857,20 @@ body.darkenshift-mode .tabsContainer button.active {
     height: 90px;
     padding: 3px 6px 6px;
     border: 1px solid #555;
-    border-radius: 4px;
+    border-radius: 8px;
     font-size: 0.9rem;
     cursor: pointer;
     background: #111;
     color: #eee;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.4);
+    transition: transform 0.15s ease-out, box-shadow 0.15s ease-out, border-color 0.15s ease-out;
 }
-.construct-card.active {
-    box-shadow: 0 0 6px #ffd27d;
-}
-.construct-card:hover {
-    box-shadow: 0 0 6px #999;
+.construct-card.active,
+.construct-card:hover,
+.construct-card:active {
+    transform: scale(1.05);
+    border-color: var(--element-color, #ffd27d);
+    box-shadow: 0 0 6px var(--element-color, #999);
 }
 
 .construct-card.collapsed > *:not(.construct-name) {


### PR DESCRIPTION
## Summary
- add element color mapping for each construct
- style construct cards with default shadow and animated glow
- document border glow colors for each construct card

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c71a5fd208326b21dcc1ff8b6fca2