### PR TITLE
Update death sequence to return disciples to sect

### DIFF
--- a/script.js
+++ b/script.js
@@ -2937,7 +2937,7 @@ function cDealerDamage(damageAmount = null, ability = null, source = "dealer") {
   const targets = drawnCards.length > 0 ? drawnCards : activeDisciples;
   if (targets.length === 0) {
     playerStats.hasDied = true;
-    showRestartScreen(respawnPlayer);
+    showRestartScreen(returnPartyToSect);
     return;
   }
 
@@ -2996,17 +2996,21 @@ function cDealerDamage(damageAmount = null, ability = null, source = "dealer") {
         updateDeckDisplay();
         if (drawnCards.length === 0) {
           playerStats.hasDied = true;
-          showRestartScreen(respawnPlayer);
+          showRestartScreen(returnPartyToSect);
         }
       });
     } else {
       activeDisciples.splice(idx, 1);
+      card.incapacitated = true;
+      card.health = 0;
+      card.stamina = 0;
+      sectState.discipleTasks[card.id] = 'Idle';
       animateCardDeath(card, () => {
         removeBloodSplat(card);
         card.wrapperElement?.remove();
         if (activeDisciples.length === 0) {
           playerStats.hasDied = true;
-          showRestartScreen(respawnPlayer);
+          showRestartScreen(returnPartyToSect);
         }
       });
     }
@@ -3660,6 +3664,27 @@ function respawnPlayer() {
   renderGlobalStats();
   renderWorldsMenu();
   checkSpeakerEncounter();
+}
+
+function returnPartyToSect() {
+  currentExplorationParty.forEach(id => {
+    const d = speechState.disciples.find(x => x.id === id);
+    if (d) {
+      d.currentHp = 0;
+      d.health = 0;
+      d.stamina = 0;
+      d.incapacitated = true;
+      sectState.discipleTasks[d.id] = 'Idle';
+    }
+  });
+  currentExplorationParty = [];
+  clearActiveDisciples();
+  showTab(playerTab);
+  setActiveTabButton(playerTabButton);
+  if (playerSectSubTabButton) playerSectSubTabButton.click();
+  updateSectDisplay();
+  renderDiscipleList();
+  renderDiscipleDetails();
 }
 
 

--- a/ui/restartOverlay.js
+++ b/ui/restartOverlay.js
@@ -27,6 +27,12 @@ export function drawRestartArt(canvas) {
   ctx.stroke();
 }
 
+export const SPEAKER_QUOTES = [
+  'Sometimes it\u2019s safer to hide in a nightmare... but are we ever truly free from the dream?',
+  'Words don\u2019t just describe. They make.',
+  'The soul is the only prison you\u2019ve never tried to break.'
+];
+
 export function showRestartScreen(onRestart) {
   if (restartOverlay) return;
 
@@ -42,17 +48,18 @@ export function showRestartScreen(onRestart) {
 
   const message = document.createElement('div');
   message.classList.add('restart-message');
-  message.textContent = 'Game Over';
+  const quote = SPEAKER_QUOTES[Math.floor(Math.random() * SPEAKER_QUOTES.length)];
+  message.textContent = quote;
   box.appendChild(message);
 
   const flavor = document.createElement('div');
   flavor.classList.add('restart-flavor');
-  flavor.textContent = 'The deck runs cold. Try your luck again.';
+  flavor.textContent = 'You muster your strength and bring back your party.';
   box.appendChild(flavor);
 
   const btn = document.createElement('button');
   btn.classList.add('restart-button');
-  btn.textContent = 'Draw New Hand';
+  btn.textContent = 'Return to Sect';
   btn.addEventListener('click', () => {
     if (onRestart) onRestart();
     hideRestartScreen();


### PR DESCRIPTION
## Summary
- update restart screen to show a random Speaker quote and new flavor text
- add `returnPartyToSect` logic for exploration defeat
- mark defeated disciples incapacitated and return to sect on party wipe

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ee8e0d36c8326810094eb6d2b97fa