### PR TITLE
Fix missing speech exports

### DIFF
--- a/speech.js
+++ b/speech.js
@@ -730,7 +730,7 @@ export function unlockConstruct(name) {
   }
 }
 
-function renderConstructCards() {
+export function renderConstructCards() {
   const cont = panel.querySelector('#modalCardContainer');
   const slotCont = panel.querySelector('#memorySlotsDisplay');
   if (!cont || !slotCont) return;
@@ -1025,7 +1025,7 @@ export function castConstruct(name, el, powerMult = 1, caster = 'player') {
   renderOrbs();
 }
 
-function renderHotbar() {
+export function renderHotbar() {
   const bars = [];
   if (container) {
     const b = container.querySelector('#constructHotbar');


### PR DESCRIPTION
## Summary
- export `renderConstructCards` and `renderHotbar`

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686f42eded7c832690d00afa5d32795d