### PR TITLE
Fix disciple global level on save load

### DIFF
--- a/script.js
+++ b/script.js
@@ -4509,6 +4509,14 @@ Object.assign(playerStats, state.playerStats || {});
     sectState.researchProgress = 0; // progress is not persisted
   }
 
+  // synchronize disciple global levels with saved skill data
+  if (Array.isArray(speechState.disciples)) {
+    speechState.disciples.forEach(d => {
+      const lvl = computeGlobalSkillLevel(d.id);
+      if (lvl > d.globalLevel) d.globalLevel = lvl;
+    });
+  }
+
   if (state.sectTabUnlocked ||
       (speechState.disciples && speechState.disciples.length > 0)) {
     sectTabUnlocked = true;


### PR DESCRIPTION
## Summary
- sync disciple `globalLevel` with saved skill data during load

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68705dc7e6c08326ab2c8b429d8321dd