### PR TITLE
Update disciple stats layout

### DIFF
--- a/script.js
+++ b/script.js
@@ -2309,6 +2309,12 @@ function openDiscipleOverlay(d) {
   discipleOverlay = createOverlay({ className: 'disciple-overlay' });
   const { box } = discipleOverlay;
 
+  const closeBtn = document.createElement('button');
+  closeBtn.className = 'close-btn';
+  closeBtn.innerHTML = '&times;';
+  closeBtn.addEventListener('click', discipleOverlay.close);
+  box.appendChild(closeBtn);
+
   const tabs = document.createElement('div');
   tabs.className = 'disciple-tabs';
   box.appendChild(tabs);
@@ -2327,15 +2333,9 @@ function openDiscipleOverlay(d) {
     content.innerHTML = '';
     discipleOverlayData.bars = null;
     if (active === 'general') {
-      content.appendChild(buildDiscipleGeneralView(d));
-    } else if (active === 'stats') {
-      const c = document.createElement('div');
-      const statsView = buildDiscipleStatsView(d);
-      c.appendChild(statsView);
-      c.appendChild(buildDiscipleLifeStatsView(d));
-      c.appendChild(buildDiscipleCombatStatsView(d));
-      content.appendChild(c);
-      const rows = statsView.querySelectorAll('.stat-row');
+      const view = buildDiscipleGeneralView(d);
+      content.appendChild(view);
+      const rows = view.querySelectorAll('.stat-row');
       if (rows.length >= 3) {
         discipleOverlayData.bars = {
           healthFill: rows[0].querySelector('.bar-fill'),
@@ -2346,6 +2346,23 @@ function openDiscipleOverlay(d) {
           hungerVal: rows[2].lastElementChild
         };
       }
+    } else if (active === 'stats') {
+      const c = document.createElement('div');
+      const genSection = document.createElement('div');
+      genSection.className = 'disciple-stats-general';
+      const genTitle = document.createElement('h3');
+      genTitle.textContent = 'General Stats';
+      genSection.appendChild(genTitle);
+      genSection.appendChild(buildDiscipleStatsView(d));
+      const combatSection = document.createElement('div');
+      combatSection.className = 'disciple-stats-combat';
+      const comTitle = document.createElement('h3');
+      comTitle.textContent = 'Combat Stats';
+      combatSection.appendChild(comTitle);
+      combatSection.appendChild(buildDiscipleCombatStatsView(d));
+      c.appendChild(genSection);
+      c.appendChild(combatSection);
+      content.appendChild(c);
     } else if (active === 'skills') {
       content.appendChild(buildDiscipleSkillsList(d));
     } else if (active === 'inventory') {
@@ -2368,7 +2385,6 @@ function openDiscipleOverlay(d) {
   });
   discipleOverlayData.disciple = d;
   render();
-  discipleOverlay.appendButton('Close', discipleOverlay.close);
   discipleOverlay.onClose(() => {
     discipleOverlayData.disciple = null;
     discipleOverlayData.bars = null;

--- a/style.css
+++ b/style.css
@@ -609,11 +609,37 @@ body.darkenshift-mode .tabsContainer button.active {
     width: 300px;
     min-height: 260px;
     font-size: 0.75rem;
+    position: relative;
 }
 .disciple-overlay .overlay-box button {
     background: var(--verdantia-parchment);
     color: #000;
     border: 1px solid #3a5a3a;
+}
+.disciple-overlay .close-btn {
+    position: absolute;
+    top: 4px;
+    right: 4px;
+    width: 16px;
+    height: 16px;
+    background: #c33;
+    color: #fff;
+    border: none;
+    border-radius: 50%;
+    font-size: 12px;
+    line-height: 14px;
+    text-align: center;
+    cursor: pointer;
+}
+.disciple-stats-general,
+.disciple-stats-combat {
+    margin-bottom: 8px;
+    font-size: 0.75rem;
+}
+.disciple-stats-general h3,
+.disciple-stats-combat h3 {
+    margin: 0 0 4px 0;
+    font-size: 0.8rem;
 }
 
 .qi-regen-overlay {
@@ -4203,9 +4229,9 @@ body.darkenshift-mode .tabsContainer button.active {
 .disciple-general {
     display: flex;
     flex-direction: column;
-    align-items: center;
+    align-items: flex-start;
     gap: 4px;
-    text-align: center;
+    text-align: left;
 }
 .disciple-portrait {
     width: 80px;


### PR DESCRIPTION
## Summary
- tweak disciple overlay layout
- split stats tab into General and Combat sections
- left-align general tab
- style close button

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870097449d8832689635e3580e5d511