### PR TITLE
Add debug unlock for exploration

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,6 +39,7 @@
       <br>
       <button onclick="devTools.save()">Save Game</button>
       <button onclick="devTools.load()">Load Game</button>
+      <button onclick="devTools.unlockExploration()">Unlock Exploration</button>
     </div>
 
     <!---tabs container--->

--- a/script.js
+++ b/script.js
@@ -4230,10 +4230,13 @@ const amt = parseFloat(document.getElementById("debugManaRegen").value) || 0;
 stats.manaRegen += amt;
 renderPlayerStats(stats);
 },
-toggleFastMode: () => {
-timeScale = timeScale === 1 ? FAST_MODE_SCALE: 1;
-},
-save: saveGame,
-load: loadGame,
-newGame: startNewGame
-};
+  toggleFastMode: () => {
+    timeScale = timeScale === 1 ? FAST_MODE_SCALE: 1;
+  },
+  unlockExploration: () => {
+    systems.explorationUnlocked = true;
+    addDiscoveredLocation('Esoteric Dungeon');
+  },
+  save: saveGame,
+  load: loadGame,
+  newGame: startNewGame};


### PR DESCRIPTION
## Summary
- add `unlockExploration` helper in `script.js`
- show a new button in debug panel for unlocking exploration and the Esoteric Dungeon

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686e80fce8288326a2fd6f4061ee779c