### PR TITLE
Display disciple combat stats

### DIFF
--- a/disciple.js
+++ b/disciple.js
@@ -13,6 +13,7 @@ export default class Disciple {
     this.dexterity = attributes.dexterity || 0;
     this.endurance = attributes.endurance || 0;
     this.intelligence = attributes.intelligence || 0;
+    this.defense = 1;
     this.updateCombatStats();
   }
 
@@ -32,6 +33,7 @@ export default class Disciple {
   updateCombatStats() {
     this.damage = this.combatLevel * 3 * (1 + 0.05 * this.strength);
     this.attackSpeed = 10000 / (1 + 0.05 * this.dexterity);
+    this.defense = (1 + 0.05 * this.endurance) * this.combatLevel;
   }
 
   takeDamage(amount) {

--- a/rendering.js
+++ b/rendering.js
@@ -75,7 +75,9 @@ export function renderDiscipleCard(disciple, handContainer) {
   xpLabel.classList.add('xpBarLabel');
   xpLabel.textContent = `LV: ${disciple.combatLevel}`;
   xpBar.append(xpBarFill, xpLabel);
-  wrapper.append(cardPane, xpBar);
+  const statsDiv = document.createElement('div');
+  statsDiv.className = 'disciple-stats';
+  wrapper.append(cardPane, xpBar, statsDiv);
   handContainer.appendChild(wrapper);
   disciple.wrapperElement = wrapper;
   disciple.cardElement = cardPane;
@@ -83,6 +85,7 @@ export function renderDiscipleCard(disciple, handContainer) {
   disciple.xpBar = xpBar;
   disciple.xpBarFill = xpBarFill;
   disciple.xpLabel = xpLabel;
+  disciple.statsElement = statsDiv;
 }
 
 

--- a/script.js
+++ b/script.js
@@ -3065,6 +3065,7 @@ function combatXp(xpAmount) {
     d.gainCombatXp(xpAmount);
   });
   updatePlayerStats();
+  updateHandDisplay();
 }
 
 /**
@@ -3092,6 +3093,15 @@ function updateRedrawButton() {
   // removed redraw button UI
 }
 
+function updateDiscipleStatsDisplay(d) {
+  if (!d.statsElement) return;
+  const atkPerSec = (1000 / d.attackSpeed).toFixed(2);
+  const defense = Math.round(d.defense ?? 0);
+  d.statsElement.innerHTML =
+    `LV ${d.combatLevel} | DMG ${Math.round(d.damage)}<br>` +
+    `Atk/s ${atkPerSec} | Def ${defense}`;
+}
+
 // Refresh the cards currently shown in the player's hand
 function updateHandDisplay() {
   drawnCards.forEach(card => {
@@ -3115,6 +3125,7 @@ function updateHandDisplay() {
       const pct = (d.combatXp / d.xpForNextLevel()) * 100;
       d.xpBarFill.style.width = `${Math.min(pct, 100)}%`;
     }
+    updateDiscipleStatsDisplay(d);
     updateBloodSplat(d);
   });
 }
@@ -3131,6 +3142,7 @@ function renderCombatDisciples() {
     bar.appendChild(fill);
     d.wrapperElement.insertBefore(bar, d.xpBar);
     d.attackFill = fill;
+    updateDiscipleStatsDisplay(d);
   });
 }
 

--- a/style.css
+++ b/style.css
@@ -4010,3 +4010,10 @@ body.darkenshift-mode .tabsContainer button.active {
     width: 0%;
     background: #d4af37;
 }
+
+.disciple-stats {
+    font-size: 0.6rem;
+    text-align: center;
+    line-height: 1.1;
+    margin-top: 2px;
+}


### PR DESCRIPTION
## Summary
- compute a basic defense stat for disciples
- render disciple combat stats on the combat cards
- show updated stats whenever disciples spawn or level up
- minor UI tweaks for new display

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686efee4215c83268411af9711512857