### PR TITLE
Implement seasonal backdrop

### DIFF
--- a/speech.js
+++ b/speech.js
@@ -35,6 +35,21 @@ const seasonIcons = ['\uD83C\uDF31', '\u2600\uFE0F', '\u2728', '\uD83C\uDF42', '
 const seasonClasses = ['spring','summer','aurora','autumn','winter'];
 const seasonTemps = [15, 25, 20, 10, -5];
 
+export const SEASON_COLORS = {
+  Verdantia: ['rgba(40,90,40,0.4)', 'rgba(20,40,20,0.8)'],
+  Solaria: ['rgba(120,50,20,0.4)', 'rgba(60,20,10,0.8)'],
+  Aurora: ['rgba(100,80,40,0.4)', 'rgba(50,40,20,0.8)'],
+  Aurelia: ['rgba(90,90,100,0.4)', 'rgba(40,40,50,0.8)'],
+  Bruma: ['rgba(40,80,100,0.4)', 'rgba(20,40,50,0.8)']
+};
+
+export function setSeasonBackdrop(season) {
+  const [start, end] = SEASON_COLORS[season];
+  const root = document.documentElement;
+  root.style.setProperty('--season-start', start);
+  root.style.setProperty('--season-end', end);
+}
+
 
 export const speechState = {
   orbs: {
@@ -1070,6 +1085,7 @@ function renderSeasonBanner() {
   if (!banner) return;
   const idx = speechState.seasonIndex;
   const season = seasons[idx];
+  setSeasonBackdrop(season.name);
   const day = speechState.seasonDay + 1;
   const daysLeft = SEASON_LENGTH_DAYS - day;
   const temp = seasonTemps[idx];

--- a/style.css
+++ b/style.css
@@ -27,6 +27,8 @@ body {
     --core-accent: #7fafff;
     --core-text: #e0e0f0;
     --core-glow: rgba(127, 175, 255, 0.2);
+    --season-start: rgba(60,70,90,0.4);
+    --season-end: rgba(20,25,35,0.8);
 }
 
 body.darkenshift-mode {
@@ -3139,8 +3141,8 @@ body.darkenshift-mode .tabsContainer button.active {
         ),
         radial-gradient(
             circle at top center,
-            rgba(60,70,90,0.4),
-            rgba(20,25,35,0.8)
+            var(--season-start),
+            var(--season-end)
         );
     z-index: 0;
 }


### PR DESCRIPTION
## Summary
- support seasonal color variables in `style.css`
- update construct area gradient to use seasonal variables
- add `SEASON_COLORS` and `setSeasonBackdrop` helper in `speech.js`
- call backdrop function in `renderSeasonBanner`

## Testing
- `npm test` *(fails: mocha not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686d9e94c0848326931ebebfc629394b