### PR TITLE
Ensure Murmur appears after loading saves

### DIFF
--- a/script.js
+++ b/script.js
@@ -4164,6 +4164,7 @@ updateUpgradeButtons();
   updateSectDisplay();
   if (typeof renderConstructCards === 'function') {
     renderConstructCards();
+    if (typeof renderHotbar === 'function') renderHotbar();
   }
 
 addLog("Game loaded!",


### PR DESCRIPTION
## Summary
- fix missing Murmur card when loading saved games by re-rendering the construct hotbar

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686f3b8b766083269bc917aa29a178c4