### PR TITLE
Adjust construct card icon size

### DIFF
--- a/style.css
+++ b/style.css
@@ -3889,8 +3889,13 @@ body.darkenshift-mode .tabsContainer button.active {
 }
 
 .construct-icon {
-    font-size: 1rem;
+    font-size: 0.9rem;
     margin-bottom: 2px;
+}
+
+.construct-icon .lucide {
+    width: 1em;
+    height: 1em;
 }
 
 .construct-stats {


### PR DESCRIPTION
## Summary
- scale down icons in construct cards to match text

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686da5be0b4c83269b02a49e86bce578