### PR TITLE
Update disciple overlay styling

### DIFF
--- a/script.js
+++ b/script.js
@@ -2298,6 +2298,7 @@ function renderSectDiscipleList() {
 }
 
 let discipleOverlay = null;
+let discipleOverlayData = { disciple: null, bars: null };
 function openDiscipleOverlay(d) {
   if (discipleOverlay) discipleOverlay.close();
   discipleOverlay = createOverlay({ className: 'disciple-overlay' });
@@ -2319,13 +2320,27 @@ function openDiscipleOverlay(d) {
   let active = 'general';
   function render() {
     content.innerHTML = '';
-    if (active === 'general') content.appendChild(buildDiscipleGeneralView(d));
-    else if (active === 'stats') {
+    discipleOverlayData.bars = null;
+    if (active === 'general') {
+      content.appendChild(buildDiscipleGeneralView(d));
+    } else if (active === 'stats') {
       const c = document.createElement('div');
-      c.appendChild(buildDiscipleStatsView(d));
+      const statsView = buildDiscipleStatsView(d);
+      c.appendChild(statsView);
       c.appendChild(buildDiscipleLifeStatsView(d));
       c.appendChild(buildDiscipleCombatStatsView(d));
       content.appendChild(c);
+      const rows = statsView.querySelectorAll('.stat-row');
+      if (rows.length >= 3) {
+        discipleOverlayData.bars = {
+          healthFill: rows[0].querySelector('.bar-fill'),
+          healthVal: rows[0].lastElementChild,
+          staminaFill: rows[1].querySelector('.bar-fill'),
+          staminaVal: rows[1].lastElementChild,
+          hungerFill: rows[2].querySelector('.bar-fill'),
+          hungerVal: rows[2].lastElementChild
+        };
+      }
     } else if (active === 'skills') {
       content.appendChild(buildDiscipleSkillsList(d));
     } else if (active === 'inventory') {
@@ -2346,8 +2361,32 @@ function openDiscipleOverlay(d) {
     });
     tabs.appendChild(btn);
   });
+  discipleOverlayData.disciple = d;
   render();
   discipleOverlay.appendButton('Close', discipleOverlay.close);
+  discipleOverlay.onClose(() => {
+    discipleOverlayData.disciple = null;
+    discipleOverlayData.bars = null;
+  });
+}
+
+function updateDiscipleOverlayBars() {
+  const data = discipleOverlayData;
+  if (!data.disciple || !data.bars) return;
+  const d = data.disciple;
+  const maxStamina = calculateMaxStamina(d.endurance);
+  if (data.bars.healthFill)
+    data.bars.healthFill.style.width = `${(d.health / DISCIPLE_MAX_HEALTH) * 100}%`;
+  if (data.bars.healthVal)
+    data.bars.healthVal.textContent = `${Math.round(d.health)}/${DISCIPLE_MAX_HEALTH}`;
+  if (data.bars.staminaFill)
+    data.bars.staminaFill.style.width = `${(d.stamina / maxStamina) * 100}%`;
+  if (data.bars.staminaVal)
+    data.bars.staminaVal.textContent = `${Math.round(d.stamina)}/${Math.round(maxStamina)}`;
+  if (data.bars.hungerFill)
+    data.bars.hungerFill.style.width = `${(d.hunger / 20) * 100}%`;
+  if (data.bars.hungerVal)
+    data.bars.hungerVal.textContent = `${Math.round(d.hunger)}/20`;
 }
 
 function buildDiscipleSkillsList(d) {
@@ -4506,6 +4545,7 @@ if (currentEnemy) {
   tickBarProgress(deltaTime);
   tickSpeech(deltaTime);
   tickSect(deltaTime);
+  updateDiscipleOverlayBars();
   const dtSeconds = deltaTime / 1000;
   speechState.gains.qi =
     dtSeconds > 0

--- a/style.css
+++ b/style.css
@@ -594,6 +594,27 @@ body.darkenshift-mode .tabsContainer button.active {
     margin: 4px;
 }
 
+/* Disciple overlay positioning and style */
+.disciple-overlay.overlay {
+    background: none;
+    backdrop-filter: none;
+    justify-content: flex-end;
+    align-items: flex-start;
+}
+.disciple-overlay .overlay-box {
+    background: var(--verdantia-parchment);
+    color: #000;
+    border: 1px solid #3a5a3a;
+    box-shadow: 0 2px 6px rgba(0,0,0,0.4);
+    max-width: 300px;
+    font-size: 0.75rem;
+}
+.disciple-overlay .overlay-box button {
+    background: var(--verdantia-parchment);
+    color: #000;
+    border: 1px solid #3a5a3a;
+}
+
 .qi-regen-overlay {
     flex-direction: column;
     gap: 8px;
@@ -4167,8 +4188,16 @@ body.darkenshift-mode .tabsContainer button.active {
     margin-bottom: 6px;
     justify-content: center;
 }
+.disciple-tabs button {
+    background: var(--verdantia-parchment);
+    border: 1px solid #3a5a3a;
+    color: #000;
+    padding: 2px 4px;
+    font-size: 0.7rem;
+}
 .disciple-tabs button.active {
-    background: #333;
+    background: #3a5a3a;
+    color: var(--verdantia-parchment);
 }
 .disciple-general {
     display: flex;
@@ -4251,6 +4280,7 @@ body.darkenshift-mode .tabsContainer button.active {
   flex-direction: column;
   gap: 2px;
   font-size: 0.7rem;
+  color: #000;
 }
 
 .disciple-card-head {
@@ -4258,7 +4288,7 @@ body.darkenshift-mode .tabsContainer button.active {
   align-items: center;
   gap: 4px;
   font-weight: 600;
-  color: #3a5a3a;
+  color: #000;
 }
 
 .disciple-card-icon {


### PR DESCRIPTION
## Summary
- style disciple overlay like parchment card on right side
- darken disciple card text
- update bars in disciple overlay dynamically
- style disciple tabs consistently

## Testing
- `npm test` *(fails: mocha not found)*
- `npm run lint` *(fails: cannot find ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_686ff529a2c08326aab76787d92f56ed