### PR TITLE
Implement disciple incapacitation logic

### DIFF
--- a/docs/disciples.md
+++ b/docs/disciples.md
@@ -44,6 +44,15 @@ The current inventory contents are shown in the colony interface when viewing a 
 
 Gaining three points in a single stat is therefore possible but uncommon.
 
+## Incapacitation and Resting
+
+When a disciple's health drops to zero they become **incapacitated**. Incapacitated followers
+gather around the Body orb in the Sect tab and emit a red glow while they rest. During this
+time they do not regain stamina and cannot be assigned any tasks. Health steadily returns to
+full over five minutes of real time. Once their health is above zero they begin recovering
+stamina at the normal rate. When stamina reaches its maximum the disciple leaves the resting
+state and may be assigned work again.
+
 ## Task Proficiency
 
 Disciples gain skill experience (XP) for the task they are performing. XP follows an exponential curve where the XP required for each level is `50 × 1.2^level`:

--- a/script.js
+++ b/script.js
@@ -185,6 +185,7 @@ export const sectState = {
   discipleSkills: {}, // map disciple id -> skill levels per task
   discipleConstructXp: {}, // map disciple id -> construct XP
   chantAssignments: {}, // map disciple id -> assigned construct
+  discipleRest: {}, // map disciple id -> time spent resting
   buildings: { pineShack: 0, researchTable: 0, chantingHall: 0 },
   researchPoints: 0,
   researchProgress: 0,
@@ -208,6 +209,8 @@ const RESEARCH_XP_PER_CYCLE = 20;
 const CHANT_XP_PER_CYCLE = 0.5;
 const EXPLORATION_CYCLE_SECONDS = 150;
 const STAMINA_DRAIN_PER_EXPLORATION = 1;
+const DISCIPLE_MAX_HEALTH = 10;
+const REST_TIME_SECONDS = 300; // health fully restored over 5 minutes
 
 const TASK_ICONS = {
   'Gather Fruit': '🍎',
@@ -217,7 +220,8 @@ const TASK_ICONS = {
   Chant: '🎶',
   Exploration: '🧭',
   'Delve Dungeon': '🗝️',
-  Idle: '💤'
+  Idle: '💤',
+  Resting: '🛌'
 };
 
 const LOCATION_DEFS = [
@@ -1119,6 +1123,24 @@ function tickSect(delta) {
     const maxStamina = calculateMaxStamina(d.endurance);
     const regenRate = calculateStaminaRegen(d.endurance);
     d.stamina = Math.min(maxStamina, Math.max(0, d.stamina));
+
+    if (d.incapacitated) {
+      sectState.discipleTasks[d.id] = 'Idle';
+      if (d.health < DISCIPLE_MAX_HEALTH) {
+        d.health = Math.min(
+          DISCIPLE_MAX_HEALTH,
+          d.health + (DISCIPLE_MAX_HEALTH / REST_TIME_SECONDS) * dt
+        );
+      } else {
+        d.stamina = Math.min(maxStamina, d.stamina + regenRate * dt);
+        if (d.stamina >= maxStamina) {
+          d.incapacitated = false;
+          sectState.discipleRest[d.id] = 0;
+        }
+      }
+      return;
+    }
+
     const task = sectState.discipleTasks[d.id];
     if (task === 'Exploration') {
       // drain stamina once per completed cycle
@@ -1267,7 +1289,9 @@ function updateTaskProgressDisplay() {
     const fill = wrapper.querySelector('.disciple-progress-fill');
     const label = wrapper.querySelector('.disciple-progress-label');
     const rateEl = wrapper.querySelector('.disciple-task-rate');
-    const taskName = sectState.discipleTasks[d.id] || 'Idle';
+    const taskName = d.incapacitated
+      ? 'Resting'
+      : sectState.discipleTasks[d.id] || 'Idle';
     if (taskName === 'Gather Fruit' || taskName === 'Log Pine') {
       const progress = sectState.discipleProgress[d.id] || 0;
       const baseSeconds =
@@ -1308,6 +1332,10 @@ function updateTaskProgressDisplay() {
       const pct = (progress / EXPLORATION_CYCLE_SECONDS) * 100;
       if (fill) fill.style.width = `${pct}%`;
       if (label) label.textContent = 'Exploring';
+      if (rateEl) rateEl.textContent = '';
+    } else if (taskName === 'Resting') {
+      if (fill) fill.style.width = '0%';
+      if (label) label.textContent = 'Resting';
       if (rateEl) rateEl.textContent = '';
     } else {
       if (fill) fill.style.width = '0%';
@@ -1450,9 +1478,21 @@ function startDiscipleMovement() {
     speechState.disciples.forEach(d => {
       const el = sectDiscipleEls[d.id];
       if (!el) return;
-      const task = sectState.discipleTasks[d.id];
-      if (task === 'Gather Fruit' || task === 'Log Pine') updateDiscipleGather(d.id, el);
-      else moveDisciple(el);
+      if (d.incapacitated) {
+        const orb = document.querySelector('#sectOrbs .body');
+        if (orb) {
+          const bx = orb.offsetLeft + orb.offsetWidth / 2 - 2;
+          const by = orb.offsetTop + orb.offsetHeight / 2 - 2;
+          el.style.transform = `translate(${bx}px, ${by}px)`;
+        }
+        el.classList.add('incapacitated');
+      } else {
+        el.classList.remove('incapacitated');
+        const task = sectState.discipleTasks[d.id];
+        if (task === 'Gather Fruit' || task === 'Log Pine')
+          updateDiscipleGather(d.id, el);
+        else moveDisciple(el);
+      }
     });
   }, 3000);
 }
@@ -1468,7 +1508,9 @@ function renderColonyTasks() {
     const row = document.createElement('div');
     row.className = 'task-entry';
     if (d.id === selectedDiscipleId) row.classList.add('selected');
-    const current = sectState.discipleTasks[d.id] || 'Idle';
+    const current = d.incapacitated
+      ? 'Resting'
+      : sectState.discipleTasks[d.id] || 'Idle';
     if (current === 'Idle') row.classList.add('idle');
     row.addEventListener('click', () => {
       selectedDiscipleId = d.id;
@@ -1541,6 +1583,7 @@ function renderColonyInfo() {
   tasks.forEach(t => {
     const option = document.createElement('div');
     option.className = 'disciple-skill-option';
+    if (d.incapacitated) option.classList.add('disabled');
 
     const skills =
       sectState.discipleSkills[d.id] || {
@@ -1568,6 +1611,7 @@ function renderColonyInfo() {
     option.appendChild(bar);
 
     option.addEventListener('click', () => {
+      if (d.incapacitated) return;
       const prev = sectState.discipleTasks[d.id];
       sectState.discipleTasks[d.id] = t;
       discipleGatherPhase[d.id] = -1;
@@ -1870,7 +1914,10 @@ function buildDiscipleStatusView(d) {
     body.appendChild(wrapper);
   });
   const task = document.createElement('div');
-  task.textContent = `Current Task: ${sectState.discipleTasks[d.id] || 'Idle'}`;
+  const curTask = d.incapacitated
+    ? 'Resting'
+    : sectState.discipleTasks[d.id] || 'Idle';
+  task.textContent = `Current Task: ${curTask}`;
   body.appendChild(task);
 
   const invRow = document.createElement('div');

--- a/style.css
+++ b/style.css
@@ -3770,6 +3770,10 @@ body.darkenshift-mode .tabsContainer button.active {
     pointer-events: none;
     transition: transform 3s;
 }
+.sect-disciple.incapacitated {
+    background: rgba(255, 64, 64, 0.9);
+    box-shadow: 0 0 6px rgba(255, 0, 0, 0.9);
+}
 #colonyTasksPanel .task-entry {
     width: 100%;
     font-size: 0.75rem;
@@ -3961,6 +3965,10 @@ body.darkenshift-mode .tabsContainer button.active {
     flex-direction: column;
     width: 120px;
     cursor: pointer;
+}
+.disciple-skill-option.disabled {
+    opacity: 0.5;
+    pointer-events: none;
 }
 .disciple-skill-label { font-size: 0.75rem; }
 .disciple-skill-progress {


### PR DESCRIPTION
## Summary
- allow disciples to enter a resting state when their health hits zero
- show incapacitated disciples around the Body orb with a red glow
- regenerate health then stamina while incapacitated
- block task assignment until stamina is full
- document incapacitation in disciple guide

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_686dc26f9b5c832683f96ca21d498f47