### PR TITLE
Improve Verdantia colony map visuals

### DIFF
--- a/index.html
+++ b/index.html
@@ -246,17 +246,20 @@
                 <button id="locationsPanelBtn">📍</button>
               </div>
               <div id="sectDisciplesContainer" class="sect-disciples-container">
+                <div class="zone orchard"></div>
+                <div class="zone lumberyard"></div>
+                <div class="zone meditation"></div>
                 <div class="sect-orbs" id="sectOrbs"></div>
                 <div id="sectBasket" class="sect-basket"></div>
                 <div id="sectShack" class="sect-shack"></div>
                 <div id="fruitPatch" class="fruit-patch"></div>
               </div>
             </div>
+            <div id="sectDiscipleList" class="sect-disciple-list"></div>
             <div class="colony-side">
               <div id="colonyTasksPanel" class="colony-panel"></div>
               <div id="colonyInfoPanel" class="colony-panel"></div>
               <div id="colonyResourcesPanel" class="colony-panel" style="display:none;">
-                <div id="sectDiscipleList" class="sect-disciple-list"></div>
                 <div id="sectSummary" class="sect-summary"></div>
               </div>
               <div id="colonyBuildPanel" class="colony-panel" style="display:none;"></div>

--- a/script.js
+++ b/script.js
@@ -994,6 +994,21 @@ function initTabs() {
   if (playerConstructSubTabButton) playerConstructSubTabButton.click();
 }
 
+function initPollen() {
+  if (!sectDisciplesContainer) return;
+  const layer = document.createElement('div');
+  layer.className = 'pollen-layer';
+  for (let i = 0; i < 20; i++) {
+    const p = document.createElement('div');
+    p.className = 'pollen';
+    p.style.left = Math.random() * 100 + '%';
+    p.style.animationDelay = (Math.random() * 10) + 's';
+    p.style.animationDuration = (30 + Math.random() * 20) + 's';
+    layer.appendChild(p);
+  }
+  sectDisciplesContainer.appendChild(layer);
+}
+
 // Allow collapsing/expanding vignette UI panels
 function initVignetteToggles() {
   document.querySelectorAll(".vignette-toggle").forEach(btn => {
@@ -1653,8 +1668,6 @@ function renderColonyInfo() {
 function renderColonyResources() {
   colonyResourcesPanel.innerHTML = '';
   renderSectDiscipleList();
-  if (sectDiscipleListContainer)
-    colonyResourcesPanel.appendChild(sectDiscipleListContainer);
   if (sectSummaryDisplay) colonyResourcesPanel.appendChild(sectSummaryDisplay);
   checkBuildingUnlock();
 }
@@ -2446,6 +2459,7 @@ document.addEventListener("DOMContentLoaded", () => {
   // now the DOM is in, and lucide.js has run, so window.lucide is defined
   initSpeech();
   initTabs();
+  initPollen();
   window.addEventListener('location-discovered', e => addDiscoveredLocation(e.detail.name));
   loadGame();
   checkBuildingUnlock();

--- a/style.css
+++ b/style.css
@@ -3480,10 +3480,10 @@ body.darkenshift-mode .tabsContainer button.active {
     position: absolute;
     inset: 0;
     box-sizing: border-box;
-    border: 2px solid rgba(255, 255, 255, 0.1);
-    box-shadow: inset 0 0 20px rgba(0, 0, 0, 0.4);
+    border: 1px solid rgba(0, 0, 0, 0.6);
+    box-shadow: inset 0 0 8px rgba(0, 0, 0, 0.6);
     background-image: url('img/sect-map.png');
-    background-size: contain;
+    background-size: cover;
     background-position: center;
     background-repeat: no-repeat;
     overflow: hidden;
@@ -3497,18 +3497,83 @@ body.darkenshift-mode .tabsContainer button.active {
     background: radial-gradient(circle at 50% 10%, rgba(255, 255, 200, 0.2), transparent 80%);
     z-index: 1;
 }
+
+.sect-disciples-container::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background: radial-gradient(circle at center, rgba(0,0,0,0) 60%, rgba(0,0,0,0.6) 100%);
+    z-index: 1;
+}
 .sect-summary {
     display: flex;
-    justify-content: space-around;
-    gap: 8px;
-    padding: 4px;
-    font-size: 0.75rem;
-    background: rgba(0,0,0,0.4);
+    justify-content: center;
+    gap: 16px;
+    padding: 6px 8px;
+    font-size: 0.8rem;
+    background: rgba(0,0,0,0.25);
+    box-shadow: 0 2px 6px rgba(0,0,0,0.4);
+    border-top: 1px solid rgba(0,0,0,0.6);
 }
 .sect-summary span {
     display: flex;
     align-items: center;
-    gap: 2px;
+    gap: 4px;
+    padding: 0 4px;
+}
+
+.zone {
+    position: absolute;
+    pointer-events: none;
+    border: 2px solid rgba(0,0,0,0.2);
+    border-radius: 4px;
+    box-shadow: inset 0 0 8px rgba(0,0,0,0.4);
+    z-index: 0;
+}
+.zone.orchard {
+    left: 2%;
+    top: 2%;
+    width: 30%;
+    height: 40%;
+    background: radial-gradient(circle, rgba(160,220,160,0.15), transparent 80%);
+}
+.zone.lumberyard {
+    right: 2%;
+    top: 2%;
+    width: 30%;
+    height: 40%;
+    background: radial-gradient(circle, rgba(200,170,120,0.15), transparent 80%);
+}
+.zone.meditation {
+    left: 20%;
+    bottom: 2%;
+    width: 60%;
+    height: 40%;
+    background: radial-gradient(circle, rgba(250,250,200,0.1), transparent 80%);
+}
+
+.pollen-layer {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    overflow: hidden;
+    z-index: 2;
+}
+.pollen {
+    position: absolute;
+    top: -10px;
+    width: 4px;
+    height: 4px;
+    background: rgba(255,255,200,0.5);
+    border-radius: 50%;
+    opacity: 0.6;
+    animation: pollen-fall linear infinite;
+}
+
+@keyframes pollen-fall {
+    from { transform: translateY(0); opacity: 0.6; }
+    to { transform: translateY(110%); opacity: 0; }
 }
 
 .colony-container {
@@ -4040,9 +4105,11 @@ body.darkenshift-mode .tabsContainer button.active {
 /* Sect disciple list cards */
 .sect-disciple-list {
     display: flex;
-    flex-wrap: wrap;
+    justify-content: center;
     gap: 8px;
-    justify-content: space-around;
+    padding: 4px 0;
+    flex-wrap: nowrap;
+    overflow-x: auto;
 }
 .sect-disciple-card {
     position: relative;
@@ -4056,12 +4123,12 @@ body.darkenshift-mode .tabsContainer button.active {
     align-items: center;
     cursor: pointer;
     background: var(--verdantia-parchment);
-    box-shadow: 0 2px 4px rgba(0,0,0,0.15);
+    box-shadow: 0 2px 6px rgba(0,0,0,0.4);
     transition: box-shadow 0.2s, background 0.2s;
 }
 .sect-disciple-card:hover {
     background: #fbf6e0;
-    box-shadow: 0 0 6px rgba(0,0,0,0.3);
+    box-shadow: 0 0 8px rgba(0,0,0,0.4);
 }
 .disciple-icon {
     position: absolute;


### PR DESCRIPTION
## Summary
- enhance sect map container styling and fade edges
- add Orchard, Lumberyard and Meditation Grove zones
- create drifting pollen animation
- reposition disciple list below the map
- style disciple cards and resource bar as elevated panels

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686fd87af6a48326bd13ac9b2a0518c8