### PR TITLE
Fix missing Murmur after load

### DIFF
--- a/script.js
+++ b/script.js
@@ -4036,6 +4036,12 @@ Object.assign(playerStats, state.playerStats || {});
       });
     }
 
+    if (!Array.isArray(speechState.savedConstructs)) {
+      speechState.savedConstructs = ['Murmur'];
+    } else if (!speechState.savedConstructs.includes('Murmur')) {
+      speechState.savedConstructs.unshift('Murmur');
+    }
+
     // ensure disciples have required stats when loading older saves
     if (Array.isArray(speechState.disciples)) {
       speechState.disciples.forEach(d => {
@@ -4152,6 +4158,9 @@ updateUpgradeButtons();
 
   updateWorldTabNotification();
   updateSectDisplay();
+  if (typeof renderConstructCards === 'function') {
+    renderConstructCards();
+  }
 
 addLog("Game loaded!",
 "info");


### PR DESCRIPTION
## Summary
- ensure the Murmur construct is present when loading saved games
- refresh the construct panel after loading

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686f2f43bf4c8326b8989eb874afcd0c