### PR TITLE
Enhance disciple cards for exploration

### DIFF
--- a/docs/disciples.md
+++ b/docs/disciples.md
@@ -161,6 +161,29 @@ With these values, the default XP gain rates and example time to reach higher pr
 
 These estimates assume no attribute bonuses and continuous work on the same task. Attribute points or upgrades will shorten the timelines further.
 
+## Disciple Cards
+
+Disciples appear in the colony interface as compact cards. Each card displays:
+
+```
+┌───────────────────────────────┐
+│ ● [Portrait]  Name LvX        │
+│ ───────────────────────────── │
+│ ❤️  h/m  [bar]                │
+│ ⚡  s/m  [bar]                │
+│ 🍖  h/m  [bar]                │
+│ ───────────────────────────── │
+│ 📋 Task: Current              │
+│ ⏳ ETA: time                  │
+│ ───────────────────────────── │
+│ [ Assign ] [ Stats ] [ Feed ] │
+└───────────────────────────────┘
+```
+
+Health, stamina and hunger are shown with icons, numeric values and colored bars. The task line reflects the follower's current job and the ETA counts down to the next cycle. Action buttons provide quick access to assignment, stats and feeding.
+
+Exploration uses the same layout—disciples selected for an expedition are shown with identical cards in the **Exploration** tab.
+
 ## Combat Participation
 
 Disciples join the player during combat encounters. Each follower acts in place

--- a/script.js
+++ b/script.js
@@ -274,6 +274,120 @@ function makeBar(value, max, color) {
   return bar;
 }
 
