### PR TITLE
Align disciple generation with recruitment docs

### DIFF
--- a/disciple.js
+++ b/disciple.js
@@ -15,6 +15,7 @@ export default class Disciple {
     this.dexterity = attributes.dexterity || 0;
     this.endurance = attributes.endurance || 0;
     this.intelligence = attributes.intelligence || 0;
+    this.charisma = attributes.charisma || 0;
     this.defense = 1;
     this.lastTab = 'general';
     this.updateCombatStats();

--- a/discipleAttributes.js
+++ b/discipleAttributes.js
@@ -1,18 +1,13 @@
 export function generateDiscipleAttributes() {
-  const attrs = ['strength', 'dexterity', 'endurance', 'intelligence'];
-  const result = { strength: 0, dexterity: 0, endurance: 0, intelligence: 0 };
-  const points = Math.floor(Math.random() * 3) + 3; // 3-5 total
+  const attrs = ['strength', 'dexterity', 'endurance', 'intelligence', 'charisma'];
+  const result = {};
+  attrs.forEach(a => {
+    result[a] = 3; // base value for each attribute
+  });
+  const points = 6; // extra points distributed randomly
   for (let i = 0; i < points; i++) {
-    const weights = attrs.map(a => 1 / Math.pow(result[a] + 1, 2));
-    const sum = weights.reduce((a, b) => a + b, 0);
-    let r = Math.random() * sum;
-    for (let j = 0; j < attrs.length; j++) {
-      r -= weights[j];
-      if (r <= 0) {
-        result[attrs[j]] += 1;
-        break;
-      }
-    }
+    const idx = Math.floor(Math.random() * attrs.length);
+    result[attrs[idx]] += 1;
   }
   return result;
 }

--- a/script.js
+++ b/script.js
@@ -108,6 +108,7 @@ let drawnCards = [];
 // Active disciples engaged in combat
 let activeDisciples = [];
 // Available disciples under the player's control
+// Start with three disciples as outlined in the recruitment docs
 let disciples = [new Disciple({ id: 1 }), new Disciple({ id: 2 }), new Disciple({ id: 3 })];
 disciples.forEach(initializeDisciple);
 // Functions to manage which disciples are active in combat

--- a/test/disciple.distribution.test.cjs
+++ b/test/disciple.distribution.test.cjs
@@ -2,26 +2,36 @@ const { expect } = require('chai');
 const { generateDiscipleAttributes } = require('../discipleAttributes.js');
 
 describe('🧍 Disciple attribute distribution', () => {
-  it('allocates between 3 and 5 points total', () => {
-    for (let i = 0; i < 50; i++) {
+  it('starts with base attributes of 3 and distributes 6 extra points', () => {
+    for (let i = 0; i < 10; i++) {
       const dist = generateDiscipleAttributes();
       const total =
-        dist.strength + dist.dexterity + dist.endurance + dist.intelligence;
-      expect(total).to.be.at.least(3).and.at.most(5);
+        dist.strength +
+        dist.dexterity +
+        dist.endurance +
+        dist.intelligence +
+        dist.charisma;
+      expect(total).to.equal(21);
+      Object.values(dist).forEach(v => expect(v).to.be.at.least(3));
     }
   });
 
-  it('rarely gives 3 points in one stat', () => {
-    let triples = 0;
-    const runs = 500;
-    for (let i = 0; i < runs; i++) {
-      const d = generateDiscipleAttributes();
+  it('adds random points beyond the base', () => {
+    const first = generateDiscipleAttributes();
+    let varied = false;
+    for (let i = 0; i < 20; i++) {
+      const next = generateDiscipleAttributes();
       if (
-        Math.max(d.strength, d.dexterity, d.endurance, d.intelligence) >= 3
+        next.strength !== first.strength ||
+        next.dexterity !== first.dexterity ||
+        next.endurance !== first.endurance ||
+        next.intelligence !== first.intelligence ||
+        next.charisma !== first.charisma
       ) {
-        triples++;
+        varied = true;
+        break;
       }
     }
-    expect(triples).to.be.below(runs * 0.1);
+    expect(varied).to.equal(true);
   });
 });

--- a/utils/discipleInit.js
+++ b/utils/discipleInit.js
@@ -10,12 +10,14 @@ export function initializeDisciple(d) {
   if (d.dexterity === undefined) d.dexterity = 1;
   if (d.endurance === undefined) d.endurance = 1;
   if (d.intelligence === undefined) d.intelligence = 1;
+  if (d.charisma === undefined) d.charisma = 1;
   if (d.globalLevel === undefined) d.globalLevel = 0;
   if (d.combatXp === undefined) d.combatXp = 0;
   if (d.baseStrength === undefined) d.baseStrength = d.strength;
   if (d.baseDexterity === undefined) d.baseDexterity = d.dexterity;
   if (d.baseEndurance === undefined) d.baseEndurance = d.endurance;
   if (d.baseIntelligence === undefined) d.baseIntelligence = d.intelligence;
+  if (d.baseCharisma === undefined) d.baseCharisma = d.charisma;
   if (d.incapacitated === undefined) d.incapacitated = false;
   if (!d.name) d.name = `Disciple ${d.id}`;
   if (d.inventorySlots === undefined) d.inventorySlots = 10;


### PR DESCRIPTION
## Summary
- generate disciples with base attributes of 3 and distribute 6 random points
- store charisma attribute on disciples and ensure it has defaults
- document start of three disciples in script
- update disciple attribute tests for new generation logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6876c57f63c08326b6e068edb172b122