### PR TITLE
Add Verdantia background

### DIFF
--- a/speech.js
+++ b/speech.js
@@ -1132,6 +1132,11 @@ function renderSeasonBanner() {
   if (container) {
     seasonClasses.forEach(cls => container.classList.remove(cls));
     container.classList.add(seasonClasses[idx]);
+    if (season.name === 'Verdantia') {
+      container.classList.add('verdantia-bg');
+    } else {
+      container.classList.remove('verdantia-bg');
+    }
   }
   if (speechState.weather) {
     banner.innerHTML = `${season.name} Day ${day} (${daysLeft}d) ${temp}°C<span class="weather-icon">${speechState.weather.icon}</span>`;

--- a/style.css
+++ b/style.css
@@ -3088,6 +3088,8 @@ body.darkenshift-mode .tabsContainer button.active {
 
 #constructTabCardContainer {
     backdrop-filter: blur(8px);
+    position: relative;
+    z-index: 1;
 }
 
 .construct-lexicon {
@@ -4058,3 +4060,24 @@ body.darkenshift-mode .tabsContainer button.active {
 .skill-group > div:first-child {
     cursor: pointer;
 }
+.verdantia-bg::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image: url('img/mist.png');
+  background-size: cover;
+  background-position: center;
+  opacity: 0.25;
+  z-index: 0;
+  pointer-events: none;
+}
+
+.verdantia-bg::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(to bottom right, rgba(50, 100, 50, 0.1), rgba(80, 150, 80, 0.15));
+  z-index: 0;
+  pointer-events: none;
+}
+


### PR DESCRIPTION
## Summary
- add Verdantia mist asset
- overlay Verdantia background and color gradient
- apply Verdantia class when the season changes

## Testing
- `npm test`
- `npm run lint` *(fails: 'describe' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_686f3892e148832696b554a94a10547a