### PR TITLE
Implement disciple overlay tab memory

### DIFF
--- a/disciple.js
+++ b/disciple.js
@@ -16,6 +16,7 @@ export default class Disciple {
     this.endurance = attributes.endurance || 0;
     this.intelligence = attributes.intelligence || 0;
     this.defense = 1;
+    this.lastTab = 'general';
     this.updateCombatStats();
   }
 

--- a/script.js
+++ b/script.js
@@ -2386,8 +2386,13 @@ function renderSectDiscipleList() {
 
 let discipleOverlay = null;
 let discipleOverlayData = { disciple: null, bars: null };
+let discipleOverlayActiveTab = 'general';
 function openDiscipleOverlay(d) {
-  if (discipleOverlay) discipleOverlay.close();
+  if (discipleOverlay) {
+    discipleOverlay.close();
+  } else {
+    discipleOverlayActiveTab = d.lastTab || 'general';
+  }
   discipleOverlay = createOverlay({ className: 'disciple-overlay' });
   const { box } = discipleOverlay;
 
@@ -2410,7 +2415,7 @@ function openDiscipleOverlay(d) {
     { key: 'inventory', label: 'Inventory' },
     { key: 'gear', label: 'Gear' }
   ];
-  let active = 'general';
+  let active = discipleOverlayActiveTab;
   function render() {
     content.innerHTML = '';
     discipleOverlayData.bars = null;
@@ -2460,6 +2465,7 @@ function openDiscipleOverlay(d) {
     if (def.key === active) btn.classList.add('active');
     btn.addEventListener('click', () => {
       active = def.key;
+      discipleOverlayActiveTab = def.key;
       tabs.querySelectorAll('button').forEach(b => b.classList.toggle('active', b === btn));
       render();
     });
@@ -2468,6 +2474,9 @@ function openDiscipleOverlay(d) {
   discipleOverlayData.disciple = d;
   render();
   discipleOverlay.onClose(() => {
+    if (discipleOverlayData.disciple) {
+      discipleOverlayData.disciple.lastTab = discipleOverlayActiveTab;
+    }
     discipleOverlayData.disciple = null;
     discipleOverlayData.bars = null;
   });

--- a/utils/discipleInit.js
+++ b/utils/discipleInit.js
@@ -23,6 +23,7 @@ export function initializeDisciple(d) {
   if (d.combatLevel === undefined) d.combatLevel = 1;
   if (d.maxHp === undefined) d.maxHp = 10;
   if (d.currentHp === undefined) d.currentHp = d.maxHp;
+  if (d.lastTab === undefined) d.lastTab = 'general';
   Object.setPrototypeOf(d, Disciple.prototype);
   if (typeof d.updateCombatStats === 'function') d.updateCombatStats();
   return d;


### PR DESCRIPTION
## Summary
- store `lastTab` property on Disciple instances
- initialise `lastTab` when disciples are created
- keep track of active tab in disciple overlay and restore it when reopened

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68705d770e908326a917787662019daf