### PR TITLE
Improve disciple UI updates

### DIFF
--- a/disciple.js
+++ b/disciple.js
@@ -1,5 +1,6 @@
 import { generateDiscipleAttributes } from './discipleAttributes.js';
 import { xpRequirement } from './utils/xp.js';
+import { runAnimation } from './utils/animation.js';
 
 export default class Disciple {
   constructor({ id = 0, name = `Disciple ${id}`, maxHp = 10, combatLevel = 1, attributes = generateDiscipleAttributes() } = {}) {
@@ -23,11 +24,15 @@ export default class Disciple {
   }
 
   gainCombatXp(amount) {
+    const before = this.combatLevel;
     this.combatXp += amount;
     while (this.combatXp >= this.xpForNextLevel()) {
       this.combatXp -= this.xpForNextLevel();
       this.combatLevel += 1;
       this.updateCombatStats();
+    }
+    if (this.combatLevel > before && this.cardElement) {
+      runAnimation(this.cardElement, 'levelup-animate');
     }
   }
 

--- a/script.js
+++ b/script.js
@@ -275,6 +275,7 @@ function awardAttributePoints(d, group) {
     }
     d[target] += 1;
   }
+  if (d.cardElement) runAnimation(d.cardElement, 'levelup-animate');
 }
 
 function addSkillXp(d, group, amount) {
@@ -289,6 +290,7 @@ function addSkillXp(d, group, amount) {
       d.globalLevel = newLevel;
       awardAttributePoints(d, group);
     }
+    if (d.cardElement) runAnimation(d.cardElement, 'levelup-animate');
   }
 }
 
@@ -315,6 +317,17 @@ function getTaskSkillProgress(xp) {
   }
   const progress = (xp - total) / next;
   return { level, progress, next };
+}
+
+function computeGlobalSkillLevel(id) {
+  ensureDiscipleSkills(id);
+  const skills = sectState.discipleSkills[id];
+  let max = 0;
+  for (const xp of Object.values(skills)) {
+    const lvl = getTaskSkillProgress(xp).level;
+    if (lvl > max) max = lvl;
+  }
+  return max;
 }
 
 function makeBar(value, max, color) {
@@ -444,6 +457,8 @@ function createDiscipleCard(d) {
   actions.append(assign, statsBtn, feedBtn);
   card.appendChild(actions);
   d.gLevelLabel = gLevel;
+  d.etaLabel = eta;
+  d.cardElement = card;
   return card;
 }
 
@@ -696,6 +711,7 @@ let enemyAttackFill = null;
 let discipleAttackTimers = {}; // map disciple id -> elapsed attack time
 let enemyAttackProgress = 0; // carryover ratio of enemy attack timer
 let worldProgressTimer = 0;
+let discipleEtaTimer = 0;
 //let sanityTimer = 0;
 const worldProgressRateTracker = new RateTracker(30000);
 // Chance to trigger a random event each step of movement
@@ -1464,6 +1480,11 @@ function tickSect(delta) {
     }
   });
   updateTaskProgressDisplay();
+  discipleEtaTimer += delta;
+  if (discipleEtaTimer >= 1000) {
+    updateSectCardInfo();
+    discipleEtaTimer = 0;
+  }
   tickBuilding(dt);
 }
 
@@ -3636,6 +3657,22 @@ function updateHandDisplay() {
     }
     updateDiscipleStatsDisplay(d);
     updateBloodSplat(d);
+  });
+}
+
+function updateSectCardInfo() {
+  speechState.disciples.forEach(d => {
+    if (d.etaLabel) {
+      d.etaLabel.textContent = `ETA: ${formatTime(getTaskEta(d))}`;
+    }
+    const lvl = computeGlobalSkillLevel(d.id);
+    if (lvl > d.globalLevel) {
+      d.globalLevel = lvl;
+      if (d.gLevelLabel) d.gLevelLabel.textContent = `Skill ${d.globalLevel}`;
+      if (d.cardElement) runAnimation(d.cardElement, 'levelup-animate');
+    } else if (d.gLevelLabel) {
+      d.gLevelLabel.textContent = `Skill ${d.globalLevel}`;
+    }
   });
 }
 

--- a/style.css
+++ b/style.css
@@ -4251,7 +4251,8 @@ body.darkenshift-mode .tabsContainer button.active {
     font-size: 0.75rem;
 }
 .vital-bar {
-    flex: 1;
+    width: 100px;
+    flex: 0 0 100px;
 }
 .attribute-table {
     width: 100%;


### PR DESCRIPTION
## Summary
- give vital stats bars fixed widths
- track disciples' highest skill level and update cards
- animate disciple cards on level-up and attribute gain
- refresh disciple ETA every second

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6870479f2b388326be5f927fb0e81232