### PR TITLE
Fix attributes docs typos

### DIFF
--- a/docs/19-attributes.md
+++ b/docs/19-attributes.md
@@ -76,7 +76,7 @@ Determines initial learning speed
 
 
 
-Afects chanting and researching
+Affects chanting and researching
 
 
 


### PR DESCRIPTION
## Summary
- rename `docs/22-attributes.md` to `docs/19-attributes.md`
- correct 'Afects' typo in the attributes documentation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6876c9fb2a2c8326a9d4d7c6d6a96656