### PR TITLE
Add cooldown bar to construct cards

### DIFF
--- a/speech.js
+++ b/speech.js
@@ -793,9 +793,12 @@ export function createConstructCard(name) {
       card.appendChild(bar);
     }
     if (recipe.cooldown) {
-      const overlay = document.createElement('div');
-      overlay.className = 'cooldown-overlay';
-      card.appendChild(overlay);
+      const bar = document.createElement('div');
+      bar.className = 'cooldown-bar';
+      const fill = document.createElement('div');
+      fill.className = 'cooldown-bar-fill';
+      bar.appendChild(fill);
+      card.appendChild(bar);
     }
   } else {
     card.textContent = name;
@@ -1335,8 +1338,8 @@ function updateCooldownOverlays() {
     if (!def) return;
     const remaining = def.cooldown ? (speechState.cooldowns[name] || 0) : 0;
     const ratio = def.cooldown ? 1 - remaining / def.cooldown : 1;
-    const overlay = card.querySelector('.cooldown-overlay');
-    if (overlay) overlay.style.setProperty('--cooldown', ratio);
+    const fill = card.querySelector('.cooldown-bar-fill');
+    if (fill) fill.style.width = `${ratio * 100}%`;
     const cost = def.castCost || def.input || {};
     const affordable = Object.entries(cost).every(([res, amt]) => {
       const r = speechState.resources[res];

--- a/style.css
+++ b/style.css
@@ -910,6 +910,23 @@ body.darkenshift-mode .tabsContainer button.active {
     border-radius: 4px;
 }
 
+.cooldown-bar {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: 4px;
+    background: #333;
+    border-radius: 0 0 4px 4px;
+    overflow: hidden;
+}
+
+.cooldown-bar-fill {
+    height: 100%;
+    width: 0%;
+    background: var(--element-color, #ffd27d);
+}
+
 .intone-meter {
     display: grid;
     grid-template-columns: repeat(15, 1fr);


### PR DESCRIPTION
## Summary
- display cooldown as a horizontal bar under each construct card
- update the JS logic to populate the bar

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c976f6e808326a82dfbcc76179f1e