### PR TITLE
Remove disciple construct power from stats view

### DIFF
--- a/script.js
+++ b/script.js
@@ -2223,7 +2223,6 @@ function openDiscipleOverlay(d) {
       const c = document.createElement('div');
       c.appendChild(buildDiscipleStatsView(d));
       c.appendChild(buildDiscipleLifeStatsView(d));
-      c.appendChild(buildDiscipleCastingStatsView(d));
       c.appendChild(buildDiscipleCombatStatsView(d));
       content.appendChild(c);
     } else if (active === 'skills') {


### PR DESCRIPTION
## Summary
- remove `buildDiscipleCastingStatsView` from the disciple stats overlay

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686f4285d1a08326a0c84e1756ef55ff