### PR TITLE
Fix stats loading crash and update combat UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,6 +48,7 @@
       <button class="explorationTabButton" style="display:none;">exploration</button>
       <button class="playerStatsTabButton">stats</button>
       <button class="locationTabButton" style="display:none;">locations</button>
+      <button class="logTabButton">log</button>
     </div>
 
     <!--------------main tab panel----------------->
@@ -98,10 +99,11 @@
             </div>
           </div>
         </div>
-        <div class="vignette log">
-          <button class="vignette-toggle">Log</button>
-          <div class="casino-section vignette-content" id="log-panel">
-            <div id="game-log"></div>
+        <div class="vignette resources">
+          <button class="vignette-toggle">Resources</button>
+          <div class="casino-section vignette-content">
+            <div id="combatOrbs" class="construct-orbs combat-orbs"></div>
+            <div id="combatResources" class="secondary-resources"></div>
           </div>
         </div>
         <div class="deck-info">
@@ -144,8 +146,6 @@
         </div>
         <div class="handContainer casino-section"></div>
         <div id="combatHotbar" class="construct-hotbar casino-section"></div>
-        <div id="combatOrbs" class="construct-orbs combat-orbs"></div>
-        <div id="combatResources" class="secondary-resources"></div>
       </div>
       </div>
       <div class="worldsTab" style="display:none;">
@@ -280,6 +280,10 @@
     <div class="locationTab" style="display:none;">
       <div class="location-list casino-section"></div>
     </div>
+    <div class="logTab" style="display:none;">
+      <div id="log-panel" class="casino-section">
+        <div id="game-log"></div>
+      </div>
+    </div>
     <div id="tooltip"></div>
-    <script type="module" src="script.js"></script>
-  </body></html>
+    <script type="module" src="script.js"></script>  </body></html>

--- a/script.js
+++ b/script.js
@@ -145,6 +145,7 @@ const BASE_STATS = {
   attackSpeed: 10000,
   //ms between automatic attacks
   hpPerKill: 1,
+  avgCombatLevel: 0,
   baseCardHpBoost: 0,
   maxMana: 0,
   mana: 0,
@@ -524,6 +525,7 @@ let cardSubTabButton;
 let playerTabButton;
 let explorationTabButton;
 let locationTabButton;
+let logTabButton;
 let mainTab;
 let cardSubTab;
 let deckTab;
@@ -533,6 +535,7 @@ let worldsTab;
 let playerTab;
 let explorationTab;
 let locationTab;
+let logTab;
 let locationListContainer;
 let explorationListContainer;
 let startDungeonBtn;
@@ -652,6 +655,13 @@ function setupTabHandlers() {
         showTab(locationTab);
         setActiveTabButton(locationTabButton);
       }
+    },
+    {
+      buttonSelector: '.logTabButton',
+      onClick: () => {
+        showTab(logTab);
+        setActiveTabButton(logTabButton);
+      }
     }
   ];
 
@@ -688,6 +698,7 @@ function hideTab() {
   if (playerTab) playerTab.style.display = "none";
   if (explorationTab) explorationTab.style.display = "none";
   if (locationTab) locationTab.style.display = "none";
+  if (logTab) logTab.style.display = "none";
 }
 
 function showTab(tab) {
@@ -772,6 +783,7 @@ function initTabs() {
   playerTabButton = document.querySelector('.playerTabButton');
   explorationTabButton = document.querySelector('.explorationTabButton');
   locationTabButton = document.querySelector('.locationTabButton');
+  logTabButton = document.querySelector('.logTabButton');
   mainTab = document.querySelector('.mainTab');
   cardSubTab = document.querySelector('.cardSubTab');
   deckTab = document.querySelector('.deckTab');
@@ -781,6 +793,7 @@ function initTabs() {
   playerTab = document.querySelector('.playerTab');
   explorationTab = document.querySelector('.explorationTab');
   locationTab = document.querySelector('.locationTab');
+  logTab = document.querySelector('.logTab');
   locationListContainer = document.querySelector('.location-list');
   explorationListContainer = document.querySelector('.exploration-list');
   startDungeonBtn = document.querySelector('.startDungeonBtn');
@@ -2238,6 +2251,8 @@ document.addEventListener("DOMContentLoaded", () => {
   showDeckListView();
   showColonyTab('tasks');
   Object.values(upgrades).forEach(u => u.effect({ stats, pDeck, stageData, systems }));
+  updatePlayerStats(stats);
+  updatePlayerStats(stats);
   renderPurchasedUpgrades();
   // Start or resume the game after loading
   spawnPlayer();
@@ -2307,6 +2322,7 @@ function unlockManaSystem() {
   stats.manaRegen = 0.01;
   // re-apply upgrade effects in case levels were purchased before unlock
   Object.values(upgrades).forEach(u => u.effect({ stats, pDeck, stageData, systems }));
+  updatePlayerStats(stats);
   updateManaBar();
   checkUpgradeUnlocks();
 }
@@ -3925,6 +3941,7 @@ if (
 }
 
 Object.values(upgrades).forEach(u => u.effect({ stats, pDeck, stageData, systems }));
+  updatePlayerStats(stats);
 
 
   renderJokers();

--- a/speech.js
+++ b/speech.js
@@ -1041,7 +1041,10 @@ function renderHotbar() {
   if (combatBar) bars.push(combatBar);
   bars.forEach(bar => {
     bar.innerHTML = '';
+    const combatOnly = bar.id === 'combatHotbar';
     speechState.activeConstructs.forEach(c => {
+      const recipe = recipes.find(r => r.name === c);
+      if (combatOnly && (!recipe || !recipe.tags || !recipe.tags.includes('combat'))) return;
       const wrapper = document.createElement('div');
       wrapper.className = 'construct-card-wrapper';
       const card = createConstructCard(c);


### PR DESCRIPTION
## Summary
- ensure `avgCombatLevel` exists on base stats and recompute stats when loading saves
- filter combat hotbar constructs to only show items tagged `combat`
- move combat resources and orbs to side panel and add log tab

## Testing
- `npm run lint` *(fails: many existing issues)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ea65cc58c832699caaad725d98e29