### PR TITLE
Update season UI styling

### DIFF
--- a/speech.js
+++ b/speech.js
@@ -1137,6 +1137,10 @@ function renderSeasonBanner() {
   const temp = seasonTemps[idx];
   banner.textContent = `${season.name} Day ${day} (${daysLeft}d) ${temp}°C`;
   banner.className = `season-banner ${seasonClasses[idx]}`;
+  if (container) {
+    seasonClasses.forEach(cls => container.classList.remove(cls));
+    container.classList.add(seasonClasses[idx]);
+  }
   if (speechState.weather) {
     banner.innerHTML = `${season.name} Day ${day} (${daysLeft}d) ${temp}°C<span class="weather-icon">${speechState.weather.icon}</span>`;
   }

--- a/style.css
+++ b/style.css
@@ -3109,16 +3109,13 @@ body.darkenshift-mode .tabsContainer button.active {
     z-index: 0;
 }
 
-.construct-area.verdantia {
-    backdrop-filter: blur(8px) hue-rotate(60deg) brightness(0.9);
-}
-
-.construct-area.solaria {
-    backdrop-filter: blur(8px) hue-rotate(-20deg) brightness(1.1);
-}
-
-.construct-area.bruma {
-    backdrop-filter: blur(8px) hue-rotate(180deg) brightness(0.8);
+.construct-area.spring,
+.construct-area.summer,
+.construct-area.aurora,
+.construct-area.autumn,
+.construct-area.winter {
+    background: linear-gradient(135deg, var(--season-start), var(--season-end));
+    backdrop-filter: blur(8px) brightness(0.9);
 }
 
 @supports not (backdrop-filter: blur(1px)) {
@@ -3129,7 +3126,6 @@ body.darkenshift-mode .tabsContainer button.active {
 
 #constructTabCardContainer {
     backdrop-filter: blur(8px);
-    background: rgba(255, 255, 255, 0.05);
 }
 
 .construct-lexicon {


### PR DESCRIPTION
## Summary
- update season banner logic so the construct panel updates with new season class
- revamp construct area CSS to use season classes and gradient colors
- drop old Verdantia/Solaria/Bruma classes and cleanup container background rule

## Testing
- `npm test` *(fails: `mocha` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686eba6447cc832697dadc0bb9bb4a6f