### PR TITLE
Revamp combat stats and clean UI

### DIFF
--- a/cardManagement.js
+++ b/cardManagement.js
@@ -11,7 +11,6 @@ export function drawCard(state) {
     applyCardUpgrade,
     renderCardUpgrades,
     purchaseCardUpgrade,
-    cash,
     renderPurchasedUpgrades,
     updateActiveEffects,
     updateAllCardHp,
@@ -30,7 +29,6 @@ export function drawCard(state) {
     applyCardUpgrade(card.upgradeId, { stats, pDeck, updateAllCardHp });
     renderCardUpgrades(document.querySelector('.card-upgrade-list'), {
       stats,
-      cash,
       onPurchase: purchaseCardUpgrade
     });
     renderPurchasedUpgrades();

--- a/disciple.js
+++ b/disciple.js
@@ -1,16 +1,36 @@
 import { generateDiscipleAttributes } from './discipleAttributes.js';
+import { xpRequirement } from './utils/xp.js';
 
 export default class Disciple {
-  constructor({ id = 0, name = `Disciple ${id}`, maxHp = 10, damage = 1, attackSpeed = 1000, attributes = generateDiscipleAttributes() } = {}) {
+  constructor({ id = 0, name = `Disciple ${id}`, maxHp = 10, combatLevel = 1, attributes = generateDiscipleAttributes() } = {}) {
     this.id = id;
     this.name = name;
     this.maxHp = maxHp;
     this.currentHp = maxHp;
-    this.damage = damage;
-    this.attackSpeed = attackSpeed;
+    this.combatLevel = combatLevel;
+    this.combatXp = 0;
     this.strength = attributes.strength || 0;
     this.dexterity = attributes.dexterity || 0;
     this.endurance = attributes.endurance || 0;
     this.intelligence = attributes.intelligence || 0;
+    this.updateCombatStats();
+  }
+
+  xpForNextLevel() {
+    return xpRequirement(5, this.combatLevel);
+  }
+
+  gainCombatXp(amount) {
+    this.combatXp += amount;
+    while (this.combatXp >= this.xpForNextLevel()) {
+      this.combatXp -= this.xpForNextLevel();
+      this.combatLevel += 1;
+      this.updateCombatStats();
+    }
+  }
+
+  updateCombatStats() {
+    this.damage = this.combatLevel * 3 * (1 + 0.05 * this.strength);
+    this.attackSpeed = 10000 / (1 + 0.05 * this.dexterity);
   }
 }

--- a/index.html
+++ b/index.html
@@ -73,29 +73,15 @@
       </div>
 
       <div class="sidePanel">
-        <div class="chipsContainer">
-          <div id="chipsDisplay">
-            Chips: 0
-          </div>
-        </div>
         <div class="vignette stats open">
           <button class="vignette-toggle">Stats</button>
           <div class="vignette-content">
             <div class="statsSidePanel casino-section">
-              <div id="pointsDisplay">
-                Attack: 0
-              </div>
-              <div id="cashDisplay">
-                Cash: 0
-              </div>
               <div id="damageDisplay">
                 Damage: 0
               </div>
-              <div id="cashMultiDisplay">
-                Cash Multi: 0
-              </div>
-              <div id="cardPointsDisplay">
-                Card Points: 0
+              <div id="combatLevelDisplay">
+                Combat Lv: 1
               </div>
               <div id="hpPerKillDisplay">
                 HP per Kill: 1

--- a/script.js
+++ b/script.js
@@ -122,29 +122,9 @@ const cardBackImages = {
 // theme state
 let isDarkenshift = false;
 // resources and progress trackers
-let cash = 0;
-let chips = 0;
 let cardPoints = 0;
-// Track how many card points have already been converted to cash
-let lastCashOutPoints = 0;
 let currentEnemy = null;
 
-function spendCash(amount) {
-  const amt = Math.min(amount, cash);
-  cash -= amt;
-  if (cashDisplay) cashDisplay.textContent = `Cash: $${formatNumber(cash)}`;
-  recordCashRates(cash);
-  updateUpgradeButtons();
-  return amt;
-}
-
-function updateChipsDisplay() {
-  if (chipsDisplay) chipsDisplay.textContent = `Chips: ${formatNumber(chips)}`;
-}
-
-function computeChipReward() {
-  return Math.floor((1 + Math.pow(stageData.stage, 0.5)) * stats.cashMulti);
-}
 
 // track how many upgrade power points have been bought total
 let upgradePowerPurchased = 0;
@@ -155,11 +135,9 @@ function upgradePowerCost() {
 
 // Base player stats used for resets
 const BASE_STATS = {
-  points: 0,
   upgradePower: 0,
   pDamage: 0,
   pRegen: 0,
-  cashMulti: 1,
   damageMultiplier: 1,
   upgradeDamageMultiplier: 1,
   cardSlots: 3,
@@ -183,8 +161,7 @@ const BASE_STATS = {
   hpMultiplier: 1,
   extraDamageMultiplier: 1,
   damageBuffMultiplier: 1,
-  damageBuffExpiration: 0,
-  cashOutWithoutRedraw: false
+  damageBuffExpiration: 0
 };
 
 // Persistent player stats affecting combat and rewards
@@ -448,7 +425,6 @@ function getCardState() {
     applyCardUpgrade,
     renderCardUpgrades,
     purchaseCardUpgrade,
-    cash,
     renderPurchasedUpgrades,
     updateActiveEffects,
     updateAllCardHp: recalcAllCardHp,
@@ -466,10 +442,6 @@ const nextStageProgress = document.getElementById("nextStageProgress");
 const fightBossBtn = document.getElementById("fightBossBtn");
 const bossProgress = document.getElementById("bossProgress");
 const campBtn = document.getElementById("campBtn");
-const pointsDisplay = document.getElementById("pointsDisplay");
-const cashDisplay = document.getElementById("cashDisplay");
-const chipsDisplay = document.getElementById("chipsDisplay");
-const cardPointsDisplay = document.getElementById("cardPointsDisplay");
 const handContainer = document.getElementsByClassName("handContainer")[0];
 const discardContainer = document.getElementsByClassName("discardContainer")[0];
 const deckContainer = document.getElementsByClassName("deckContainer")[0];
@@ -529,25 +501,9 @@ let playerAttackFill = null;
 let enemyAttackFill = null;
 let discipleAttackTimers = {}; // map disciple id -> elapsed attack time
 let enemyAttackProgress = 0; // carryover ratio of enemy attack timer
-let cashTimer = 0;
 let worldProgressTimer = 0;
 //let sanityTimer = 0;
-const cashRateTracker = new RateTracker(10000);
-const cashRateTracker1h = new RateTracker(3600000);
-const cashRateTracker24h = new RateTracker(86400000);
 const worldProgressRateTracker = new RateTracker(30000);
-
-function recordCashRates(value) {
-  cashRateTracker.record(value);
-  cashRateTracker1h.record(value);
-  cashRateTracker24h.record(value);
-}
-
-function resetCashRates(value = 0) {
-  cashRateTracker.reset(value);
-  cashRateTracker1h.reset(value);
-  cashRateTracker24h.reset(value);
-}
 // Chance to trigger a random event each step of movement
 // Reduced from 30% to 10% so encounters feel more like rare discoveries
 const EVENT_CHANCE = 0.1;
@@ -992,7 +948,7 @@ function initTabs() {
       if (statsEconomyContainer) statsEconomyContainer.style.display = '';
       statsEconomySubTabButton.classList.add('active');
       if (statsOverviewSubTabButton) statsOverviewSubTabButton.classList.remove('active');
-      renderEconomyStats();
+      // economy stats removed
     });
 
   showTab(playerTab); // Start with construct panel visible
@@ -1019,11 +975,9 @@ function updateUpgradeButtons() {
     const up = upgrades[key];
     if (!up || typeof up.costFormula !== 'function') return;
     const cost = up.costFormula(up.level + 1);
-    const affordable = cash >= cost;
-    btn.disabled = !affordable;
-    btn.textContent = `Buy $${cost}`;
-    row.classList.toggle("affordable", affordable);
-    row.classList.toggle("unaffordable", !affordable);
+    btn.disabled = false;
+    btn.textContent = `Buy ${cost}`;
+    row.classList.add("affordable");
   });
   updateCardUpgradeButtons();
 }
@@ -1034,8 +988,8 @@ function updateCardUpgradeButtons() {
     const id = wrap.dataset.id;
     if (!btn || !id) return;
     const cost = getCardUpgradeCost(id, stats);
-    btn.disabled = cash < cost;
-    btn.textContent = `Buy $${cost}`;
+    btn.disabled = false;
+    btn.textContent = `Buy ${cost}`;
   });
 }
 
@@ -1057,16 +1011,11 @@ function checkUpgradeUnlocks() {
 
 
 function purchaseCardUpgrade(id, cost) {
-  if (cash < cost) return;
-  cash -= cost;
-  cashDisplay.textContent = `Cash: $${formatNumber(cash)}`;
-  recordCashRates(cash);
   applyCardUpgrade(id, { stats, pDeck, updateAllCardHp: recalcAllCardHp });
   removeActiveUpgrade(id);
   renderCardUpgrades(document.querySelector('.card-upgrade-list'), {
     stats,
     stageData,
-    cash,
     onPurchase: purchaseCardUpgrade
   });
   renderPurchasedUpgrades();
@@ -2312,7 +2261,6 @@ document.addEventListener("DOMContentLoaded", () => {
   const buttons = document.querySelector('.buttonsContainer');
   playerAttackFill = renderPlayerAttackBar(buttons);
   hidePlayerAttackBar();
-  updateChipsDisplay();
   requestAnimationFrame(gameLoop);
 });
 
@@ -2366,15 +2314,13 @@ function renderStageInfo() {
 
 function renderPlayerStats(stats) {
   const damageDisplay = document.getElementById("damageDisplay");
-  const cashMultiDisplay = document.getElementById("cashMultiDisplay");
   const hpPerKillDisplay = document.getElementById("hpPerKillDisplay");
   const attackSpeedDisplay = document.getElementById("attackSpeedDisplay");
+  const combatLevelDisplay = document.getElementById("combatLevelDisplay");
 
   damageDisplay.textContent = `Damage: ${formatNumber(Math.floor(stats.pDamage))}`;
-  cashMultiDisplay.textContent = `Cash Multi: ${formatNumber(Math.floor(stats.cashMulti))}`;
-  pointsDisplay.textContent = `Points: ${formatNumber(stats.points)}`;
-  cardPointsDisplay.textContent = `Card Points: ${formatNumber(cardPoints)}`;
-  attackSpeedDisplay.textContent = `Attack Speed: ${Math.floor(stats.attackSpeed / 1000)}s`;
+  combatLevelDisplay.textContent = `Combat Lv: ${stats.avgCombatLevel.toFixed(1)}`;
+  attackSpeedDisplay.textContent = `Attack Speed: ${(stats.attackSpeed / 1000).toFixed(1)}s`;
   if (manaRegenDisplay) {
     manaRegenDisplay.textContent = `Mana Regen: ${stats.manaRegen.toFixed(2)}/s`;
   }
@@ -2419,17 +2365,7 @@ function renderGlobalStats() {
   container.appendChild(restartBtn);
 }
 
-function renderEconomyStats() {
-  if (!statsEconomyContainer) return;
-  statsEconomyContainer.innerHTML = '';
-  const hourRate = cashRateTracker1h.getRate();
-  const dayRate = cashRateTracker24h.getRate();
-  const hRow = document.createElement('div');
-  hRow.textContent = `Avg Cash/sec (1h): ${hourRate.toFixed(2)}`;
-  const dRow = document.createElement('div');
-  dRow.textContent = `Avg Cash/sec (24h): ${dayRate.toFixed(2)}`;
-  statsEconomyContainer.append(hRow, dRow);
-}
+
 
 function renderConstructLexicon() {
   if (!constructLexiconContainer) return;
@@ -2682,8 +2618,6 @@ function nextStage() {
   renderStageInfo();
   checkUpgradeUnlocks();
   checkSpeakerEncounter();
-  // start the next stage without double-counting points
-  lastCashOutPoints = stats.points;
   inCombat = false;
   currentEnemy = null;
   redrawAllowed = false;
@@ -2717,8 +2651,6 @@ function nextWorld() {
   renderGlobalStats();
   renderStageInfo();
   checkUpgradeUnlocks();
-  // entering a new world resets cash-out tracking
-  lastCashOutPoints = stats.points;
   inCombat = false;
   currentEnemy = null;
   redrawAllowed = false;
@@ -2747,7 +2679,6 @@ function goToWorld(id) {
   renderGlobalStats();
   renderStageInfo();
   checkUpgradeUnlocks();
-  lastCashOutPoints = stats.points;
   inCombat = false;
   currentEnemy = null;
   redrawAllowed = false;
@@ -2759,8 +2690,7 @@ function goToWorld(id) {
 
 // Reset tracking for average cash when a new stage begins
 function resetStageCashStats() {
-  cashTimer = 0;
-  resetCashRates(cash);
+  // no cash stats
 }
 
 function updateNextStageAvailability() {
@@ -2867,8 +2797,7 @@ function onDealerDefeat() {
   // capture remaining attack progress before resetting
   enemyAttackProgress = currentEnemy.attackTimer / currentEnemy.attackInterval;
   cardXp(calculateKillXp(stageData.stage, stageData.world));
-  chips += computeChipReward();
-  updateChipsDisplay();
+  combatXp(calculateKillXp(stageData.stage, stageData.world));
   healCardsOnKill();
   stageData.kills += 1;
   playerStats.stageKills[stageData.stage] = stageData.kills;
@@ -2903,8 +2832,7 @@ function onSpeakerDefeat() {
   dealerBarDeathAnimation(() => {
     inCombat = false;
     currentEnemy = null;
-    chips += computeChipReward();
-    updateChipsDisplay();
+    combatXp(calculateKillXp(stageData.stage, stageData.world));
     updateDealerLifeDisplay();
     hidePlayerAttackBar();
     respawnDealerStage();
@@ -2949,8 +2877,7 @@ function onBossDefeat(boss) {
   dealerBarDeathAnimation(() => {
     inCombat = false;
     currentEnemy = null;
-    chips += computeChipReward();
-    updateChipsDisplay();
+    combatXp(boss.xp);
     hidePlayerAttackBar();
     nextWorld();
   });
@@ -3097,6 +3024,14 @@ function cardXp(xpAmount) {
   updateDeckDisplay(); // paints deck tab bars
 }
 
+function combatXp(xpAmount) {
+  drawnCards.forEach(d => {
+    if (!d) return;
+    d.gainCombatXp(xpAmount);
+  });
+  updatePlayerStats();
+}
+
 /**
 * Draws the top card from `Deck` into `intoHand`.
 * Renders it with `renderFn` and then calls `updateFn`.
@@ -3233,8 +3168,7 @@ function openCardUpgradeSelection(onCloseCallback = null) {
   statsRow.innerHTML = `
     <div>Damage: ${formatNumber(Math.floor(stats.pDamage))}</div>
     <div>Attack: ${(stats.attackSpeed / 1000).toFixed(1)}s</div>
-    <div>HP/kill: ${stats.hpPerKill}</div>
-    <div>Cash: $${formatNumber(cash)}</div>`;
+    <div>HP/kill: ${stats.hpPerKill}</div>`;
   box.appendChild(statsRow);
 
 
@@ -3247,7 +3181,7 @@ function openCardUpgradeSelection(onCloseCallback = null) {
   const freeIndex = Math.floor(Math.random() * ids.length);
   ids.forEach((id, idx) => {
     const def = cardUpgradeDefinitions[id];
-    const baseCost = getCardUpgradeCost(id, { points: stats.points }, stageData);
+    const baseCost = getCardUpgradeCost(id, {}, stageData);
     const cost = idx === freeIndex ? 0 : baseCost;
     const wrap = document.createElement('div');
     wrap.classList.add('card-wrapper');
@@ -3256,14 +3190,10 @@ function openCardUpgradeSelection(onCloseCallback = null) {
     const icon = def.icon || 'sword';
     card.innerHTML = `\n      <div class="card-suit"><i data-lucide="${icon}"></i></div>\n      <div class="card-desc">${def.name} - ${cost === 0 ? 'FREE' : '$' + cost}</div>\n      <div class="card-flavor">${def.flavor || ''}</div>\n    `;
     wrap.appendChild(card);
-    if (cash >= cost) {
-      wrap.addEventListener('click', () => {
-        purchaseCardUpgrade(id, cost);
-        closeCardUpgradeSelection();
-      });
-    } else {
-      card.classList.add('unaffordable');
-    }
+    wrap.addEventListener('click', () => {
+      purchaseCardUpgrade(id, cost);
+      closeCardUpgradeSelection();
+    });
     cardsContainer.appendChild(wrap);
   });
   upgradeOverlay.appendButton('Skip', () => closeCardUpgradeSelection());
@@ -3323,8 +3253,7 @@ function openCamp(onCloseCallback = null) {
   statsRow.innerHTML = `
     <div>Damage: ${formatNumber(Math.floor(stats.pDamage))}</div>
     <div>Attack: ${(stats.attackSpeed / 1000).toFixed(1)}s</div>
-    <div>HP/kill: ${stats.hpPerKill}</div>
-    <div>Cash: $${formatNumber(cash)}</div>`;
+    <div>HP/kill: ${stats.hpPerKill}</div>`;
   box.appendChild(statsRow);
 
 
@@ -3351,18 +3280,10 @@ function openCamp(onCloseCallback = null) {
 
   addBtn('▶ Continue', () => closeCamp(), 'Resume journey');
 
-  if (stats.cashOutWithoutRedraw) {
-    addBtn('💰 Cash Out', () => {
-      cashOut();
-      closeCamp();
-    }, 'Collect chips and quit');
-  }
-
-  addBtn('⟳ Redraw & Cash Out', () => {
-    cashOut();
+  addBtn('⟳ Redraw', () => {
     handleRedraw();
     closeCamp();
-  }, 'Cash out then draw again');
+  }, 'Draw again');
 
   addBtn('♥ Heal Party', () => {
     drawnCards.forEach(c => {
@@ -3652,9 +3573,7 @@ function respawnPlayer() {
   playerStats.hasDied = false;
   Object.assign(stats, BASE_STATS);
   stats.cardSlots = BASE_STATS.cardSlots + attributes.Strength.inventorySlots;
-  cash = 0;
-  chips = 0;
-  resetCashRates(cash);
+  // reset resources
 
   resetCardUpgrades();
   pDeck = [];
@@ -3668,15 +3587,11 @@ function respawnPlayer() {
   renderCardUpgrades(document.querySelector('.card-upgrade-list'), {
     stats,
     stageData,
-    cash,
     onPurchase: purchaseCardUpgrade
   });
 
   clearActiveDisciples();
   
-  cashDisplay.textContent = `Cash: $${formatNumber(cash)}`;
-  updateChipsDisplay();
-  resetCashRates(cash);
   updateUpgradeButtons();
   stageData.world = 1;
   stageData.stage = 1;
@@ -3686,8 +3601,6 @@ function respawnPlayer() {
   spawnPlayer();
   respawnDealerStage();
   updatePlayerStats(stats);
-  // reset baseline so new kills don't award previous points again
-  lastCashOutPoints = stats.points;
   killsDisplay.textContent = `Kills: ${formatNumber(stageData.kills)}`;
   renderGlobalStats();
   renderWorldsMenu();
@@ -3760,50 +3673,7 @@ function attack(deltaTime = 0) {
   }
 }
 
-/*if (currentEnemy instanceof Boss) {
-  // Handle boss damage
-  currentEnemy.takeDamage(stats.pDamage);
-  stageData.dealerLifeCurrent = currentEnemy.currentHp;
-  if (currentEnemy.currentHp <= 0) {
-    onBossDefeat(currentEnemy);
-    respawnDealer();
-    dealerLifeBar();
-    cashOut();
-    nextWorld();
-    dealerDeathAnimation();
-  } else {
-    dealerLifeDisplay.textContent = `Life: ${formatNumber(Math.floor(currentEnemy.currentHp))}/${formatNumber(currentEnemy.maxHp)}`;
-    dealerLifeBar();
-  }
-} else {
-  // Handle regular enemy damage
-  if (stageData.dealerLifeCurrent - stats.pDamage <= 0) {
-    stageData.kills += 1;
-    killsDisplay.textContent = `Kills: ${formatNumber(stageData.kills)}`;
-    respawnDealer();
-    dealerLifeBar();
-    cardXp(stageData.stage ** 1.2);
-    cashOut();
-    dealerDeathAnimation();
-  } else {
-    stageData.dealerLifeCurrent = stageData.dealerLifeCurrent - stats.pDamage;
-    dealerLifeDisplay.textContent = `Life: ${formatNumber(Math.floor(stageData.dealerLifeCurrent))}/${formatNumber(stageData.dealerLifeMax)}`;
-    dealerLifeBar();
-  }
-}*/
 
-// Convert points earned this stage into spendable cash
-function cashOut() {
-  if (chips <= 0) return cash;
-  const reward = chips * stats.points;
-  cash += reward;
-  chips = 0;
-  cashDisplay.textContent = `Cash: $${formatNumber(cash)}`;
-  updateChipsDisplay();
-  recordCashRates(cash);
-  updateUpgradeButtons();
-  return cash;
-}
 
 // Recalculate combat stats based on cards currently drawn
 function updatePlayerStats() {
@@ -3812,8 +3682,8 @@ function updatePlayerStats() {
   stats.damageMultiplier =
     stats.upgradeDamageMultiplier * barUpgrades.damage.multiplier * stats.extraDamageMultiplier;
   stats.pRegen = 0;
-  stats.cashMulti = 1;
-  stats.points = 0;
+  stats.avgCombatLevel = 0;
+  stats.attackSpeed = 0;
 
   if (stats.damageBuffExpiration && Date.now() > stats.damageBuffExpiration) {
     stats.damageBuffMultiplier = 1;
@@ -3823,17 +3693,22 @@ function updatePlayerStats() {
     if (!card) continue;
     recalcCardHp(card, stats, barUpgrades);
 
-    const suitMult =
-      card.suit === "Spades" ? stats.spadeDamageMultiplier || 1 : 1;
-    card.damage = (card.baseDamage + 5 * (card.currentLevel - 1)) * suitMult;
     stats.pDamage += card.damage;
-    stats.points += card.value;
+    stats.attackSpeed += card.attackSpeed;
+    stats.avgCombatLevel += card.combatLevel;
   }
 
   stats.pDamage *=
     stats.damageMultiplier *
     stats.damageBuffMultiplier *
     attributes.Strength.meleeDamageMultiplier;
+
+  if (drawnCards.length > 0) {
+    stats.attackSpeed /= drawnCards.length;
+    stats.avgCombatLevel /= drawnCards.length;
+  } else {
+    stats.attackSpeed = BASE_STATS.attackSpeed;
+  }
 
   stats.cardSlots = BASE_STATS.cardSlots + attributes.Strength.inventorySlots;
   renderPlayerStats(stats);
@@ -3871,10 +3746,7 @@ Object.entries(upgrades).map(([k, u]) => [k, u.unlocked])
   const state = {
     stats,
     stageData,
-    cash,
-    chips,
     upgradePowerPurchased,
-    lastCashOutPoints,
     cardPoints,
     redrawCost,
     deck: deckData,
@@ -3912,12 +3784,10 @@ if (!json) return;
 
 try {
 const state = JSON.parse(json);
-  cash = state.cash || 0;
-  chips = state.chips || 0;
+  // legacy cash/chip values are ignored
   cardPoints = state.cardPoints || 0;
   redrawCost = state.redrawCost || 10;
   upgradePowerPurchased = state.upgradePowerPurchased || 0;
-  lastCashOutPoints = state.lastCashOutPoints || 0;
   Object.assign(stats, state.stats || {});
   if (state.systems) {
     Object.assign(systems, state.systems);
@@ -4044,9 +3914,6 @@ if (
 
 Object.values(upgrades).forEach(u => u.effect({ stats, pDeck, stageData, systems }));
 
-cashDisplay.textContent = `Cash: $${formatNumber(cash)}`;
-updateChipsDisplay();
-cardPointsDisplay.textContent = `Card Points: ${formatNumber(cardPoints)}`;
 
   renderJokers();
 updateUpgradeButtons();
@@ -4054,7 +3921,6 @@ updateUpgradeButtons();
   renderStageInfo();
   renderGlobalStats();
   renderWorldsMenu();
-  resetCashRates(cash);
   worldProgressRateTracker.reset(
     computeWorldProgress(stageData.world) * 100
   );
@@ -4133,15 +3999,7 @@ if (currentEnemy) {
   updateDrawButton();
   updateRedrawButton();
   updatePlayerStats(stats);
-  cashTimer += deltaTime;
   worldProgressTimer += deltaTime;
-  if (cashTimer >= 1000) {
-    recordCashRates(cash);
-    if (statsEconomyContainer && statsEconomyContainer.style.display !== 'none') {
-      renderEconomyStats();
-    }
-    cashTimer = 0;
-  }
   if (worldProgressTimer >= 1000) {
     const currentPct = computeWorldProgress(stageData.world) * 100;
     worldProgressRateTracker.record(currentPct);
@@ -4233,14 +4091,6 @@ currentEnemy.onDefeat?.();
 logEnemy: () => console.log(currentEnemy),
 advanceStage: () => nextStage(),
 
-giveCash: () => {
-const amount =
-parseInt(document.getElementById("debugCash").value) || 0;
-cash += amount;
-  cashDisplay.textContent = `Cash: $${formatNumber(cash)}`;
-recordCashRates(cash);
-updateUpgradeButtons();
-},
 
 setStageWorld: () => {
 const stage = parseInt(document.getElementById("debugStage").value);

--- a/speech.js
+++ b/speech.js
@@ -2,6 +2,7 @@ import addLog from './log.js';
 import { coreState, refreshCore } from './core.js';
 import { sectState, systems } from './script.js';
 import { generateDiscipleAttributes } from './discipleAttributes.js';
+import Disciple from './disciple.js';
 import { createOverlay } from './ui/overlay.js';
 
 // Core state for the Constructs system. Orbs and upgrades from the
@@ -450,21 +451,13 @@ const constructEffects = {
     const chance = Math.max(0.05, Math.min(1, callPower / reqPower));
     if (Math.random() < chance) {
       const bonus = generateDiscipleAttributes();
-      speechState.disciples.push({
-        id: targetIdx,
-        name: `Disciple ${targetIdx}`,
-        health: 10,
-        stamina: 10,
-        hunger: 20,
-        power: 1,
+      const attrs = {
         strength: 1 + bonus.strength,
         dexterity: 1 + bonus.dexterity,
         endurance: 1 + bonus.endurance,
-        intelligence: 1 + bonus.intelligence,
-        incapacitated: false,
-        inventorySlots: 10,
-        inventory: {}
-      });
+        intelligence: 1 + bonus.intelligence
+      };
+      speechState.disciples.push(new Disciple({ id: targetIdx, name: `Disciple ${targetIdx}`, attributes: attrs }));
       sectState.discipleConstructXp[targetIdx] = {};
       addLog('A new Disciple has answered your call!', 'info');
       if (lastConstructTarget) showConstructCloud('+1', lastConstructTarget);

--- a/style.css
+++ b/style.css
@@ -427,15 +427,6 @@ body.darkenshift-mode .tabsContainer button.active {
     margin-bottom: 0;
 }
 
-.chipsContainer {
-    background: rgba(133, 163, 139, 0.5);
-    color: white;
-    text-shadow: 0 0 5px black;
-    border: 1px solid #d4af37;
-    border-radius: 4px;
-    padding: 4px;
-    font-size: 0.6rem;
-}
 
 #log-panel {
     border: 2px solid grey;
@@ -486,19 +477,6 @@ body.darkenshift-mode .tabsContainer button.active {
     z-index: 1;
     display: block; /* ensure consistent vertical spacing */
 }*/
-
-#chipsDisplay {
-    align-self: flex-start;
-    font-size: 0.8rem;
-    color: #d4af37;
-    text-shadow: 0 0 5px black;
-    z-index: 1;
-}
-
-#cashPerSecDisplay {
-    align-self: flex-start;
-    font-size: 0.8rem;
-}
 
 #worldProgressPerSecDisplay {
     align-self: flex-start;


### PR DESCRIPTION
## Summary
- drop chips and cash references
- remove old cash-out code
- keep per-disciple attack and combat XP gains
- show combat level and attack speed in sidebar

## Testing
- `npm test`
- `npm run lint` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_686e84965ea88326b1b31cb1c1d5bb54