### PR TITLE
Enhance construct panel backdrop and orbs

### DIFF
--- a/index.html
+++ b/index.html
@@ -246,7 +246,7 @@
             </div>
           </div>
           <div class="construct-main">
-            <div id="constructTabCardContainer" class="construct-panel built-constructs crystal-backdrop"></div>
+            <div id="constructTabCardContainer" class="construct-panel built-constructs construct-area"></div>
             <div id="constructGains" class="construct-gains"></div>
           </div>
         </div>

--- a/speech.js
+++ b/speech.js
@@ -476,20 +476,26 @@ export function initSpeech() {
       <div class="orbs-section">
         <h3 class="section-title">Core Orbs</h3>
         <div class="construct-orbs construct-tab-orbs">
-          <div id="orbInsightContainer" class="orb-container">
-          <div id="orbInsight" class="construct-orb"><div class="orb-fill"></div></div>
+          <div id="orbInsightContainer" class="orb-wrapper">
+            <div class="orb-container">
+              <div id="orbInsight" class="construct-orb"><div class="orb-fill"></div></div>
+            </div>
             <div id="orbInsightValue" class="orb-value"></div>
             <div id="orbInsightRegen" class="orb-regen">
               <span class="season-icon"></span><span class="regen-value"></span><span id="intoneMultiplier" class="mult-badge"></span>
             </div>
           </div>
-          <div id="orbBodyContainer" class="orb-container" style="display:none">
-          <div id="orbBody" class="construct-orb"><div class="orb-fill"></div></div>
+          <div id="orbBodyContainer" class="orb-wrapper" style="display:none">
+            <div class="orb-container">
+              <div id="orbBody" class="construct-orb"><div class="orb-fill"></div></div>
+            </div>
             <div id="orbBodyValue" class="orb-value"></div>
             <div id="orbBodyRegen" class="orb-regen"></div>
           </div>
-          <div id="orbWillContainer" class="orb-container" style="display:none">
-          <div id="orbWill" class="construct-orb"><div class="orb-fill"></div></div>
+          <div id="orbWillContainer" class="orb-wrapper" style="display:none">
+            <div class="orb-container">
+              <div id="orbWill" class="construct-orb"><div class="orb-fill"></div></div>
+            </div>
             <div id="orbWillValue" class="orb-value"></div>
             <div id="orbWillRegen" class="orb-regen"></div>
           </div>

--- a/style.css
+++ b/style.css
@@ -2706,12 +2706,27 @@ body.darkenshift-mode .tabsContainer button.active {
     to { background-position: 100% 0; }
 }
 
-.orb-container {
+.orb-wrapper {
     display: flex;
     flex-direction: column;
     align-items: center;
     gap: 2px;
     padding: 4px;
+}
+
+.orb-container {
+    display: inline-block;
+    padding: 8px;
+    border-radius: 50%;
+    background: rgba(255,255,255,0.05);
+    box-shadow: 0 0 16px rgba(100,180,240,0.6),
+                inset 0 0 8px rgba(255,255,255,0.2);
+    transition: box-shadow 0.3s ease;
+}
+
+.orb-container:hover {
+    box-shadow: 0 0 24px rgba(100,180,240,0.8),
+                inset 0 0 12px rgba(255,255,255,0.3);
 }
 
 .orb-value {
@@ -3102,19 +3117,32 @@ body.darkenshift-mode .tabsContainer button.active {
     position: relative; /* allow background texture overlay */
 }
 
-.crystal-backdrop {
-    position: relative;
-}
 
-.crystal-backdrop::before {
-    content: "";
-    position: absolute;
-    inset: 0;
-    background: linear-gradient(rgba(10, 20, 60, 0.8), rgba(10, 20, 60, 0.8)), url('img/crystal-pattern.png');
-    background-size: cover;
-    opacity: 0.1;
-    pointer-events: none;
-    z-index: -1;
+.construct-area {
+    position: relative;
+    padding: 32px;
+    border-radius: 8px;
+    background:
+        repeating-linear-gradient(
+            60deg,
+            rgba(255,255,255,0.03),
+            rgba(255,255,255,0.03) 1px,
+            transparent 1px,
+            transparent 20px
+        ),
+        repeating-linear-gradient(
+            -60deg,
+            rgba(255,255,255,0.03),
+            rgba(255,255,255,0.03) 1px,
+            transparent 1px,
+            transparent 20px
+        ),
+        radial-gradient(
+            circle at top center,
+            rgba(60,70,90,0.4),
+            rgba(20,25,35,0.8)
+        );
+    z-index: 0;
 }
 
 #constructTabCardContainer {


### PR DESCRIPTION
## Summary
- add CSS for construct area backdrop and orb glow
- update construct tab markup to apply new styles
- wrap orbs with new glow container

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d50c3a2008326a2a83586fbe6d57b