### PR TITLE
Display combat stats in sect info panel

### DIFF
--- a/script.js
+++ b/script.js
@@ -2009,13 +2009,13 @@ function buildDiscipleCastingStatsView(d) {
 
 function buildDiscipleCombatStatsView(d) {
   const body = document.createElement('div');
-  const melee = (1 + 0.05 * (d.strength - 1)).toFixed(2);
-  const attackSpeed = (1 + 0.05 * (d.dexterity - 1)).toFixed(2);
-  const stamina = (1 + 0.05 * (d.endurance - 1)).toFixed(2);
+  const atkPerSec = (1000 / d.attackSpeed).toFixed(2);
+  const defense = Math.round(d.defense ?? 0);
   body.innerHTML =
-    `Melee Damage ×${melee}<br>` +
-    `Attack Speed ×${attackSpeed}<br>` +
-    `Stamina ×${stamina}`;
+    `Level ${d.combatLevel}<br>` +
+    `Damage ${Math.round(d.damage)}<br>` +
+    `Attack/s ${atkPerSec}<br>` +
+    `Defense ${defense}`;
   return body;
 }
 
@@ -3087,11 +3087,8 @@ function updateRedrawButton() {
 
 function updateDiscipleStatsDisplay(d) {
   if (!d.statsElement) return;
-  const atkPerSec = (1000 / d.attackSpeed).toFixed(2);
-  const defense = Math.round(d.defense ?? 0);
-  d.statsElement.innerHTML =
-    `LV ${d.combatLevel} | DMG ${Math.round(d.damage)}<br>` +
-    `Atk/s ${atkPerSec} | Def ${defense}`;
+  // Stats are now shown in the sect info panel rather than below the card
+  d.statsElement.innerHTML = '';
 }
 
 // Refresh the cards currently shown in the player's hand


### PR DESCRIPTION
## Summary
- remove combat stats from disciple card display
- show a disciple's combat stats in the sect info panel

## Testing
- `npm test` *(fails: mocha not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686f0623a7d08326a57d135483e8e9e0