### PR TITLE
Render disciples with card visuals

### DIFF
--- a/disciple.js
+++ b/disciple.js
@@ -33,4 +33,12 @@ export default class Disciple {
     this.damage = this.combatLevel * 3 * (1 + 0.05 * this.strength);
     this.attackSpeed = 10000 / (1 + 0.05 * this.dexterity);
   }
+
+  takeDamage(amount) {
+    this.currentHp = Math.round(Math.max(0, this.currentHp - amount));
+  }
+
+  isDefeated() {
+    return this.currentHp <= 0;
+  }
 }

--- a/rendering.js
+++ b/rendering.js
@@ -61,6 +61,30 @@ export function renderCard(card, handContainer) {
   card.xpLabel = xpLabel;
 }
 
+export function renderDiscipleCard(disciple, handContainer) {
+  const wrapper = document.createElement('div');
+  wrapper.classList.add('card-wrapper');
+  const cardPane = document.createElement('div');
+  cardPane.classList.add('card');
+  cardPane.innerHTML = `\n  <div class="card-value">${disciple.name}</div>\n  <div class="card-suit">🧍</div>\n  <div class="card-hp">HP: ${Math.round(disciple.currentHp)}/${Math.round(disciple.maxHp)}</div>\n  `;
+  const xpBar = document.createElement('div');
+  const xpBarFill = document.createElement('div');
+  const xpLabel = document.createElement('div');
+  xpBar.classList.add('xpBar');
+  xpBarFill.classList.add('xpBarFill');
+  xpLabel.classList.add('xpBarLabel');
+  xpLabel.textContent = `LV: ${disciple.combatLevel}`;
+  xpBar.append(xpBarFill, xpLabel);
+  wrapper.append(cardPane, xpBar);
+  handContainer.appendChild(wrapper);
+  disciple.wrapperElement = wrapper;
+  disciple.cardElement = cardPane;
+  disciple.hpDisplay = cardPane.querySelector('.card-hp');
+  disciple.xpBar = xpBar;
+  disciple.xpBarFill = xpBarFill;
+  disciple.xpLabel = xpLabel;
+}
+
 export function renderDiscardCard(card, discardContainer, backImages) {
   discardContainer.innerHTML = '';
   const img = document.createElement('img');

--- a/script.js
+++ b/script.js
@@ -63,6 +63,7 @@ import {
 } from "./enemySpawning.js";
 import {
   renderCard,
+  renderDiscipleCard,
   renderDiscardCard,
   renderDealerLifeBar,
   renderEnemyAttackBar,
@@ -2931,8 +2932,8 @@ function updateDealerLifeDisplay() {
 
 // Apply damage from the enemy to the first card in the player's hand
 function cDealerDamage(damageAmount = null, ability = null, source = "dealer") {
-  // If no card is available to take the hit, trigger game over
-  if (drawnCards.length === 0) {
+  const targets = drawnCards.length > 0 ? drawnCards : activeDisciples;
+  if (targets.length === 0) {
     playerStats.hasDied = true;
     showRestartScreen(respawnPlayer);
     return;
@@ -2956,20 +2957,23 @@ function cDealerDamage(damageAmount = null, ability = null, source = "dealer") {
     finalDamage -= absorbed;
   }
 
-  // randomly target one of the drawn cards
-  const idx = Math.floor(Math.random() * drawnCards.length);
-  const card = drawnCards[idx];
+  // randomly target one of the available targets
+  const idx = Math.floor(Math.random() * targets.length);
+  const card = targets[idx];
 
   // subtract **one** hit’s worth
   card.currentHp = Math.round(Math.max(0, card.currentHp - finalDamage));
+  const targetName = card.name ? card.name : `${card.value}${card.symbol}`;
   addLog(
-    `${source} hit ${card.value}${card.symbol} for ${finalDamage} damage!`,
+    `${source} hit ${targetName} for ${finalDamage} damage!`,
     "damage"
   );
 
   // update its specific HP display
-  card.hpDisplay.textContent = `HP: ${formatNumber(Math.round(card.currentHp))}/${formatNumber(Math.round(card.maxHp))}`;
-  updateDeckDisplay();
+  if (card.hpDisplay) {
+    card.hpDisplay.textContent = `HP: ${formatNumber(Math.round(card.currentHp))}/${formatNumber(Math.round(card.maxHp))}`;
+  }
+  if (targets === drawnCards) updateDeckDisplay();
   if (card.wrapperElement) {
     animateCardHit(card);
     // Show actual damage dealt after shield reduction
@@ -2978,23 +2982,32 @@ function cDealerDamage(damageAmount = null, ability = null, source = "dealer") {
   updateBloodSplat(card);
   // if it’s dead, remove it
   if (card.currentHp === 0) {
-    // immediately remove from data so new draws don't shift the wrong card
-    drawnCards.splice(idx, 1);
-
-    animateCardDeath(card, () => {
-      // 1) from the DOM
-      removeBloodSplat(card);
-      card.wrapperElement?.remove();
-
-      discardCard(card);
-      updatePlayerStats(stats);
-      updateDrawButton();
-      updateDeckDisplay();
-      if (drawnCards.length === 0) {
-        playerStats.hasDied = true;
-        showRestartScreen(respawnPlayer);
-      }
-    });
+    if (targets === drawnCards) {
+      // immediately remove from data so new draws don't shift the wrong card
+      drawnCards.splice(idx, 1);
+      animateCardDeath(card, () => {
+        removeBloodSplat(card);
+        card.wrapperElement?.remove();
+        discardCard(card);
+        updatePlayerStats(stats);
+        updateDrawButton();
+        updateDeckDisplay();
+        if (drawnCards.length === 0) {
+          playerStats.hasDied = true;
+          showRestartScreen(respawnPlayer);
+        }
+      });
+    } else {
+      activeDisciples.splice(idx, 1);
+      animateCardDeath(card, () => {
+        removeBloodSplat(card);
+        card.wrapperElement?.remove();
+        if (activeDisciples.length === 0) {
+          playerStats.hasDied = true;
+          showRestartScreen(respawnPlayer);
+        }
+      });
+    }
   }
   // Optional ability logic (e.g., healing, fireball
 }
@@ -3099,28 +3112,31 @@ function updateHandDisplay() {
     }
     updateBloodSplat(card);
   });
+  activeDisciples.forEach(d => {
+    if (!d || !d.hpDisplay) return;
+    d.hpDisplay.textContent = `HP: ${Math.round(d.currentHp)}/${Math.round(d.maxHp)}`;
+    if (d.xpLabel) {
+      d.xpLabel.textContent = `LV: ${d.combatLevel}`;
+    }
+    if (d.xpBarFill) {
+      const pct = (d.combatXp / d.xpForNextLevel()) * 100;
+      d.xpBarFill.style.width = `${Math.min(pct, 100)}%`;
+    }
+    updateBloodSplat(d);
+  });
 }
 
 function renderCombatDisciples() {
   if (!handContainer) return;
   handContainer.innerHTML = '';
   activeDisciples.forEach(d => {
-    const wrap = document.createElement('div');
-    wrap.className = 'disciple-card';
-    const name = document.createElement('div');
-    name.textContent = d.name || `Disciple ${d.id}`;
-    const hp = document.createElement('div');
-    hp.className = 'disciple-hp';
-    hp.textContent = `HP: ${Math.round(d.currentHp)}/${Math.round(d.maxHp)}`;
+    renderDiscipleCard(d, handContainer);
     const bar = document.createElement('div');
     bar.className = 'disciple-attack-bar';
     const fill = document.createElement('div');
     fill.className = 'disciple-attack-fill';
     bar.appendChild(fill);
-    wrap.append(name, hp, bar);
-    handContainer.appendChild(wrap);
-    d.wrapperElement = wrap;
-    d.hpDisplay = hp;
+    d.wrapperElement.appendChild(bar);
     d.attackFill = fill;
   });
 }

--- a/style.css
+++ b/style.css
@@ -4022,15 +4022,7 @@ body.darkenshift-mode .tabsContainer button.active {
     text-align: center;
 }
 
-.disciple-card {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    width: 64px;
-    font-size: 0.7rem;
-    margin: 2px;
-}
-
+/* disciple combat cards reuse generic card styles */
 .disciple-hp {
     margin-top: 2px;
 }


### PR DESCRIPTION
## Summary
- add `renderDiscipleCard` to create card-style disciples
- track disciple HP and death like cards
- show disciple hits using dealer logic when no cards present
- refresh disciple display with blood splats

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ede69c694832692a9feca9a0d74da