### PR TITLE
Remove unused tabs and default to construct panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,9 +43,6 @@
 
     <!---tabs container--->
     <div class="tabsContainer">
-      <button class="mainTabButton">imaginary</button>
-      <button class="deckTabButton">deck</button>
-      <button class="starChartTabButton">star chart</button>
       <button class="playerStatsTabButton">stats</button>
       <button class="playerTabButton">real</button>
       <button class="locationTabButton" style="display:none;">locations</button>
@@ -203,9 +200,9 @@
       <div class="playerMainContainer">
         <div class="player-header">
           <div class="player-subtabs">
-            <button class="playerConstructSubTabButton active">Construct Tab</button>
-            <button class="playerCoreSubTabButton">Core</button>
+            <button class="playerConstructSubTabButton active">Construct</button>
             <button class="playerLexiconSubTabButton">Lexicon</button>
+            <button class="playerCoreSubTabButton">Core</button>
             <button class="playerSectSubTabButton" style="display:none;">Sect</button>
           </div>
         </div>

--- a/script.js
+++ b/script.js
@@ -537,9 +537,6 @@ const saveInterval = setInterval(saveGame, 30000);
 
 //=========tabs==========
 
-let mainTabButton;
-let deckTabButton;
-let starChartTabButton;
 let playerStatsTabButton;
 let worldSubTabButton;
 let cardSubTabButton;
@@ -630,29 +627,6 @@ function addDiscoveredLocation(name) {
 
 function setupTabHandlers() {
   const tabHandlers = [
-    {
-      buttonSelector: '.mainTabButton',
-      onClick: () => {
-        showTab(mainTab);
-        setActiveTabButton(mainTabButton);
-      }
-    },
-    {
-      buttonSelector: '.deckTabButton',
-      onClick: () => {
-        showTab(deckTab);
-        setActiveTabButton(deckTabButton);
-        showDeckListView();
-      }
-    },
-    {
-      buttonSelector: '.starChartTabButton',
-      onClick: () => {
-        initStarChart();
-        showTab(starChartTab);
-        setActiveTabButton(starChartTabButton);
-      }
-    },
     {
       buttonSelector: '.playerStatsTabButton',
       onClick: () => {
@@ -789,9 +763,6 @@ function showColonyTab(name) {
 function initTabs() {
   if (typeof document === 'undefined') return;
 
-  mainTabButton = document.querySelector('.mainTabButton');
-  deckTabButton = document.querySelector('.deckTabButton');
-  starChartTabButton = document.querySelector('.starChartTabButton');
   playerStatsTabButton = document.querySelector('.playerStatsTabButton');
   cardSubTabButton = document.querySelector('.cardSubTabButton');
   worldSubTabButton = document.querySelector('.worldSubTabButton');
@@ -962,8 +933,9 @@ function initTabs() {
       renderEconomyStats();
     });
 
-  showTab(mainTab); // Start with main tab visible
-  setActiveTabButton(mainTabButton);
+  showTab(playerTab); // Start with construct panel visible
+  setActiveTabButton(playerTabButton);
+  if (playerConstructSubTabButton) playerConstructSubTabButton.click();
 }
 
 // Allow collapsing/expanding vignette UI panels
@@ -2166,6 +2138,7 @@ function showJobCarouselView() {
 //========render functions==========
 document.addEventListener("DOMContentLoaded", () => {
   // now the DOM is in, and lucide.js has run, so window.lucide is defined
+  initSpeech();
   initTabs();
   window.addEventListener('location-discovered', e => addDiscoveredLocation(e.detail.name));
   loadGame();
@@ -2180,7 +2153,6 @@ document.addEventListener("DOMContentLoaded", () => {
   initVignetteToggles();
   if (window.lucide) lucide.createIcons({ icons: lucide.icons });
   initCore();
-  initSpeech();
   renderConstructLexicon();
   document.addEventListener('day-passed', () => {
     speechState.disciples.forEach(d => {
@@ -2844,7 +2816,6 @@ function onSpeakerDefeat() {
   } else if (idx === 3) {
     showSpeakerQuote("The soul is the only prison you’ve never tried to break.");
     if (playerTabButton) playerTabButton.style.display = "inline-block";
-    if (mainTabButton) mainTabButton.disabled = true;
     showTab(playerTab);
     setActiveTabButton(playerTabButton);
   }


### PR DESCRIPTION
## Summary
- remove unused main, deck, and star chart tab buttons
- reorder player subtabs to Construct, Lexicon, Core
- initialize `initSpeech()` before other startup code
- start the app on the construct panel

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686e5cdf1c0c8326989947a40fe27af6