### PR TITLE
Improve season backdrops and construct panel style

### DIFF
--- a/speech.js
+++ b/speech.js
@@ -36,11 +36,11 @@ const seasonClasses = ['spring','summer','aurora','autumn','winter'];
 const seasonTemps = [15, 25, 20, 10, -5];
 
 export const SEASON_COLORS = {
-  Verdantia: ['rgba(40,90,40,0.6)', 'rgba(20,40,20,1.0)'],
-  Solaria: ['rgba(120,50,20,0.6)', 'rgba(60,20,10,1.0)'],
-  Aurora: ['rgba(100,80,40,0.6)', 'rgba(50,40,20,1.0)'],
-  Aurelia: ['rgba(90,90,100,0.6)', 'rgba(40,40,50,1.0)'],
-  Bruma: ['rgba(40,80,100,0.6)', 'rgba(20,40,50,1.0)']
+  Verdantia: ['rgba(80,160,80,0.9)', 'rgba(30,70,30,1.0)'],
+  Solaria: ['rgba(200,120,40,0.9)', 'rgba(90,40,10,1.0)'],
+  Aurora: ['rgba(150,130,80,0.9)', 'rgba(70,50,30,1.0)'],
+  Aurelia: ['rgba(140,140,160,0.9)', 'rgba(60,60,80,1.0)'],
+  Bruma: ['rgba(60,120,160,0.9)', 'rgba(30,60,80,1.0)']
 };
 
 export function setSeasonBackdrop(season) {

--- a/style.css
+++ b/style.css
@@ -27,8 +27,8 @@ body {
     --core-accent: #7fafff;
     --core-text: #e0e0f0;
     --core-glow: rgba(127, 175, 255, 0.2);
-    --season-start: rgba(60,70,90,0.4);
-    --season-end: rgba(20,25,35,0.8);
+    --season-start: rgba(80,160,80,0.9);
+    --season-end: rgba(30,70,30,1.0);
 }
 
 body.darkenshift-mode {
@@ -2990,7 +2990,9 @@ body.darkenshift-mode .tabsContainer button.active {
     background: linear-gradient(#11131c, #0e0f1a);
     border: 1px solid #4a4a60;
     box-shadow: 0 0 8px #7f7fcf;
-    backdrop-filter: blur(4px);
+    backdrop-filter: blur(6px);
+    border-radius: 10px;
+    overflow: hidden;
     display: flex;
     flex-direction: column;
     height: 100%;
@@ -3140,9 +3142,11 @@ body.darkenshift-mode .tabsContainer button.active {
             transparent 20px
         ),
         radial-gradient(
-            circle 150% at top center,
-            var(--season-start),
-            var(--season-end)
+            circle at top center,
+            var(--season-start) 0%,
+            var(--season-start) 20%,
+            var(--season-end) 80%,
+            rgba(0,0,0,0.9) 100%
         );
     background-blend-mode: screen;
     z-index: 0;


### PR DESCRIPTION
## Summary
- intensify season backdrop colors for each season
- fade the construct area background more dramatically
- round and blur the constructor panel edges for a smoother look

## Testing
- `npm test`
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_686dbf9c8e6083269bc7fb8614422291