### PR TITLE
Enable disciple-driven Body regeneration

### DIFF
--- a/speech.js
+++ b/speech.js
@@ -1421,6 +1421,8 @@ function updateMnemonicUI() {
 export function tickSpeech(delta) {
   const hasUI = !!container;
   const dt = delta / 1000;
+  const activeDisc = speechState.disciples.filter(d => !d.incapacitated).length;
+  speechState.gains.body = activeDisc * 0.1;
   if (speechState.intoneTimer > 0) {
     speechState.intoneTimer = Math.max(0, speechState.intoneTimer - dt);
     if (speechState.intoneTimer === 0) {


### PR DESCRIPTION
## Summary
- keep Body orb hidden until there is Body to display
- show Body orb when it contains at least 1 point
- regenerate Body by 0.1 per active disciple

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_686da59b34908326bbf004fe9acc9e6e