### PR TITLE
Rename Qi to Water

### DIFF
--- a/core.js
+++ b/core.js
@@ -1,4 +1,4 @@
-import { speechState, renderXpBar, openQiRegenPopup } from './speech.js';
+import { speechState, renderXpBar, openWaterRegenPopup } from './speech.js';
 
 export const coreState = {
   coreLevel: 1,
@@ -42,15 +42,15 @@ const bodyPath = `M200 140
     <svg id="coreDiagram" viewBox="0 0 400 400" width="100%" height="100%">
       <defs>
         <clipPath id="bodyShapeClip"><path d="${bodyPath}" /></clipPath>
-        <clipPath id="qiClip"><circle cx="200" cy="80" r="20" /></clipPath>
+        <clipPath id="waterClip"><circle cx="200" cy="80" r="20" /></clipPath>
       </defs>
       <path d="${bodyPath}" fill="rgba(0,0,0,0.3)" stroke="#888" stroke-width="2" />
       <circle id="coreHalo" cx="200" cy="180" r="70" fill="none" stroke="gold" stroke-width="4" opacity="0" />
       <rect id="bodyFill" x="170" y="240" width="60" height="0" fill="rgba(255,255,255,0.4)" clip-path="url(#bodyShapeClip)" />
       <circle cx="200" cy="80" r="20" fill="rgba(127,217,255,0.3)" />
-      <rect id="qiFill" x="180" y="100" width="40" height="0" fill="rgba(127,217,255,0.6)" clip-path="url(#qiClip)" />
-      <circle id="qiOrb" cx="200" cy="80" r="20" fill="none" stroke="#7fd9ff" stroke-width="2" />
-      <text id="qiText" x="200" y="115" text-anchor="middle" class="orb-text"></text>
+      <rect id="waterFill" x="180" y="100" width="40" height="0" fill="rgba(127,217,255,0.6)" clip-path="url(#waterClip)" />
+      <circle id="waterOrb" cx="200" cy="80" r="20" fill="none" stroke="#7fd9ff" stroke-width="2" />
+      <text id="waterText" x="200" y="115" text-anchor="middle" class="orb-text"></text>
       <text id="coreProgressText" x="200" y="260" text-anchor="middle" class="orb-text"></text>
     </svg>
   `;
@@ -58,14 +58,14 @@ const bodyPath = `M200 140
   levelDisplay = container.querySelector('#coreLevelText');
   progressText = container.querySelector("#coreProgressText");
   window.addEventListener('orbs-changed', renderCore);
-  const qiOrb = container.querySelector('#qiOrb');
-  if (qiOrb) {
-    qiOrb.addEventListener('mouseenter', e => {
-      const orb = speechState.orbs.qi;
-      window.showTooltip(`Qi: ${Math.floor(orb.current)}/${orb.max}`, e.pageX + 10, e.pageY + 10);
+  const waterOrb = container.querySelector('#waterOrb');
+  if (waterOrb) {
+    waterOrb.addEventListener('mouseenter', e => {
+      const orb = speechState.orbs.water;
+      window.showTooltip(`Water: ${Math.floor(orb.current)}/${orb.max}`, e.pageX + 10, e.pageY + 10);
     });
-    qiOrb.addEventListener('mouseleave', window.hideTooltip);
-    qiOrb.addEventListener('click', openQiRegenPopup);
+    waterOrb.addEventListener('mouseleave', window.hideTooltip);
+    waterOrb.addEventListener('click', openWaterRegenPopup);
   }
   meditateBtn.addEventListener('click', toggleMeditation);
   meditateBtn.addEventListener('mouseenter', e => {
@@ -108,14 +108,14 @@ function breakthrough() {
   coreState.coreLevel += 1;
   coreState.meditationProgress = 0;
   // requirement could scale later; keep constant for now
-  speechState.orbs.qi.current = 0;
+  speechState.orbs.water.current = 0;
   meditateBtn.textContent = 'Meditate Core';
   renderCore();
 }
 
 function renderCore() {
   if (!container) return;
-  const qiFill = Math.min(1, speechState.orbs.qi.current / speechState.orbs.qi.max);
+  const waterFill = Math.min(1, speechState.orbs.water.current / speechState.orbs.water.max);
   const bodyFill = 0;
   const willFill = 0;
 
@@ -130,23 +130,23 @@ function renderCore() {
     rect.setAttribute('height', h);
   };
 
-  updateRect('#qiFill', 200, 80, 20, qiFill);
+  updateRect('#waterFill', 200, 80, 20, waterFill);
   updateRect('#bodyFill', 200, 180, 60, coreFill);
 
-  const qiOrbEl = container.querySelector('#qiOrb');
-  if (qiOrbEl) qiOrbEl.setAttribute('stroke', qiFill >= 1 ? '#7fafff' : '#7fd9ff');
+  const waterOrbEl = container.querySelector('#waterOrb');
+  if (waterOrbEl) waterOrbEl.setAttribute('stroke', waterFill >= 1 ? '#7fafff' : '#7fd9ff');
   const bodyOrb = null;
   const willOrb = null;
 
-  const qiText = container.querySelector('#qiText');
-  if (qiText) qiText.textContent = `${Math.floor(speechState.orbs.qi.current)}/${speechState.orbs.qi.max}`;
+  const waterText = container.querySelector('#waterText');
+  if (waterText) waterText.textContent = `${Math.floor(speechState.orbs.water.current)}/${speechState.orbs.water.max}`;
   const bodyText = null;
   const willText = null;
   const progressText = container.querySelector('#coreProgressText');
   if (progressText) progressText.textContent = `${Math.floor(coreState.meditationProgress)}/${coreState.requirement}`;
   levelDisplay.textContent = `Core Level: ${coreState.coreLevel}`;
   if (voiceLevelEl) voiceLevelEl.textContent = speechState.level;
-  if (mindValEl) mindValEl.textContent = `${Math.floor(speechState.orbs.qi.current)}/${speechState.orbs.qi.max}`;
+  if (mindValEl) mindValEl.textContent = `${Math.floor(speechState.orbs.water.current)}/${speechState.orbs.water.max}`;
   if (coreState.meditationProgress >= coreState.requirement) {
     meditateBtn.textContent = 'Breakthrough';
   } else {

--- a/docs/00-wireframes.md
+++ b/docs/00-wireframes.md
@@ -20,8 +20,8 @@
 │                      │  │      workshops…)      │        │                                   │
 │                      │  └───────────────────────┘        │                                   │
 │                      │                                   │                                   │
-│                      │        [   Qi Orb: 3.34 Qi/s   ]  │                                   │
-│                      │        (current Qi rate here)    │                                   │
+│                      │        [   Water Orb: 3.34 Water/s   ]  │                                   │
+│                      │        (current Water rate here)    │                                   │
 │                      │                                   │                                   │
 │                      │  ┌───────────────────────┐        │                                   │
 │                      │  │  Storage / Items      │        │                                   │
@@ -73,7 +73,7 @@ Research Zone (lower-right)
 
 Center
 
-Qi Orb widget showing current Qi per second.
+Water Orb widget showing current Water per second.
 
 
 Footer
@@ -87,7 +87,7 @@ Footer
 │ ○ General  ○ Proficiency  ○ Constructs  ○ Moodlets  ○ Stats │
 ├────────────────────────────────────────────────────┤
 │ [Portrait]     Li Xuan            Path: Ember 🔥       │
-│ Core Stage: Qi Shaping       │
+│ Core Stage: Water Shaping       │
 ├────────────────────────────────────────────────────┤
 │ **Attributes**                                  │
 │ DEX: 8   (effect description)                     │
@@ -116,7 +116,7 @@ Footer
 ├────────────────────────────────────────────────────┤
 │ sort by [school, passive, spell]
   **learned Constructs**                          │
-│ [spell: fireball]   [passive:max Qi upgrade]       │
+│ [spell: fireball]   [passive:max Water upgrade]       │
 │                                                  │
 │
 └────────────────────────────────────────────────────┘
@@ -143,7 +143,7 @@ Footer
 │ • Chanting Multiplier: 1.20×                      │
 │ • Learning Speed: 1.5×                            │
 │ • Exploration Speed: 0.8×                         │
-│ • Qi Regen Rate: 3.34 Qi/s                        │
+│ • Water Regen Rate: 3.34 Water/s                        │
 │ • Health: 80 / 100                                │
 │ • Defense: 15                                    │
 └────────────────────────────────────────────────────┘

--- a/docs/08-ornaments.md
+++ b/docs/08-ornaments.md
@@ -2,7 +2,7 @@
 
 **Sunday, July 13, 2025 • 5:13 PM**
 
-| Name               | Element | Tier | Qi Regen | Source              | Materials Needed                            |
+| Name               | Element | Tier | Water Regen | Source              | Materials Needed                            |
 |--------------------|:-------:|:----:|---------:|---------------------|---------------------------------------------|
 | Sunflame Brazier   | Fire    | 1    | +3       | Ash Warden (Dungeon)| 1 × Brazen Core, 2 × Dry Bark, 1 × Charcoal   |
 | Woodbound Totem    | Wood    | 1    | +3       | Ancient Grove (60%) | 2 × Polished Bark, 1 × Phoenix Wood, 1 × Sticky Resin |

--- a/docs/11-needs.md
+++ b/docs/11-needs.md
@@ -6,7 +6,7 @@
 - Starts at 100; drains at 0.383/s.
 - < 30 → hungry; seeks food.
 - < 20 → –50% sect happiness.
-- < 10 → disables activities; moves to Qi Orb.
+- < 10 → disables activities; moves to Water Orb.
 
 ### Stamina
 - Max 100; regenerates in 1 day.

--- a/docs/12-buildings.md
+++ b/docs/12-buildings.md
@@ -19,12 +19,12 @@ Utility Buildings
 
 Building	Cost (Materials)	Effect	Unlock
 
-Qi Fonts	Stone: 30 × (1.3^lvl)	+10% global Qi generation per level	Start
+Water Fonts	Stone: 30 × (1.3^lvl)	+10% global Water generation per level	Start
 Granary	Softwood: 50 × (1.2^lvl)	+400 food storage capacity	Farming research
 Storage	Softwood & Stone: 30 × (1.3^lvl) each	+100 wood cap, +200 stone cap per level	Granary Lv1
-Celestial Sanctum	Any: 200 × (1.4^lvl)	Unlocks Cultivation Rooms; +4% areaQi, +3% cult speed per level	Research Tree Lv5
+Celestial Sanctum	Any: 200 × (1.4^lvl)	Unlocks Cultivation Rooms; +4% areaWater, +3% cult speed per level	Research Tree Lv5
 Training Dummy	Softwood: 10	Foundation training station; +2× foundation XP	Start
-Research Table	Softwood: 30 × (lvl^1.3)	Convert 4% global Qi → Insight per level	Chanting research
+Research Table	Softwood: 30 × (lvl^1.3)	Convert 4% global Water → Insight per level	Chanting research
 Library	Wood: 200 × (lvl^1.1); Stone: 100 × (lvl^1.1)	Unlock learning/spell teaching; +4% teaching rate per level	Research Table Lv1
 Jadefire Pavilion	Softwood & Stone: 20 × (1.1^lvl) each	Enables Transmutation; +3% spell potency per level	Transmutation research
 Chanting Halls	Wood: 300 × (1.15^lvl)	–4% chant cooldown per level; +1 chanter per 3 levels	Library Lv2
@@ -34,14 +34,14 @@ Ornaments / Cultivation Enhancers
 
 Ornaments can be placed in Cultivation Rooms for elemental buffs (fengshui effects).
 
-Ornament	Element	Tier	Qi Regen	Source / Unlock
+Ornament	Element	Tier	Water Regen	Source / Unlock
 
-Ceremonious Monastery	—	1	+5 Qi/s	Celestial Sanctum unlocked
+Ceremonious Monastery	—	1	+5 Water/s	Celestial Sanctum unlocked
 Furnace	Fire	1	—	Transmutation research
-Woodbound Totem	Wood	1	+3 Qi/s	Exploration milestone / Blueprint
-Soulglass Gong	Metal	1	+3 Qi/s	Dungeon drop (Ironshade Vault)
-Moondrip Basin	Water	1	+3 Qi/s	Dungeon drop (Frozen Grotto)
-Sunflame Brazier	Fire	1	+3 Qi/s	Dungeon drop (Molten Vault)
+Woodbound Totem	Wood	1	+3 Water/s	Exploration milestone / Blueprint
+Soulglass Gong	Metal	1	+3 Water/s	Dungeon drop (Ironshade Vault)
+Moondrip Basin	Water	1	+3 Water/s	Dungeon drop (Frozen Grotto)
+Sunflame Brazier	Fire	1	+3 Water/s	Dungeon drop (Molten Vault)
 
 
 Spell Schools & Tags
@@ -90,6 +90,6 @@ Chanting Management
 
 After Chanting Halls unlocks, assign idle disciples to chant.
 
-UI shows available disciples and their chant rate (Qi/s).
+UI shows available disciples and their chant rate (Water/s).
 
 Unassigned chanters free up to perform other tasks.

--- a/docs/13-cultivation-stages-&-methods.md
+++ b/docs/13-cultivation-stages-&-methods.md
@@ -21,7 +21,7 @@ Cultivation Stages
 1. Foundation
 
 
-2. Qi Shaping
+2. Water Shaping
 
 
 3. Core Shaping

--- a/docs/15-research.md
+++ b/docs/15-research.md
@@ -45,9 +45,9 @@ Unlocks creation of Elemental Cores (Brazen, Earthen, Aquatic, etc.).
 
 15.2 Cultivation Tree
 
-Qi Fonts
+Water Fonts
 
-Unlocks the Qi Fonts building, granting flat global Qi generation and a minor increase to Max Qi.
+Unlocks the Water Fonts building, granting flat global Water generation and a minor increase to Max Water.
 
 
 Chanting Halls

--- a/docs/16-qi-orb.md
+++ b/docs/16-qi-orb.md
@@ -1,8 +1,0 @@
-# 17 – Qi Orb Mechanics
-
-**Saturday, July 12, 2025 • 3:07 PM**
-
-- Central map Qi Orb gathers Qi from disciples (1 Qi/s each when not incapacitated).
-- Low‑food disciples divert to orb to replenish (+0.383 food/s) at cost of Qi input.
-- Orb distributes Qi as global energy; buildings can boost its output.
-- Immortals can direct % of personal Qi to orb.

--- a/docs/16-water-orb.md
+++ b/docs/16-water-orb.md
@@ -1,0 +1,8 @@
+# 17 – Water Orb Mechanics
+
+**Saturday, July 12, 2025 • 3:07 PM**
+
+- Central map Water Orb gathers Water from disciples (1 Water/s each when not incapacitated).
+- Low‑food disciples divert to orb to replenish (+0.383 food/s) at cost of Water input.
+- Orb distributes Water as global energy; buildings can boost its output.
+- Immortals can direct % of personal Water to orb.

--- a/docs/17-paths.md
+++ b/docs/17-paths.md
@@ -9,7 +9,7 @@ Each disciple chooses one Path after completing Foundation. Paths define their e
 
 Path	Element	Archetype	Focus
 
-Path of the Ember	Fire (火)	Mage	Combat Spells, Qi generation, culture speed
+Path of the Ember	Fire (火)	Mage	Combat Spells, Water generation, culture speed
 Path of the Emerald	Wood (木)	Ranger	Travel speed, gathering, stat boosts
 Path of the Azure Saint	Water (水)	Healer	Healing, crowd control, weather control
 Path of the Searing Shield	Fire (火)	Tank	Defense, resilience, frontline combat
@@ -24,7 +24,7 @@ After Foundation, disciples may choose any advanced Path:
 
 Path	Element	Archetype	Focus
 
-Path of the Ember	Fire (火)	Mage	Combat Spells, Qi generation, faster cultivation speed
+Path of the Ember	Fire (火)	Mage	Combat Spells, Water generation, faster cultivation speed
 Path of the Ruby Red Mage	Fire (火)	Mage	Offensive fire magic, area damage
 Path of the Thunder Thief	Fire (火)	Rogue	Lightning bursts, agility-based attacks
 Path of the Emerald Ranger	Wood (木)	Ranger	Marksmanship, tracking, resource gathering

--- a/docs/18-properties.md
+++ b/docs/18-properties.md
@@ -21,31 +21,31 @@ LearningSpeed = 0.5 + 0.15 × Intelligence
 
 ---
 
-21.2 Qi Regeneration (Qi/s)
+21.2 Water Regeneration (Water/s)
 
-Determines how much Qi the sect orb or a cultivator gains per second.
+Determines how much Water the sect orb or a cultivator gains per second.
 
-QiRegen = ([areaQi] × (4 + ElementStrength) × (0.5 + 0.05 × QiSense) / 320)
-        + (0.0002 × MaxQi)
-        + globalQi
+WaterRegen = ([areaWater] × (4 + ElementStrength) × (0.5 + 0.05 × WaterSense) / 320)
+        + (0.0002 × MaxWater)
+        + globalWater
 
 ElementStrength: +2 or –2 modifier based on elemental fengshui within the cultivation room.
 
-areaQi: Total ambient Qi from buildings, orb, relics, and dungeon factors.
+areaWater: Total ambient Water from buildings, orb, relics, and dungeon factors.
 
-QiSense: Cultivator’s Qi Sense skill level.
+WaterSense: Cultivator’s Water Sense skill level.
 
-globalQi: Flat Qi generation from sect-wide buffs (e.g. Qi Fonts levels).
+globalWater: Flat Water generation from sect-wide buffs (e.g. Water Fonts levels).
 
 
 
 ---
 
-21.3 Maximum Qi (MaxQi)
+21.3 Maximum Water (MaxWater)
 
 Formula:
 
-MaxQi = min(3 × QiSense + 10 × CeremoniousMonasteryLevel, 95)
+MaxWater = min(3 × WaterSense + 10 × CeremoniousMonasteryLevel, 95)
 
 CeremoniousMonasteryLevel: Each level adds +10 to the soft cap up to 95.
 

--- a/docs/19-attributes.md
+++ b/docs/19-attributes.md
@@ -68,7 +68,7 @@ Intelligence 🧙
 
 
 
-Affects Qi sense
+Affects Water sense
 
 
 
@@ -110,7 +110,7 @@ Determines maximium size of inner cauldron:
 
 Maximum size of Inner Cauldron = Innate Potential * 500 
 
-Min/Max of stat: 0.714 - 9.286 (Inner Cauldron size: 357 - 5143 Max Qi)
+Min/Max of stat: 0.714 - 9.286 (Inner Cauldron size: 357 - 5143 Max Water)
 
 
 

--- a/docs/20-skills.md
+++ b/docs/20-skills.md
@@ -5,11 +5,11 @@ Each skill has its own progression, yield formula, and spot data. Skills gain XP
 
 ---
 
-09.1 Qi Sense
+09.1 Water Sense
 
-Max Qi Bonus: +2.4% of base Max Qi per level
+Max Water Bonus: +2.4% of base Max Water per level
 
-Qi Absorption: +5% of max absorption rate per level
+Water Absorption: +5% of max absorption rate per level
 
 Cultivation Speed: +4% of base speed per level
 
@@ -47,7 +47,7 @@ Cooldown:
 
 Cooldown = 30 s × (1 - 0.04 × ChantingHallsLevel)
 
-Generation Value: Builds additional Qi/sec based on building level.
+Generation Value: Builds additional Water/sec based on building level.
 
 
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -51,7 +51,7 @@ Table of Contents
 15. Research Trees
 
 
-16. [Qi Orb Mechanics](16-qi-orb.md)
+16. [Water Orb Mechanics](16-water-orb.md)
 
 
 17. [Paths & Attribute Affinities](17-paths.md)

--- a/script.js
+++ b/script.js
@@ -30,7 +30,7 @@ import {
   createConstructCard,
   createConstructInfo,
   recipes,
-  openQiRegenPopup,
+  openWaterRegenPopup,
   unlockConstruct,
   renderConstructCards,
   renderHotbar
@@ -1437,8 +1437,8 @@ function tickSect(delta) {
         updateSectDisplay();
       }
     } else if (task === 'Research') {
-      const spend = Math.min(speechState.resources.qi.current, 4 * dt);
-      speechState.resources.qi.current -= spend;
+      const spend = Math.min(speechState.resources.water.current, 4 * dt);
+      speechState.resources.water.current -= spend;
       sectState.researchProgress += spend;
       if (sectState.researchProgress >= 500) {
         const xp = sectState.discipleSkills[d.id]?.['Researching'] || 0;
@@ -1474,8 +1474,8 @@ function tickSect(delta) {
           addSkillXp(d, 'Chanting', CHANT_XP_PER_CYCLE);
         }
       }
-      const spend = Math.min(speechState.resources.qi.current, dt);
-      speechState.resources.qi.current -= spend;
+      const spend = Math.min(speechState.resources.water.current, dt);
+      speechState.resources.water.current -= spend;
     } else if (task === 'Hunt') {
       if (!sectState.discipleProgress[d.id]) sectState.discipleProgress[d.id] = 0;
       sectState.discipleProgress[d.id] += dt;
@@ -1663,15 +1663,15 @@ function updateSectDisplay() {
     orbs.innerHTML = '';
     const mobile = window.innerWidth <= 600;
     const positions = mobile
-      ? [{ cls: 'qi', left: '50%', top: '10%' }]
-      : [{ cls: 'qi', left: '50%', top: '5%' }];
+      ? [{ cls: 'water', left: '50%', top: '10%' }]
+      : [{ cls: 'water', left: '50%', top: '5%' }];
     positions.forEach(p => {
       const orb = document.createElement('div');
       orb.className = `sect-orb ${p.cls}`;
       orb.style.left = p.left;
       orb.style.top = p.top;
-      if (p.cls === 'qi') {
-        orb.addEventListener('click', openQiRegenPopup);
+      if (p.cls === 'water') {
+        orb.addEventListener('click', openWaterRegenPopup);
       }
       orbs.appendChild(orb);
     });
@@ -1771,7 +1771,7 @@ function startDiscipleMovement() {
       const el = sectDiscipleEls[d.id];
       if (!el) return;
       if (d.incapacitated) {
-        const orb = document.querySelector('#sectOrbs .qi');
+        const orb = document.querySelector('#sectOrbs .water');
         if (orb) {
           const bx = orb.offsetLeft + orb.offsetWidth / 2 - 2;
           const by = orb.offsetTop + orb.offsetHeight / 2 - 2;
@@ -2037,7 +2037,7 @@ function renderColonyResearchPanel() {
   const time = rate > 0 ? ((500 - prog) / rate).toFixed(1) : '∞';
   const info = document.createElement('div');
   info.className = 'research-progress-info';
-  info.textContent = `Qi Rate: ${rate}/s | Next RP in ${time}s`;
+  info.textContent = `Water Rate: ${rate}/s | Next RP in ${time}s`;
   colonyResearchPanel.appendChild(info);
   if (!systems.chantingHallUnlocked) {
     const btn = document.createElement('button');
@@ -4540,18 +4540,18 @@ Object.assign(playerStats, state.playerStats || {});
       const { upgrades: savedUpgrades, ...restSpeech } = state.speechState;
       Object.assign(speechState, restSpeech);
       // ensure orbs exist for older saves
-      if (!speechState.orbs || !speechState.orbs.qi) {
-        const qi = speechState.resources?.qi || {};
+      if (!speechState.orbs || !speechState.orbs.water) {
+        const water = speechState.resources?.water || {};
         speechState.orbs = {
-          qi: {
-            current: qi.current || 0,
-            max: qi.max || 2000,
-            regen: qi.regen || 6
+          water: {
+            current: water.current || 0,
+            max: water.max || 2000,
+            regen: water.regen || 6
           }
         };
       }
-      // maintain reference between qi resource and orb
-      speechState.resources.qi = speechState.orbs.qi;
+      // maintain reference between water resource and orb
+      speechState.resources.water = speechState.orbs.water;
       if (speechState.weather && speechState.weather.days !== undefined) {
         speechState.weather.duration = speechState.weather.days;
         delete speechState.weather.days;
@@ -4712,7 +4712,7 @@ function gameLoop(currentTime) {
 const rawDelta = currentTime - lastFrameTime;
 lastFrameTime = currentTime;
 const deltaTime = rawDelta * timeScale;
-const startQi = speechState.resources.qi.current;
+const startWater = speechState.resources.water.current;
 
 if (currentEnemy) {
     currentEnemy.tick(deltaTime);
@@ -4782,9 +4782,9 @@ if (currentEnemy) {
   tickSect(deltaTime);
   updateDiscipleOverlayBars();
   const dtSeconds = deltaTime / 1000;
-  speechState.gains.qi =
+  speechState.gains.water =
     dtSeconds > 0
-      ? (speechState.resources.qi.current - startQi) / dtSeconds
+      ? (speechState.resources.water.current - startWater) / dtSeconds
       : 0;
   requestAnimationFrame(gameLoop);
 }

--- a/speech.js
+++ b/speech.js
@@ -8,16 +8,16 @@ import { createOverlay } from './ui/overlay.js';
 
 // Core state for the Constructs system. Orbs and upgrades from the
 // previous speech implementation remain intact.
-// Qi regeneration constants
-// Qi regen now scales with the Cohere upgrade using a saturating
+// Water regeneration constants
+// Water regen now scales with the Cohere upgrade using a saturating
 // logistic curve. This starts near zero and gradually approaches `R_MAX`
 // with diminishing returns as more Cohere levels are purchased. The curve
-// still tapers off as Qi accumulates.
+// still tapers off as Water accumulates.
 const R_MAX = 6;        // cap per-second regen
 const BASE_MIDPOINT = 1000;  // default inflection point
 const K = 150;          // controls steepness of taper
 
-function getQiMidpoint() {
+function getWaterMidpoint() {
   return systems.voiceOfThePeople ? 1500 : BASE_MIDPOINT;
 }
 
@@ -55,7 +55,7 @@ export function setSeasonBackdrop(season) {
 
 export const speechState = {
   orbs: {
-    qi: { current: 0, max: 2000, regen: R_MAX }
+    water: { current: 0, max: 2000, regen: R_MAX }
   },
   resources: {
     sound: { current: 0, max: 200, regen: 0, unlocked: true },
@@ -68,18 +68,18 @@ export const speechState = {
     waterEssence: { current: 0, max: 10, regen: 0, unlocked: false }
   },
   gains: {
-    qi: 0
+    water: 0
   },
   upgrades: {
-    // Cohere costs scale more steeply so high levels require larger qi
+    // Cohere costs scale more steeply so high levels require larger water
     // investment. This keeps Cohere from overwhelming Intone's impact.
     cohere: { level: 0, costFunc: lvl => Math.round(15 * Math.pow(1.2, lvl)) },
     vocalMaturity: { level: 0, baseCost: 2, unlocked: false },
-    capacityBoost: { level: 0, baseCost: { qi: 10 }, unlocked: false },
+    capacityBoost: { level: 0, baseCost: { water: 10 }, unlocked: false },
     expandMind: {
       level: 0,
       unlocked: true,
-      costFunc: lvl => ({ qi: 2 * Math.pow(lvl + 1, 2) })
+      costFunc: lvl => ({ water: 2 * Math.pow(lvl + 1, 2) })
     },
     soundExpansion: {
       level: 0,
@@ -113,7 +113,7 @@ export const speechState = {
   seasonDay: 0,
   seasonTimer: 0,
   weather: null,
-  qiRegenBase: 0,
+  waterRegenBase: 0,
   activeConstructs: [],
   savedConstructs: ['Murmur'],
   activeBuffs: {},
@@ -133,16 +133,16 @@ export const speechState = {
   murmurChain: 0
 };
 
-// use the same object for the qi resource and orb
-speechState.resources.qi = speechState.orbs.qi;
+// use the same object for the water resource and orb
+speechState.resources.water = speechState.orbs.water;
 
 // Basic construct recipe list. Additional constructs can be appended
 // later through unlocks or upgrades.
 export const recipes = [
   {
     name: 'Murmur',
-    // Increased cost to make early qi management more meaningful
-    input: { qi: 25 },
+    // Increased cost to make early water management more meaningful
+    input: { water: 25 },
     output: { sound: 1 },
     xp: { voice: 1 },
     tags: ['single-cast', 'generator'],
@@ -153,13 +153,13 @@ export const recipes = [
   },
   {
     name: 'Echo of Mind',
-    input: { sound: 1, qi: 1 },
+    input: { sound: 1, water: 1 },
     output: { thought: 1 },
     xp: { mind: 0.5, voice: 0.5 },
     tags: ['single-cast', 'generator', 'duration'],
     unlocked: false,
-    requirements: { voiceLevel: 3, qi: 1500 },
-    castCost: { sound: 25, qi: 500 },
+    requirements: { voiceLevel: 3, water: 1500 },
+    castCost: { sound: 25, water: 500 },
     duration: 5,
     cooldown: 5,
     potency: 1,
@@ -167,12 +167,12 @@ export const recipes = [
   },
   {
     name: 'Clarity Pulse',
-    input: { thought: 1, qi: 1 },
+    input: { thought: 1, water: 1 },
     output: {},
     xp: { mind: 1 },
     tags: ['single-cast', 'buff', 'duration'],
     unlocked: false,
-    requirements: { mindLevel: 2, qi: 1700 },
+    requirements: { mindLevel: 2, water: 1700 },
     castCost: { thought: 20, sound: 50 },
     duration: 30,
     cooldown: 30,
@@ -186,7 +186,7 @@ export const recipes = [
     xp: {},
     tags: ['duration', 'generator', 'drain'],
     unlocked: false,
-    requirements: { mindLevel: 3, qi: 2000 },
+    requirements: { mindLevel: 3, water: 2000 },
     duration: 30,
     cooldown: 30,
     potency: 1,
@@ -194,13 +194,13 @@ export const recipes = [
   },
   {
     name: 'Mental Construct',
-    input: { sound: 1, thought: 1, qi: 1 },
+    input: { sound: 1, thought: 1, water: 1 },
     output: {},
     xp: { invocation: 1 },
     tags: ['single-cast'],
     unlocked: false,
-    requirements: { voiceLevel: 5, mindLevel: 5, qi: 2300 },
-    castCost: { thought: 10, structure: 10, qi: 1000 },
+    requirements: { voiceLevel: 5, mindLevel: 5, water: 2300 },
+    castCost: { thought: 10, structure: 10, water: 1000 },
     cooldown: 10,
     potency: 1,
     battle: { damage: 6 }
@@ -257,7 +257,7 @@ recipes.forEach(r => {
 });
 
 const resourceIcons = {
-  qi: 'star',
+  water: 'star',
   sound: 'volume-2',
   thought: 'activity',
   structure: 'box',
@@ -275,9 +275,9 @@ const upgradeDescriptions = {
     const current = (R_MAX * (level / (level + 5))).toFixed(2);
     const next = (R_MAX * ((level + 1) / (level + 6))).toFixed(2);
     const inc = (next - current).toFixed(2);
-    return `Improves qi regeneration. Next +${inc}/s (now ${current}/s)`;
+    return `Improves water regeneration. Next +${inc}/s (now ${current}/s)`;
   },
-  expandMind: 'Increase max qi by 15% each level.',
+  expandMind: 'Increase max water by 15% each level.',
   soundExpansion: 'Raises sound capacity; Lv.2 grants an extra slot.',
   cognitiveLattice: 'Increase caps by +50 sound, +10 thought and +5 structure.',
   idleChatter: 'Bonus regen from idle disciples.',
@@ -290,7 +290,7 @@ const upgradeDescriptions = {
 export const constructEffectText = {
   'Murmur': 'Generates 1 Sound (+1 Voice XP)',
   'Echo of Mind': 'Generates 1 Thought per second for 5s',
-  'Clarity Pulse': 'Gain 1% Qi per s',
+  'Clarity Pulse': 'Gain 1% Water per s',
   'Symbol Seed': 'Gain 0.1 Structure per thought drained',
   'Intone': 'Press repeatedly to charge; 1.2× at 5, 1.5× at 10, 2× at 15 for 30s',
   'Mnemonic Rhythm': 'Grants ×2 XP to other constructs for 3s; +0.2× per potency',
@@ -392,8 +392,8 @@ function awardConstructXp(xpObj = {}, mult = 1) {
 // implementations to demonstrate the new constructs in action.
 const constructEffects = {
   Murmur(dt, pot = speechState.constructPotency['Murmur'] || 1) {
-    const amount = dt * pot; // 1 qi -> sound per second scaled
-    const ins = speechState.resources.qi;
+    const amount = dt * pot; // 1 water -> sound per second scaled
+    const ins = speechState.resources.water;
     const snd = speechState.resources.sound;
     if (ins.current >= amount) {
       ins.current -= amount;
@@ -401,7 +401,7 @@ const constructEffects = {
     }
   },
   'Echo of Mind'(dt, pot = speechState.constructPotency['Echo of Mind'] || 1) {
-    const ins = speechState.resources.qi;
+    const ins = speechState.resources.water;
     const th = speechState.resources.thought;
     const amount = dt * pot;
     if (ins.current >= amount) {
@@ -412,9 +412,9 @@ const constructEffects = {
   },
   'Clarity Pulse'(dt, pot = speechState.constructPotency['Clarity Pulse'] || 1) {
     const bonus = 0.01 * dt * pot;
-    speechState.resources.qi.current = Math.min(
-      speechState.resources.qi.max,
-      speechState.resources.qi.current + bonus
+    speechState.resources.water.current = Math.min(
+      speechState.resources.water.max,
+      speechState.resources.water.current + bonus
     );
   },
   'Symbol Seed'(dt, pot = speechState.constructPotency['Symbol Seed'] || 1) {
@@ -502,12 +502,12 @@ export function initSpeech() {
       <div class="orbs-section">
         <h3 class="section-title">Core Orbs</h3>
         <div class="construct-orbs construct-tab-orbs">
-          <div id="orbQiContainer" class="orb-wrapper">
+          <div id="orbWaterContainer" class="orb-wrapper">
             <div class="orb-container">
-              <div id="orbQi" class="construct-orb"><div class="orb-fill"></div></div>
+              <div id="orbWater" class="construct-orb"><div class="orb-fill"></div></div>
             </div>
-            <div id="orbQiValue" class="orb-value"></div>
-            <div id="orbQiRegen" class="orb-regen">
+            <div id="orbWaterValue" class="orb-value"></div>
+            <div id="orbWaterRegen" class="orb-regen">
               <span class="season-icon"></span><span class="regen-value"></span><span id="intoneMultiplier" class="mult-badge"></span>
             </div>
           </div>
@@ -572,8 +572,8 @@ export function initSpeech() {
   renderHotbar();
   renderSeasonBanner();
   if (window.lucide) lucide.createIcons({ icons: lucide.icons });
-  const qiOrbEl = container.querySelector('#orbQi');
-  if (qiOrbEl) qiOrbEl.addEventListener('click', openQiRegenPopup);
+  const waterOrbEl = container.querySelector('#orbWater');
+  if (waterOrbEl) waterOrbEl.addEventListener('click', openWaterRegenPopup);
   document.addEventListener('disciple-gained', renderChantDisciples);
 }
 
@@ -642,8 +642,8 @@ function renderConstructRequirements() {
   if (recipe.requirements.mindLevel) {
     reqs.push(`Mind Lv.${recipe.requirements.mindLevel}`);
   }
-  if (recipe.requirements.qi) {
-    reqs.push(`${recipe.requirements.qi} Qi`);
+  if (recipe.requirements.water) {
+    reqs.push(`${recipe.requirements.water} Water`);
   }
   reqEl.textContent = `Requires: ${reqs.join(' & ')}`;
   reqEl.style.display = 'block';
@@ -683,8 +683,8 @@ function performConstruct() {
       addLog(`Requires Mind Lv.${recipe.requirements.mindLevel}`, 'error');
       return;
     }
-    if (recipe.requirements.qi && speechState.resources.qi.current < recipe.requirements.qi) {
-      addLog(`Requires ${recipe.requirements.qi} Qi`, 'error');
+    if (recipe.requirements.water && speechState.resources.water.current < recipe.requirements.water) {
+      addLog(`Requires ${recipe.requirements.water} Water`, 'error');
       return;
     }
   }
@@ -959,8 +959,8 @@ export function castConstruct(name, el, powerMult = 1, caster = 'player') {
     addLog(`Requires Mind Lv.${def.requirements.mindLevel}`, 'error');
     return;
   }
-  if (def.requirements && def.requirements.qi && speechState.resources.qi.current < def.requirements.qi) {
-    addLog(`Requires ${def.requirements.qi} Qi`, 'error');
+  if (def.requirements && def.requirements.water && speechState.resources.water.current < def.requirements.water) {
+    addLog(`Requires ${def.requirements.water} Water`, 'error');
     return;
   }
   const cdKey = caster === 'player' ? name : `${name}:${caster}`;
@@ -1102,11 +1102,11 @@ function renderOrbs() {
             const gain = speechState.gains[gainKey] ?? 0;
             valEl.textContent = `+${gain.toFixed(3)}/s`;
           }
-          if (id === 'orbQi' && iconEl) {
+          if (id === 'orbWater' && iconEl) {
             const icon = seasonIcons[speechState.seasonIndex];
             iconEl.textContent = icon;
             regenLabel.onmouseenter = e => {
-              showTooltip(`Base: ${speechState.qiRegenBase.toFixed(3)}<br>Current: ${speechState.gains.qi.toFixed(3)}`, e.clientX + 10, e.clientY + 10);
+              showTooltip(`Base: ${speechState.waterRegenBase.toFixed(3)}<br>Current: ${speechState.gains.water.toFixed(3)}`, e.clientX + 10, e.clientY + 10);
             };
             regenLabel.onmouseleave = hideTooltip;
           }
@@ -1116,7 +1116,7 @@ function renderOrbs() {
         }
       }
     };
-    update('orbQi', speechState.orbs.qi);
+    update('orbWater', speechState.orbs.water);
   });
   window.dispatchEvent(new CustomEvent('orbs-changed'));
 }
@@ -1155,7 +1155,7 @@ function renderResources() {
     if (!panelRes) return;
     panelRes.innerHTML = '';
     Object.entries(speechState.resources).forEach(([key, res]) => {
-      if (key === 'qi' || res.unlocked === false) return;
+      if (key === 'water' || res.unlocked === false) return;
       const box = document.createElement('div');
       box.className = 'resource-box';
       const header = document.createElement('div');
@@ -1211,7 +1211,7 @@ function getUpgradeCost(name) {
 
 function canAfford(cost) {
   if (typeof cost === 'number') {
-    return speechState.orbs.qi.current >= cost;
+    return speechState.orbs.water.current >= cost;
   }
   for (const [k, v] of Object.entries(cost)) {
     const orb = speechState.orbs[k];
@@ -1235,7 +1235,7 @@ function updateUpgradeAffordability() {
     if (buy) buy.classList.toggle('disabled', !affordable);
     const spans = btn.querySelectorAll('.icon-row span');
     if (typeof cost === 'number') {
-      const have = speechState.orbs.qi.current;
+      const have = speechState.orbs.water.current;
       spans.forEach(span => span.classList.toggle('cost-missing', have < cost));
     } else {
       const entries = Object.entries(cost);
@@ -1254,8 +1254,8 @@ function purchaseUpgrade(name) {
   const cost = getUpgradeCost(name);
   const prevSlots = speechState.memorySlots;
   if (typeof cost === 'number') {
-    if (speechState.orbs.qi.current < cost) return;
-    speechState.orbs.qi.current -= cost;
+    if (speechState.orbs.water.current < cost) return;
+    speechState.orbs.water.current -= cost;
   } else {
     for (const [k, v] of Object.entries(cost)) {
       if (speechState.orbs[k] && speechState.orbs[k].current < v) return;
@@ -1274,7 +1274,7 @@ function purchaseUpgrade(name) {
   } else if (name === 'capacityBoost') {
     speechState.memorySlots += 1;
   } else if (name === 'expandMind') {
-    speechState.orbs.qi.max = Math.round(speechState.orbs.qi.max * 1.15);
+    speechState.orbs.water.max = Math.round(speechState.orbs.water.max * 1.15);
   } else if (name === 'soundExpansion') {
     speechState.resources.sound.max += 25;
     if (up.level === 2) {
@@ -1308,9 +1308,9 @@ export function renderUpgrades() {
     const up = speechState.upgrades[name];
     let costHtml = '';
     if (typeof cost === 'number') {
-      const have = speechState.orbs.qi.current;
+      const have = speechState.orbs.water.current;
       const cls = have >= cost ? '' : 'cost-missing';
-      costHtml = `<span class="icon-row"><span class="${cls}"><i data-lucide="${resourceIcons.qi}"></i> ${cost}</span></span>`;
+      costHtml = `<span class="icon-row"><span class="${cls}"><i data-lucide="${resourceIcons.water}"></i> ${cost}</span></span>`;
     } else {
       costHtml = `<span class="icon-row">` +
         Object.entries(cost).map(([r,a]) => {
@@ -1343,9 +1343,9 @@ export function renderUpgrades() {
     const btn = document.createElement('button');
     btn.dataset.upgrade = 'clarividence';
     const cost = getUpgradeCost('clarividence');
-    const cls = speechState.orbs.qi.current >= cost ? '' : 'cost-missing';
+    const cls = speechState.orbs.water.current >= cost ? '' : 'cost-missing';
     btn.classList.toggle('unaffordable', !canAfford(cost));
-    btn.innerHTML = `<span class="upg-info"><span class="upg-name">clarividence</span><span class="upgrade-level">Lv.0</span></span><div class="detail"><div class="cost"><span class="icon-row"><span class="${cls}"><i data-lucide="${resourceIcons.qi}"></i> ${cost}</span></span></div><div class="desc">${upgradeDescriptions.clarividence}</div><span class="buy-btn">Buy</span></div>`;
+    btn.innerHTML = `<span class="upg-info"><span class="upg-name">clarividence</span><span class="upgrade-level">Lv.0</span></span><div class="detail"><div class="cost"><span class="icon-row"><span class="${cls}"><i data-lucide="${resourceIcons.water}"></i> ${cost}</span></span></div><div class="desc">${upgradeDescriptions.clarividence}</div><span class="buy-btn">Buy</span></div>`;
     btn.addEventListener('click', e => {
       if (!btn.classList.contains('expanded')) {
         btn.classList.add('expanded');
@@ -1366,9 +1366,9 @@ export function renderUpgrades() {
     const btn = document.createElement('button');
     btn.dataset.upgrade = 'vocalMaturity';
     const cost = getUpgradeCost('vocalMaturity');
-    const cls = speechState.orbs.qi.current >= cost ? '' : 'cost-missing';
+    const cls = speechState.orbs.water.current >= cost ? '' : 'cost-missing';
     btn.classList.toggle('unaffordable', !canAfford(cost));
-    btn.innerHTML = `<span class="upg-info"><span class="upg-name">vocalMaturity</span><span class="upgrade-level">Lv.${speechState.upgrades.vocalMaturity.level}</span></span><div class="detail"><div class="cost"><span class="icon-row"><span class="${cls}"><i data-lucide="${resourceIcons.qi}"></i> ${cost}</span></span></div><div class="desc">${upgradeDescriptions.vocalMaturity}</div><span class="buy-btn">Buy</span></div>`;
+    btn.innerHTML = `<span class="upg-info"><span class="upg-name">vocalMaturity</span><span class="upgrade-level">Lv.${speechState.upgrades.vocalMaturity.level}</span></span><div class="detail"><div class="cost"><span class="icon-row"><span class="${cls}"><i data-lucide="${resourceIcons.water}"></i> ${cost}</span></span></div><div class="desc">${upgradeDescriptions.vocalMaturity}</div><span class="buy-btn">Buy</span></div>`;
     btn.addEventListener('click', e => {
       if (!btn.classList.contains('expanded')) {
         btn.classList.add('expanded');
@@ -1523,10 +1523,10 @@ export function tickSpeech(delta) {
     speechState.weather.duration -= dt;
     if (speechState.weather.duration <= 0) speechState.weather = null;
   }
-  const ins = speechState.resources.qi;
-  const startQi = ins.current;
+  const ins = speechState.resources.water;
+  const startWater = ins.current;
   const seasonMult = seasons[speechState.seasonIndex].multiplier;
-  const baseRateRaw = R_MAX / (1 + Math.exp((ins.current - getQiMidpoint()) / K));
+  const baseRateRaw = R_MAX / (1 + Math.exp((ins.current - getWaterMidpoint()) / K));
   const level = speechState.upgrades.cohere.level;
   // provide baseline regen at level 0 while still tapering off with higher levels
   const upgradeMult = (level + 1) / (level + 5);
@@ -1541,10 +1541,10 @@ export function tickSpeech(delta) {
   let regen = baseTotal * seasonMult;
   if (speechState.weather) regen *= speechState.weather.multiplier;
   regen = Math.min(R_MAX, regen) * getIntoneMultiplier();
-  speechState.qiRegenBase = baseTotal;
+  speechState.waterRegenBase = baseTotal;
   ins.current = Math.min(ins.max, ins.current + regen * dt);
-  // Unlock clarividence once the player demonstrates basic qi control
-  // by accumulating at least 50 qi.
+  // Unlock clarividence once the player demonstrates basic water control
+  // by accumulating at least 50 water.
   if (!speechState.upgrades.clarividence.unlocked && ins.current >= 50) {
     speechState.upgrades.clarividence.unlocked = true;
     if (hasUI) renderUpgrades();
@@ -1649,27 +1649,27 @@ function showConstructCloud(text, target, color) {
   setTimeout(() => el.remove(), 3000);
 }
 
-export function openQiRegenPopup() {
-  const overlay = createOverlay({ className: 'qi-regen-overlay' });
+export function openWaterRegenPopup() {
+  const overlay = createOverlay({ className: 'water-regen-overlay' });
   const box = overlay.box;
   const header = document.createElement('h2');
-  header.textContent = 'Qi Regeneration';
+  header.textContent = 'Water Regeneration';
   box.appendChild(header);
 
   const info = document.createElement('p');
-  info.className = 'qi-info';
+  info.className = 'water-info';
   info.textContent =
-    `Base qi regeneration follows a logistic curve that slows as your` +
-    ` total qi rises. At ${getQiMidpoint()} qi the base rate is half of its` +
+    `Base water regeneration follows a logistic curve that slows as your` +
+    ` total water rises. At ${getWaterMidpoint()} water the base rate is half of its` +
     ` ${R_MAX}/s maximum before multipliers.`;
   box.appendChild(info);
 
   const list = document.createElement('div');
-  list.className = 'qi-regen-list';
+  list.className = 'water-regen-list';
 
-  const ins = speechState.resources.qi;
+  const ins = speechState.resources.water;
   const season = seasons[speechState.seasonIndex];
-  const baseRateRaw = R_MAX / (1 + Math.exp((ins.current - getQiMidpoint()) / K));
+  const baseRateRaw = R_MAX / (1 + Math.exp((ins.current - getWaterMidpoint()) / K));
   const level = speechState.upgrades.cohere.level;
   const upgradeMult = (level + 1) / (level + 5);
   const idleCount =
@@ -1726,14 +1726,14 @@ export function openQiRegenPopup() {
     const isNeg =
       r.value.startsWith('-') ||
       (r.value.startsWith('×') && parseFloat(r.value.slice(1)) < 1);
-    row.className = 'qi-row' + (isNeg ? ' negative' : '');
+    row.className = 'water-row' + (isNeg ? ' negative' : '');
     row.innerHTML = `<span>${r.label}</span><span>${r.value}</span>`;
     list.appendChild(row);
   });
 
   const totalRow = document.createElement('div');
-  totalRow.className = 'qi-total';
-  totalRow.textContent = `Total: ${speechState.gains.qi.toFixed(3)}/s`;
+  totalRow.className = 'water-total';
+  totalRow.textContent = `Total: ${speechState.gains.water.toFixed(3)}/s`;
   list.appendChild(totalRow);
 
   box.appendChild(list);

--- a/style.css
+++ b/style.css
@@ -644,34 +644,34 @@ body.darkenshift-mode .tabsContainer button.active {
     font-size: 0.8rem;
 }
 
-.qi-regen-overlay {
+.water-regen-overlay {
     flex-direction: column;
     gap: 8px;
 }
 
-.qi-info {
+.water-info {
     width: 100%;
     text-align: center;
     font-size: 0.85rem;
 }
 
-.qi-regen-list {
+.water-regen-list {
     display: flex;
     flex-direction: column;
     gap: 4px;
     font-size: 0.9rem;
 }
 
-.qi-row {
+.water-row {
     display: flex;
     justify-content: space-between;
 }
 
-.qi-row.negative {
+.water-row.negative {
     color: #ff8888;
 }
 
-.qi-total {
+.water-total {
     margin-top: 4px;
     text-align: center;
     font-weight: bold;
@@ -3469,7 +3469,7 @@ body.darkenshift-mode .tabsContainer button.active {
     height: 100%;
     width: 0%;
 }
-.resource-fill.qi { background: #7fd9ff; }
+.resource-fill.water { background: #7fd9ff; }
 .resource-fill.thought { background: #c785ff; }
 .resource-fill.structure { background: #a97b5d; }
 .resource-fill.sound {
@@ -3481,7 +3481,7 @@ body.darkenshift-mode .tabsContainer button.active {
     text-align: center;
 }
 
-.construct-orb#orbQi {
+.construct-orb#orbWater {
     background: rgba(127,217,255,0.2);
     border-color: #7fd9ff;
     color: #7fd9ff;
@@ -3800,7 +3800,7 @@ body.darkenshift-mode .tabsContainer button.active {
 .sect-orb.flash {
     animation: sectGlow 3s infinite alternate, sectGlowFlash 0.5s;
 }
-.sect-orb.qi { background: rgba(127,217,255,0.6); }
+.sect-orb.water { background: rgba(127,217,255,0.6); }
 .sect-basket {
     position: absolute;
     width: 8px;
@@ -3903,7 +3903,7 @@ body.darkenshift-mode .tabsContainer button.active {
 .slot-word {
     pointer-events: none;
 }
-.construct-orb#orbQi .orb-fill {
+.construct-orb#orbWater .orb-fill {
     background: rgba(127,217,255,0.6);
 }
 


### PR DESCRIPTION
## Summary
- rename `Qi` terminology to `Water` across source files
- update `openWaterRegenPopup` and related resources
- rename documentation to reference Water energy
- adjust styles and classes for Water

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6876e30777708326861f7e2fd3ef9d6e