### PR TITLE
Fix disciple defaults

### DIFF
--- a/script.js
+++ b/script.js
@@ -54,6 +54,7 @@ import {
   calculateMaxStamina,
   calculateStaminaRegen
 } from './utils/stamina.js';
+import { initializeDisciple } from './utils/discipleInit.js';
 import {
   rollNewCardUpgrades,
   applyCardUpgrade,
@@ -4371,26 +4372,7 @@ Object.assign(playerStats, state.playerStats || {});
 
     // ensure disciples have required stats when loading older saves
     if (Array.isArray(speechState.disciples)) {
-      speechState.disciples.forEach(d => {
-        if (d.health === undefined) d.health = 10;
-        if (d.stamina === undefined) d.stamina = 10;
-        if (d.hunger === undefined) d.hunger = 20;
-        if (d.power === undefined) d.power = 1;
-        if (d.strength === undefined) d.strength = 1;
-        if (d.dexterity === undefined) d.dexterity = 1;
-        if (d.endurance === undefined) d.endurance = 1;
-        if (d.intelligence === undefined) d.intelligence = 1;
-        if (d.incapacitated === undefined) d.incapacitated = false;
-        if (!d.name) d.name = `Disciple ${d.id}`;
-        if (d.inventorySlots === undefined) d.inventorySlots = 10;
-        if (!d.inventory) d.inventory = {};
-
-        if (d.combatLevel === undefined) d.combatLevel = 1;
-        if (d.maxHp === undefined) d.maxHp = 10;
-        if (d.currentHp === undefined) d.currentHp = d.maxHp;
-        Object.setPrototypeOf(d, Disciple.prototype);
-        if (typeof d.updateCombatStats === 'function') d.updateCombatStats();
-      });
+      speechState.disciples.forEach(d => initializeDisciple(d));
     }
   }
 

--- a/speech.js
+++ b/speech.js
@@ -3,6 +3,7 @@ import { coreState, refreshCore } from './core.js';
 import { sectState, systems, currentEnemy } from './script.js';
 import { generateDiscipleAttributes } from './discipleAttributes.js';
 import Disciple from './disciple.js';
+import { initializeDisciple } from './utils/discipleInit.js';
 import { createOverlay } from './ui/overlay.js';
 
 // Core state for the Constructs system. Orbs and upgrades from the
@@ -472,7 +473,9 @@ const constructEffects = {
         endurance: 1 + bonus.endurance,
         intelligence: 1 + bonus.intelligence
       };
-      speechState.disciples.push(new Disciple({ id: targetIdx, name: `Disciple ${targetIdx}`, attributes: attrs }));
+      const newDisc = new Disciple({ id: targetIdx, name: `Disciple ${targetIdx}`, attributes: attrs });
+      initializeDisciple(newDisc);
+      speechState.disciples.push(newDisc);
       sectState.discipleConstructXp[targetIdx] = {};
       addLog('A new Disciple has answered your call!', 'info');
       if (lastConstructTarget) showConstructCloud('+1', lastConstructTarget);

--- a/test/disciple.initialization.test.cjs
+++ b/test/disciple.initialization.test.cjs
@@ -1,0 +1,14 @@
+const { expect } = require('chai');
+const { initializeDisciple } = require('../utils/discipleInit.js');
+const Disciple = require('../disciple.js').default;
+
+describe('🧍 Disciple initialization', () => {
+  it('applies default stats for new disciples', () => {
+    const d = new Disciple({ id: 42 });
+    initializeDisciple(d);
+    expect(d.health).to.equal(10);
+    expect(d.stamina).to.equal(10);
+    expect(d.inventorySlots).to.equal(10);
+    expect(d.currentHp).to.equal(d.maxHp);
+  });
+});

--- a/utils/discipleInit.js
+++ b/utils/discipleInit.js
@@ -1,0 +1,23 @@
+import Disciple from '../disciple.js';
+
+export function initializeDisciple(d) {
+  if (!d) return d;
+  if (d.health === undefined) d.health = 10;
+  if (d.stamina === undefined) d.stamina = 10;
+  if (d.hunger === undefined) d.hunger = 20;
+  if (d.power === undefined) d.power = 1;
+  if (d.strength === undefined) d.strength = 1;
+  if (d.dexterity === undefined) d.dexterity = 1;
+  if (d.endurance === undefined) d.endurance = 1;
+  if (d.intelligence === undefined) d.intelligence = 1;
+  if (d.incapacitated === undefined) d.incapacitated = false;
+  if (!d.name) d.name = `Disciple ${d.id}`;
+  if (d.inventorySlots === undefined) d.inventorySlots = 10;
+  if (!d.inventory) d.inventory = {};
+  if (d.combatLevel === undefined) d.combatLevel = 1;
+  if (d.maxHp === undefined) d.maxHp = 10;
+  if (d.currentHp === undefined) d.currentHp = d.maxHp;
+  Object.setPrototypeOf(d, Disciple.prototype);
+  if (typeof d.updateCombatStats === 'function') d.updateCombatStats();
+  return d;
+}


### PR DESCRIPTION
## Summary
- ensure new disciples start with valid defaults
- call `initializeDisciple` when loading saves and when recruiting
- add simple disciple initialization test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687036163cb08326883d1084c2272159