### PR TITLE
Update tab backgrounds and construct theme

### DIFF
--- a/style.css
+++ b/style.css
@@ -229,7 +229,7 @@ body.darkenshift-mode .tabsContainer button.active {
 }
 
 .mainTab.world-2-theme {
-    background: radial-gradient(circle, #3b1a1a 0%, #1a0000 100%);
+    background: transparent;
 }
 
 .cardSubTab {
@@ -1372,7 +1372,7 @@ body.darkenshift-mode .tabsContainer button.active {
 .deckTab {
     display: flex;
     gap: 10px;
-    background-color: #67a16c;
+    background: transparent;
     padding: 5px;
     height: 100vh;
 }
@@ -1524,7 +1524,7 @@ body.darkenshift-mode .tabsContainer button.active {
 .starChartTab {
     width: 100%;
     height: 100vh;
-    background: black;
+    background: transparent;
     overflow: hidden;
 }
 
@@ -1533,7 +1533,7 @@ body.darkenshift-mode .tabsContainer button.active {
     display: flex;
     flex-direction: column;
     gap: 10px;
-    background-color: #556b7a;
+    background: transparent;
     padding: 5px;
 }
 
@@ -2126,7 +2126,7 @@ body.darkenshift-mode .tabsContainer button.active {
 .playerTab {
     display: flex;
     gap: 10px;
-    background-color: #0b0f1a;
+    background: transparent;
     color: #e0e0f0;
     padding: 5px;
     height: 100vh;
@@ -3083,7 +3083,7 @@ body.darkenshift-mode .tabsContainer button.active {
 .construct-area.aurora,
 .construct-area.autumn,
 .construct-area.winter {
-    background: linear-gradient(135deg, var(--season-start), var(--season-end));
+    background: rgba(30, 35, 50, 0.6);
     backdrop-filter: blur(8px) brightness(0.9);
 }
 


### PR DESCRIPTION
## Summary
- remove unique background colors on major tabs
- unify all tabs by letting the page's mist background show through
- drop green seasonal gradient from construct area

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f44c3777c8326bfc022f2d23ea8ac