### PR TITLE
Improve Sect tab visuals

### DIFF
--- a/script.js
+++ b/script.js
@@ -209,6 +209,17 @@ const CHANT_XP_PER_CYCLE = 0.5;
 const EXPLORATION_CYCLE_SECONDS = 150;
 const STAMINA_DRAIN_PER_EXPLORATION = 1;
 
+const TASK_ICONS = {
+  'Gather Fruit': '🍎',
+  'Log Pine': '🪵',
+  Building: '⚒️',
+  Research: '🔬',
+  Chant: '🎶',
+  Exploration: '🧭',
+  'Delve Dungeon': '🗝️',
+  Idle: '💤'
+};
+
 const LOCATION_DEFS = [
   { name: 'Firewood Grove', reqDistance: 100, baseChance: 0.2, x: '30%', y: '70%' },
   { name: 'Crystal Cavern', reqDistance: 300, baseChance: 0.15, x: '70%', y: '40%' },
@@ -1448,20 +1459,37 @@ function startDiscipleMovement() {
 
 function renderColonyTasks() {
   colonyTasksPanel.innerHTML = '';
+  const heading = document.createElement('div');
+  heading.className = 'panel-heading';
+  heading.textContent = 'Tasks';
+  colonyTasksPanel.appendChild(heading);
+
   speechState.disciples.forEach(d => {
     const row = document.createElement('div');
     row.className = 'task-entry';
     if (d.id === selectedDiscipleId) row.classList.add('selected');
+    const current = sectState.discipleTasks[d.id] || 'Idle';
+    if (current === 'Idle') row.classList.add('idle');
     row.addEventListener('click', () => {
       selectedDiscipleId = d.id;
       renderColonyTasks();
       renderColonyInfo();
     });
+    const icon = document.createElement('span');
+    icon.textContent = TASK_ICONS[current] || '⚪️';
     const label = document.createElement('div');
-    label.textContent = `Disciple #${d.id}`;
+    label.textContent = d.name || `Disciple ${d.id}`;
+    label.addEventListener('dblclick', () => {
+      const nn = prompt('Rename disciple', d.name || `Disciple ${d.id}`);
+      if (nn) {
+        d.name = nn;
+        renderColonyTasks();
+        renderColonyInfo();
+      }
+    });
     const taskName = document.createElement('div');
     taskName.className = 'disciple-task-name';
-    taskName.textContent = sectState.discipleTasks[d.id] || 'Idle';
+    taskName.textContent = current;
 
     const taskInfo = document.createElement('div');
     taskInfo.className = 'disciple-task-info';
@@ -1481,6 +1509,7 @@ function renderColonyTasks() {
     rate.id = `disciple-rate-${d.id}`;
     taskInfo.appendChild(rate);
 
+    row.appendChild(icon);
     row.appendChild(label);
     row.appendChild(taskName);
     row.appendChild(taskInfo);
@@ -1491,9 +1520,15 @@ function renderColonyTasks() {
 
 function renderColonyInfo() {
   colonyInfoPanel.innerHTML = '';
+  const heading = document.createElement('div');
+  heading.className = 'panel-heading';
+  heading.textContent = 'Proficiencies';
+  colonyInfoPanel.appendChild(heading);
   const d = speechState.disciples.find(x => x.id === selectedDiscipleId);
   if (!d) {
-    colonyInfoPanel.textContent = 'Select a disciple';
+    const info = document.createElement('div');
+    info.textContent = 'Select a disciple';
+    colonyInfoPanel.appendChild(info);
     return;
   }
   const taskList = document.createElement('div');

--- a/style.css
+++ b/style.css
@@ -3567,6 +3567,7 @@ body.darkenshift-mode .tabsContainer button.active {
     flex: 1;
     width: 100%;
     position: relative;
+    min-height: 200px;
 }
 
 .colony-side {
@@ -3574,6 +3575,12 @@ body.darkenshift-mode .tabsContainer button.active {
     display: flex;
     gap: 6px;
     flex: 1;
+}
+#colonyTasksPanel {
+    border-right: 1px solid var(--core-border);
+}
+#colonyInfoPanel {
+    border-left: 1px solid var(--core-border);
 }
 .colony-panel {
     flex: 1;
@@ -3596,6 +3603,9 @@ body.darkenshift-mode .tabsContainer button.active {
 .task-entry.selected {
     background: #333;
 }
+.task-entry.idle {
+    opacity: 0.5;
+}
 .disciple-task-name {
     min-width: 80px;
 }
@@ -3608,8 +3618,8 @@ body.darkenshift-mode .tabsContainer button.active {
 .disciple-progress {
     position: relative;
     width: 120px;
-    height: 12px;
-    background: #222;
+    height: 10px;
+    background: #333;
     border: 1px solid #555;
     border-radius: 4px;
     overflow: hidden;
@@ -3620,7 +3630,7 @@ body.darkenshift-mode .tabsContainer button.active {
     left: 0;
     height: 100%;
     width: 0%;
-    background: #6b5b95;
+    background: var(--core-accent);
     transition: width 0.3s ease;
 }
 .disciple-progress-label {
@@ -3638,6 +3648,12 @@ body.darkenshift-mode .tabsContainer button.active {
     font-size: 0.7rem;
     text-align: right;
     color: #ddd;
+}
+.panel-heading {
+    font-weight: 600;
+    font-size: 0.8rem;
+    text-align: center;
+    margin-bottom: 4px;
 }
 .sect-disciples {
     text-align: center;
@@ -3900,7 +3916,7 @@ body.darkenshift-mode .tabsContainer button.active {
     position: relative;
     width: 100%;
     height: 8px;
-    background: #222;
+    background: #333;
     border: 1px solid #555;
     border-radius: 4px;
     overflow: hidden;
@@ -3909,7 +3925,7 @@ body.darkenshift-mode .tabsContainer button.active {
     position: absolute;
     top: 0; left: 0; bottom: 0;
     width: 0%;
-    background: #6b5b95;
+    background: var(--core-accent);
     transition: width 0.3s ease;
 }
 


### PR DESCRIPTION
## Summary
- refine Sect panel layout with borders, headings, and progress bar colors
- show task icons and renameable disciple names
- dim idle workers
- ensure map keeps a minimum height

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d4c21a7ec8326a53f0da12ebe2c24