+function formatTime(seconds) {
+  if (!isFinite(seconds)) return '∞';
+  const s = Math.max(0, Math.round(seconds));
+  const m = Math.floor(s / 60);
+  const sec = s % 60;
+  return m > 0 ? `${m}m ${sec}s` : `${sec}s`;
+}
+
+function createLabeledBar(icon, value, max, color) {
+  const row = document.createElement('div');
+  row.className = 'disciple-card-row';
+  const ic = document.createElement('span');
+  ic.className = 'disciple-bar-icon';
+  ic.textContent = icon;
+  const text = document.createElement('span');
+  text.className = 'disciple-bar-text';
+  text.textContent = `${Math.round(value)}/${Math.round(max)}`;
+  const bar = makeBar(value, max, color);
+  bar.classList.add('disciple-card-bar');
+  row.appendChild(ic);
+  row.appendChild(text);
+  row.appendChild(bar);
+  return row;
+}
+
+function getTaskEta(d) {
+  const task = d.incapacitated ? 'Resting' : sectState.discipleTasks[d.id] || 'Idle';
+  if (task === 'Gather Fruit' || task === 'Log Pine') {
+    const progress = sectState.discipleProgress[d.id] || 0;
+    const baseSeconds = task === 'Gather Fruit' ? FRUIT_CYCLE_SECONDS : PINE_LOG_CYCLE_SECONDS;
+    const cycleAmount = task === 'Gather Fruit' ? FRUIT_CYCLE_AMOUNT : PINE_LOG_CYCLE_AMOUNT;
+    const skillXp = sectState.discipleSkills[d.id]?.[task] || 0;
+    const lvl = getTaskSkillProgress(skillXp).level;
+    const yieldMult = 1 + 0.05 * lvl;
+    const gatherAmt = Math.min(cycleAmount * yieldMult, d.inventorySlots);
+    const cycleSeconds = baseSeconds * (gatherAmt / (cycleAmount * yieldMult));
+    return cycleSeconds - progress;
+  } else if (task === 'Research') {
+    const researcherCount = speechState.disciples.filter(x => sectState.discipleTasks[x.id] === 'Research').length;
+    const researchRate = researcherCount * 4;
+    const researchProg = sectState.researchProgress % 500;
+    return researchRate > 0 ? (500 - researchProg) / researchRate : Infinity;
+  } else if (task === 'Building') {
+    const buildKey = sectState.currentBuild;
+    const buildData = buildKey ? BUILDINGS[buildKey] : null;
+    const builderCount = speechState.disciples.filter(x => sectState.discipleTasks[x.id] === 'Building').length;
+    return buildData && builderCount > 0 ? ((1 - sectState.buildProgress) * buildData.time) / builderCount : Infinity;
+  } else if (task === 'Exploration') {
+    const progress = sectState.discipleProgress[d.id] || 0;
+    return EXPLORATION_CYCLE_SECONDS - progress;
+  }
+  return 0;
+}
+
+function createDiscipleCard(d) {
+  const card = document.createElement('div');
+  card.className = 'disciple-card';
+  const head = document.createElement('div');
+  head.className = 'disciple-card-head';
+  const icon = document.createElement('div');
+  icon.className = 'disciple-card-icon';
+  icon.textContent = (d.name || `Disciple ${d.id}`).charAt(0);
+  const name = document.createElement('span');
+  name.textContent = d.name || `Disciple ${d.id}`;
+  const level = document.createElement('span');
+  level.className = 'disciple-card-level';
+  level.textContent = `Lv${d.combatLevel || 1}`;
+  head.append(icon, name, level);
+  card.appendChild(head);
+
+  card.appendChild(createLabeledBar('❤️', d.health, DISCIPLE_MAX_HEALTH, '#a33'));
+  card.appendChild(
+    createLabeledBar('⚡', d.stamina, calculateMaxStamina(d.endurance), '#cc3')
+  );
+  card.appendChild(createLabeledBar('🍖', d.hunger, 20, '#996633'));
+
+  const task = document.createElement('div');
+  task.className = 'disciple-card-task';
+  const curTask = d.incapacitated ? 'Resting' : sectState.discipleTasks[d.id] || 'Idle';
+  task.textContent = `Task: ${curTask}`;
+  const eta = document.createElement('div');
+  eta.className = 'disciple-card-eta';
+  eta.textContent = `ETA: ${formatTime(getTaskEta(d))}`;
+  card.append(task, eta);
+
+  const actions = document.createElement('div');
+  actions.className = 'disciple-card-actions';
+  const assign = document.createElement('button');
+  assign.textContent = 'Assign';
+  assign.addEventListener('click', e => {
+    e.stopPropagation();
+    openDiscipleOverlay(d);
+  });
+  const statsBtn = document.createElement('button');
+  statsBtn.textContent = 'Stats';
+  statsBtn.addEventListener('click', e => {
+    e.stopPropagation();
+    openDiscipleOverlay(d);
+  });
+  const feedBtn = document.createElement('button');
+  feedBtn.textContent = 'Feed';
+  feedBtn.addEventListener('click', e => {
+    e.stopPropagation();
+    if (sectState.fruits > 0 && d.hunger < 20) {
+      sectState.fruits -= 1;
+      d.hunger = 20;
+      updateSectDisplay();
+    }
+  });
+  actions.append(assign, statsBtn, feedBtn);
+  card.appendChild(actions);
+  return card;
+}
+
 function ensureDiscipleSkills(id) {
   if (!sectState.discipleSkills[id]) {
     sectState.discipleSkills[id] = {
@@ -2176,23 +2290,7 @@ function renderSectDiscipleList() {
   const list = document.createElement('div');
   list.className = 'sect-disciple-list';
   speechState.disciples.forEach(d => {
-    const card = document.createElement('div');
-    card.className = 'sect-disciple-card';
-    const icon = document.createElement('div');
-    icon.className = 'disciple-icon';
-    icon.textContent = (d.name || `Disciple ${d.id}`).charAt(0);
-    card.appendChild(icon);
-    const name = document.createElement('div');
-    name.textContent = d.name || `Disciple ${d.id}`;
-    const task = d.incapacitated ? 'Resting' : sectState.discipleTasks[d.id] || 'Idle';
-    const taskEl = document.createElement('div');
-    taskEl.textContent = task;
-    const life = makeBar(d.health, DISCIPLE_MAX_HEALTH, '#a33');
-    const stam = makeBar(d.stamina, calculateMaxStamina(d.endurance), '#cc3');
-    card.appendChild(name);
-    card.appendChild(taskEl);
-    card.appendChild(life);
-    card.appendChild(stam);
+    const card = createDiscipleCard(d);
     card.addEventListener('click', () => openDiscipleOverlay(d));
     list.appendChild(card);
   });
@@ -2306,6 +2404,7 @@ function renderExplorationTab() {
   explorationListContainer.innerHTML = '';
   speechState.disciples.forEach(d => {
     const row = document.createElement('label');
+    row.className = 'exploration-entry';
     const cb = document.createElement('input');
     cb.type = 'checkbox';
     cb.value = d.id;
@@ -2315,7 +2414,7 @@ function renderExplorationTab() {
       else explorationParty.delete(d.id);
     });
     row.appendChild(cb);
-    row.appendChild(document.createTextNode(d.name || `Disciple ${d.id}`));
+    row.appendChild(createDiscipleCard(d));
     explorationListContainer.appendChild(row);
   });
 }

--- a/style.css
+++ b/style.css
@@ -4241,3 +4241,80 @@ body.darkenshift-mode .tabsContainer button.active {
   pointer-events: none;
 }
 
+.disciple-card {
+  background: #f5eedb;
+  border: 1px solid #3a5a3a;
+  box-shadow: inset 0 0 4px rgba(0,0,0,0.4);
+  padding: 4px;
+  width: 120px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  font-size: 0.7rem;
+}
+
+.disciple-card-head {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-weight: 600;
+  color: #3a5a3a;
+}
+
+.disciple-card-icon {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: #eee;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.7rem;
+  box-shadow: 0 0 2px rgba(0,0,0,0.5);
+}
+
+.disciple-card-level {
+  background: #3a5a3a;
+  color: #f5eedb;
+  border-radius: 4px;
+  padding: 0 4px;
+  font-size: 0.65rem;
+}
+
+.disciple-card-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.disciple-card-bar {
+  flex: 1;
+}
+
+.disciple-bar-icon {
+  width: 1em;
+}
+
+.disciple-card-task,
+.disciple-card-eta {
+  font-size: 0.65rem;
+}
+
+.disciple-card-actions {
+  display: flex;
+  gap: 4px;
+  justify-content: center;
+  margin-top: 2px;
+}
+
+.disciple-card-actions button {
+  font-size: 0.6rem;
+}
+
+.exploration-entry {
+  display: flex;
+  align-items: flex-start;
+  gap: 4px;
+  padding: 2px 0;
+}
+


### PR DESCRIPTION
## Summary
- add UI spec for disciple cards and exploration notes
- implement `createDiscipleCard` helper with ETA and action buttons
- show disciple cards in colony list and exploration tab
- style new card elements

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686fedbc2a288326be7d56efb77ab94f