### PR TITLE
Fix sect subtab initialization

### DIFF
--- a/script.js
+++ b/script.js
@@ -773,7 +773,11 @@ function setupTabHandlers() {
         refreshCore();
         showTab(playerTab);
         setActiveTabButton(playerTabButton);
-        if (playerConstructSubTabButton) playerConstructSubTabButton.click();
+        if (sectTabUnlocked && playerSectSubTabButton) {
+          playerSectSubTabButton.click();
+        } else if (playerConstructSubTabButton) {
+          playerConstructSubTabButton.click();
+        }
       }
     },
     {
@@ -1076,9 +1080,14 @@ function initTabs() {
       // economy stats removed
     });
 
-  showTab(playerTab); // Start with construct panel visible
+  // Start with the sect panel if unlocked, otherwise default to the construct panel
+  showTab(playerTab);
   setActiveTabButton(playerTabButton);
-  if (playerConstructSubTabButton) playerConstructSubTabButton.click();
+  if (sectTabUnlocked && playerSectSubTabButton) {
+    playerSectSubTabButton.click();
+  } else if (playerConstructSubTabButton) {
+    playerConstructSubTabButton.click();
+  }
 }
 
 function initPollen() {


### PR DESCRIPTION
## Summary
- open Sect panel when it is unlocked
- default to Sect tab at startup when available

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6878628856488326a6b92cd504b130e1