### PR TITLE
Polish construct UI

### DIFF
--- a/speech.js
+++ b/speech.js
@@ -515,7 +515,7 @@ export function initSpeech() {
             <div id="memorySlotsDisplay" class="memory-slots"></div>
             <div id="constructDisciples" class="construct-disciples"></div>
           </div>
-          <div id="constructCards" class="built-constructs"></div>
+          <div id="constructCardGrid" class="built-constructs crystal-backdrop"></div>
           <div id="constructStats" class="construct-stats"></div>
         </div>
       </div>
@@ -693,7 +693,7 @@ function addConstruct(name) {
 }
 
 function renderConstructCards() {
-  const cont = panel.querySelector('#constructCards');
+  const cont = panel.querySelector('#constructCardGrid');
   const slotCont = panel.querySelector('#memorySlotsDisplay');
   if (!cont || !slotCont) return;
   cont.innerHTML = '';
@@ -844,7 +844,7 @@ export function createConstructInfo(name) {
     .map(([res, amt]) => `${amt} <i data-lucide="${resourceIcons[res] || 'package'}"></i>`)
     .join(' ');
   const cd = recipe.cooldown || 0;
-  const pot = speechState.constructPotency[name] || 1;
+  const pot = (speechState.constructPotency[name] || 1).toFixed(2);
   const eff = getConstructEffect(name) || '';
   info.innerHTML = `<div class="stat-line"><span class="stat-cost">Cost: ${costHtml || '—'}</span> <span class="stat-cd">CD: ${cd} s</span> <span class="stat-potency">Potency: ${pot}</span></div><div class="stat-line">Effect: ${eff}</div>`;
   if (window.lucide) lucide.createIcons({ icons: lucide.icons });
@@ -874,7 +874,7 @@ function showConstructStats(name) {
     .map(([res, amt]) => `${amt} <i data-lucide="${resourceIcons[res] || 'package'}"></i>`)
     .join(' ');
   const cd = recipe.cooldown || 0;
-  const pot = speechState.constructPotency[name] || 1;
+  const pot = (speechState.constructPotency[name] || 1).toFixed(2);
   const eff = getConstructEffect(name) || '';
   statsEl.innerHTML = `<div class="stat-line"><span class="stat-cost">Cost: ${costHtml || '—'}</span> <span class="stat-cd">CD: ${cd} s</span> <span class="stat-potency">Potency: ${pot}</span></div><div class="stat-line">Effect: ${eff}</div>`;
   if (window.lucide) lucide.createIcons({ icons: lucide.icons });

--- a/style.css
+++ b/style.css
@@ -3102,16 +3102,21 @@ body.darkenshift-mode .tabsContainer button.active {
     position: relative; /* allow background texture overlay */
 }
 
-.built-constructs::before {
+.crystal-backdrop {
+    position: relative;
+}
+
+.crystal-backdrop::before {
     content: "";
     position: absolute;
     inset: 0;
-    background: url('img/crystal-pattern.png');
+    background: linear-gradient(rgba(0, 0, 64, 0.3), rgba(0, 0, 64, 0.3)), url('img/crystal-pattern.png');
     background-size: cover;
     opacity: 0.1;
     pointer-events: none;
     z-index: -1;
 }
+
 .construct-lexicon {
     justify-content: center;
 }
@@ -3148,6 +3153,8 @@ body.darkenshift-mode .tabsContainer button.active {
     align-items: center;
     gap: 6px;
     width: 100%;
+    backdrop-filter: blur(8px);
+    background: rgba(255, 255, 255, 0.05);
 }
 
 .slots-and-disciples {
@@ -3787,7 +3794,7 @@ body.darkenshift-mode .tabsContainer button.active {
 }
 
 .construct-info {
-    font-size: 0.55rem;
+    font-size: 0.45rem;
     text-align: center;
     display: none;
     flex-direction: column;
@@ -3803,8 +3810,8 @@ body.darkenshift-mode .tabsContainer button.active {
 }
 
 .construct-info i {
-    width: 8px;
-    height: 8px;
+    width: 6px;
+    height: 6px;
 }
 
 .construct-icons {
@@ -3812,7 +3819,7 @@ body.darkenshift-mode .tabsContainer button.active {
     flex-direction: column;
     align-items: center;
     gap: 2px;
-    font-size: 0.55rem;
+    font-size: 0.45rem;
 }
 .construct-icons .icon-row {
     display: flex;
@@ -3820,12 +3827,12 @@ body.darkenshift-mode .tabsContainer button.active {
     align-items: center;
 }
 .construct-icons i {
-    width: 8px;
-    height: 8px;
+    width: 6px;
+    height: 6px;
 }
 
 .construct-icon {
-    font-size: 1.2rem;
+    font-size: 1rem;
     margin-bottom: 2px;
 }
 
@@ -3834,12 +3841,13 @@ body.darkenshift-mode .tabsContainer button.active {
     border-bottom: 1px solid #555;
     padding: 4px;
     margin-top: 6px;
-    font-size: 0.65rem;
+    font-size: 0.55rem;
     text-align: center;
     display: flex;
     flex-direction: column;
     gap: 2px;
     align-items: center;
+    min-height: 32px;
 }
 
 .construct-stats .stat-line {


### PR DESCRIPTION
## Summary
- apply crystal backdrop only to construct cards on the construct tab
- add blur effect to card panel and shrink stats text/icons
- round potency values to two decimals
- rename card grid to avoid confusion

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d2ca508588326a85d192ae3cc4989