### PR TITLE
Fix leftover speechState reference

### DIFF
--- a/script.js
+++ b/script.js
@@ -2558,8 +2558,8 @@ document.addEventListener("DOMContentLoaded", () => {
   initPollen();
   window.addEventListener('location-discovered', e => addDiscoveredLocation(e.detail.name));
   loadGame();
-  if (speechState.disciples.length === 0) {
-    speechState.disciples.push(...disciples);
+  if (sectSystem.disciples.length === 0) {
+    sectSystem.disciples.push(...disciples);
     sectTabUnlocked = true;
     if (playerSectSubTabButton) playerSectSubTabButton.style.display = '';
     updateSectDisplay();


### PR DESCRIPTION
## Summary
- fix DOMContentLoaded initialization to use `sectSystem` instead of undefined `speechState`

## Testing
- `npm test` *(fails: no test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68790d2ac10c8326adefc936be16f1b5