### PR TITLE
Update ESLint config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,10 +5,25 @@ import markdown from "@eslint/markdown";
 import css from "@eslint/css";
 import { defineConfig } from "eslint/config";
 
+const jsGlobals = {
+  ...globals.browser,
+  ...globals.node,
+  PIXI: "readonly",
+  lucide: "readonly",
+};
+
 
 export default defineConfig([
-  { files: ["**/*.{js,mjs,cjs}"], plugins: { js }, extends: ["js/recommended"] },
-  { files: ["**/*.{js,mjs,cjs}"], languageOptions: { globals: globals.browser } },
+  {
+    files: ["**/*.{js,mjs,cjs}"],
+    plugins: { js },
+    extends: ["js/recommended"],
+    languageOptions: { globals: jsGlobals },
+  },
+  {
+    files: ["test/**/*.{js,mjs,cjs}"],
+    languageOptions: { globals: { ...jsGlobals, ...globals.mocha } },
+  },
   { files: ["**/*.json"], plugins: { json }, language: "json/json", extends: ["json/recommended"] },
   { files: ["**/*.jsonc"], plugins: { json }, language: "json/jsonc", extends: ["json/recommended"] },
   { files: ["**/*.json5"], plugins: { json }, language: "json/json5", extends: ["json/recommended"] },


### PR DESCRIPTION
## Summary
- merge browser and node globals for JS files
- expose PIXI and lucide as read-only
- add test override that includes mocha globals

## Testing
- `npm run lint` *(fails: many lint errors in repository)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687792de47b08326a5b30a810be041a0