### PR TITLE
UI tweaks for construct cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -246,7 +246,7 @@
             </div>
           </div>
           <div class="construct-main">
-            <div id="constructTabCardContainer" class="construct-panel"></div>
+            <div id="constructTabCardContainer" class="construct-panel built-constructs crystal-backdrop"></div>
             <div id="constructGains" class="construct-gains"></div>
           </div>
         </div>

--- a/speech.js
+++ b/speech.js
@@ -515,7 +515,7 @@ export function initSpeech() {
             <div id="memorySlotsDisplay" class="memory-slots"></div>
             <div id="constructDisciples" class="construct-disciples"></div>
           </div>
-          <div id="modalCardContainer" class="built-constructs crystal-backdrop"></div>
+          <div id="modalCardContainer" class="built-constructs"></div>
           <div id="constructStats" class="construct-stats"></div>
         </div>
       </div>

--- a/style.css
+++ b/style.css
@@ -3110,11 +3110,16 @@ body.darkenshift-mode .tabsContainer button.active {
     content: "";
     position: absolute;
     inset: 0;
-    background: linear-gradient(rgba(0, 0, 64, 0.3), rgba(0, 0, 64, 0.3)), url('img/crystal-pattern.png');
+    background: linear-gradient(rgba(10, 20, 60, 0.8), rgba(10, 20, 60, 0.8)), url('img/crystal-pattern.png');
     background-size: cover;
     opacity: 0.1;
     pointer-events: none;
     z-index: -1;
+}
+
+#constructTabCardContainer {
+    backdrop-filter: blur(8px);
+    background: rgba(255, 255, 255, 0.05);
 }
 
 .construct-lexicon {
@@ -3794,11 +3799,17 @@ body.darkenshift-mode .tabsContainer button.active {
 }
 
 .construct-info {
-    font-size: 0.45rem;
+    font-size: 0.4rem;
     text-align: center;
     display: none;
     flex-direction: column;
     gap: 2px;
+    min-height: 24px;
+}
+.construct-info .stat-line {
+    display: flex;
+    justify-content: center;
+    gap: 4px;
 }
 
 .construct-card-wrapper.expanded .construct-info {
@@ -3810,8 +3821,8 @@ body.darkenshift-mode .tabsContainer button.active {
 }
 
 .construct-info i {
-    width: 6px;
-    height: 6px;
+    width: 5px;
+    height: 5px;
 }
 
 .construct-icons {
@@ -3819,7 +3830,7 @@ body.darkenshift-mode .tabsContainer button.active {
     flex-direction: column;
     align-items: center;
     gap: 2px;
-    font-size: 0.45rem;
+    font-size: 0.4rem;
 }
 .construct-icons .icon-row {
     display: flex;
@@ -3827,8 +3838,8 @@ body.darkenshift-mode .tabsContainer button.active {
     align-items: center;
 }
 .construct-icons i {
-    width: 6px;
-    height: 6px;
+    width: 5px;
+    height: 5px;
 }
 
 .construct-icon {


### PR DESCRIPTION
## Summary
- use crystal backdrop on construct tab cards instead of modal
- add frosted glass styling to card container
- lighten crystal pattern and tint navy
- shrink construct info fonts and icons
- keep potency display to two decimals

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d4ba9652483268ede9fb13c25d878