### PR TITLE
Fix exploration unlock

### DIFF
--- a/script.js
+++ b/script.js
@@ -2007,6 +2007,8 @@ function renderColonyResearchPanel() {
         addLog('Research complete: Foreseers', 'good');
         unlockConstruct('Sonic Boom');
         renderColonyResearchPanel();
+        if (typeof renderColonyTasks === 'function') renderColonyTasks();
+        if (typeof renderColonyInfo === 'function') renderColonyInfo();
       }
     });
     colonyResearchPanel.appendChild(btn);
@@ -4400,7 +4402,8 @@ Object.entries(upgrades).map(([k, u]) => [k, u.unlocked])
       buildingUnlocked: systems.buildingUnlocked,
       researchUnlocked: systems.researchUnlocked,
       chantingHallUnlocked: systems.chantingHallUnlocked,
-      voiceOfThePeople: systems.voiceOfThePeople
+      voiceOfThePeople: systems.voiceOfThePeople,
+      explorationUnlocked: systems.explorationUnlocked
     }
   };
 


### PR DESCRIPTION
## Summary
- update task list after completing Foreseers research
- persist exploration unlock in save data

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68705bd2b34c8326bd09c0f892bca56a