### PR TITLE
Remove dungeon task and fix wipe overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
   <link rel="stylesheet" href="style.css">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Creepster&display=swap" rel="stylesheet">
   <script src="https://unpkg.com/lucide@latest"></script>
   <title>Page Title</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/script.js
+++ b/script.js
@@ -224,7 +224,6 @@ const TASK_ICONS = {
   Research: '🔬',
   Chant: '🎶',
   Exploration: '🧭',
-  'Delve Dungeon': '🗝️',
   Idle: '💤',
   Resting: '🛌'
 };
@@ -263,8 +262,7 @@ function ensureDiscipleSkills(id) {
       Building: 0,
       Research: 0,
       Chant: 0,
-      Exploration: 0,
-      'Delve Dungeon': 0
+      Exploration: 0
     };
   }
 }
@@ -1588,7 +1586,6 @@ function renderColonyInfo() {
   if (sectState.buildings.researchTable > 0) tasks.push('Research');
   if (sectState.buildings.chantingHall > 0) tasks.push('Chant');
   if (systems.explorationUnlocked) tasks.push('Exploration');
-  if (discoveredLocations.includes('Esoteric Dungeon')) tasks.push('Delve Dungeon');
   tasks.forEach(t => {
     const option = document.createElement('div');
     option.className = 'disciple-skill-option';
@@ -3679,6 +3676,11 @@ function returnPartyToSect() {
   });
   currentExplorationParty = [];
   clearActiveDisciples();
+  inCombat = false;
+  currentEnemy = null;
+  removeDealerLifeBar();
+  hidePlayerAttackBar();
+  playerStats.hasDied = false;
   showTab(playerTab);
   setActiveTabButton(playerTabButton);
   if (playerSectSubTabButton) playerSectSubTabButton.click();

--- a/style.css
+++ b/style.css
@@ -1946,6 +1946,7 @@ body.darkenshift-mode .tabsContainer button.active {
     font-size: 1.6rem;
     color: #ddd;
     font-style: italic;
+    font-family: 'Creepster', cursive;
     text-shadow: 0 0 8px #fff;
     animation: fogFade 7s ease-in-out;
 }


### PR DESCRIPTION
## Summary
- stop offering disciples a "Delve Dungeon" job
- reset combat and hide bars when returning to the sect after a wipe
- show Speaker quotes with spooky Creepster font
- load the Creepster font from Google Fonts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ef2f9753c8326a1488d7019a3d446