### PR TITLE
Fix disciple attribute application

### DIFF
--- a/script.js
+++ b/script.js
@@ -275,6 +275,7 @@ function awardAttributePoints(d, group) {
     }
     d[target] += 1;
   }
+  if (typeof d.updateCombatStats === 'function') d.updateCombatStats();
   if (d.cardElement) runAnimation(d.cardElement, 'levelup-animate');
 }
 

--- a/test/disciple.attribute.effects.test.cjs
+++ b/test/disciple.attribute.effects.test.cjs
@@ -1,0 +1,16 @@
+const { expect } = require('chai');
+const Disciple = require('../disciple.js').default;
+
+describe('⚔️ Disciple attribute effects', () => {
+  it('applies strength, dexterity and endurance to combat stats', () => {
+    const d = new Disciple({ id: 1 });
+    d.strength = 4;
+    d.dexterity = 6;
+    d.endurance = 3;
+    d.combatLevel = 5;
+    d.updateCombatStats();
+    expect(d.damage).to.equal(d.combatLevel * 3 * (1 + 0.05 * d.strength));
+    expect(d.attackSpeed).to.equal(10000 / (1 + 0.05 * d.dexterity));
+    expect(d.defense).to.equal((1 + 0.05 * d.endurance) * d.combatLevel);
+  });
+});

--- a/utils/discipleInit.js
+++ b/utils/discipleInit.js
@@ -10,6 +10,8 @@ export function initializeDisciple(d) {
   if (d.dexterity === undefined) d.dexterity = 1;
   if (d.endurance === undefined) d.endurance = 1;
   if (d.intelligence === undefined) d.intelligence = 1;
+  if (d.globalLevel === undefined) d.globalLevel = 0;
+  if (d.combatXp === undefined) d.combatXp = 0;
   if (d.baseStrength === undefined) d.baseStrength = d.strength;
   if (d.baseDexterity === undefined) d.baseDexterity = d.dexterity;
   if (d.baseEndurance === undefined) d.baseEndurance = d.endurance;


### PR DESCRIPTION
## Summary
- initialise `globalLevel` and `combatXp` for disciples
- refresh combat stats when disciples gain attribute points
- add tests verifying disciple combat stats respond to attributes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68704f7458008326b9408cc9a4d9b87c