### PR TITLE
Handle corrupted game saves

### DIFF
--- a/script.js
+++ b/script.js
@@ -49,6 +49,7 @@ import {
 } from './attributes.js';
 import { createOverlay } from './ui/overlay.js';
 import { showRestartScreen } from './ui/restartOverlay.js';
+import { showLoadErrorOverlay } from './ui/loadErrorOverlay.js';
 import { calculateKillXp, XP_EFFICIENCY } from './utils/xp.js';
 import {
   calculateMaxStamina,
@@ -4690,8 +4691,12 @@ updateUpgradeButtons();
 addLog("Game loaded!",
 "info");
 } catch (e) {
-console.error("Load failed",
-e);
+  console.error("Load failed", e);
+  if (typeof showLoadErrorOverlay === 'function') {
+    showLoadErrorOverlay(e, startNewGame);
+  } else {
+    startNewGame();
+  }
 }
 }
 

--- a/style.css
+++ b/style.css
@@ -1943,6 +1943,21 @@ body.darkenshift-mode .tabsContainer button.active {
     border-radius: 4px;
 }
 
+.load-error-overlay {
+    flex-direction: column;
+    text-align: center;
+}
+
+.load-error-message {
+    font-size: 1rem;
+    margin-bottom: 0.5rem;
+}
+
+.reset-save-button {
+    padding: 6px 16px;
+    font-size: 1rem;
+}
+
 .restart-art {
     width: 80px;
     height: 60px;

--- a/ui/loadErrorOverlay.js
+++ b/ui/loadErrorOverlay.js
@@ -1,0 +1,29 @@
+import { createOverlay } from './overlay.js';
+
+export function showLoadErrorOverlay(error, onReset) {
+  const overlay = createOverlay({ className: 'load-error-overlay' });
+  const { box } = overlay;
+
+  const msg = document.createElement('div');
+  msg.className = 'load-error-message';
+  msg.textContent = 'Failed to load saved data. It may be corrupted.';
+  box.appendChild(msg);
+
+  if (error && error.message) {
+    const detail = document.createElement('pre');
+    detail.className = 'load-error-detail';
+    detail.textContent = error.message;
+    box.appendChild(detail);
+  }
+
+  const btn = document.createElement('button');
+  btn.className = 'reset-save-button';
+  btn.textContent = 'Reset Save';
+  btn.addEventListener('click', () => {
+    if (onReset) onReset();
+    overlay.close();
+  });
+  box.appendChild(btn);
+
+  return overlay;
+}


### PR DESCRIPTION
## Summary
- add overlay to inform players when loading save data fails
- show overlay with Reset Save button during JSON parse failure
- style load-error overlay

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_687138a4944083268f875b128a7dd540