### PR TITLE
Adjust colony map layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -239,16 +239,21 @@
         </div>
         <div class="player-sect-panel" style="display:none;">
           <div class="colony-main">
-            <div id="colonyMap" class="colony-map">
-              <div class="colony-tabs">
+            <div class="colony-map-area">
+              <div id="colonyMap" class="colony-map">
+                <div class="colony-tabs">
                 <button id="colonyTasksTabBtn" style="display:none;">👤</button>
                 <button id="colonyInfoTabBtn" style="display:none;">ℹ️</button>
-                <button id="colonyResourcesTabBtn">🍎</button>
+                <button id="colonyResourcesTabBtn">Resources</button>
                 <button id="colonyBuildTabBtn" style="display:none;">🏠</button>
                 <button id="colonyResearchTabBtn" style="display:none;">🔬</button>
-                <button id="locationsPanelBtn">📍</button>
+                <button id="locationsPanelBtn">Locations</button>
               </div>
               <div id="sectDisciplesContainer" class="sect-disciples-container">
+                <div id="discipleStatus" class="disciple-status" style="display:none;">
+                  <div class="status-bar life-bar"><div class="bar-fill"></div><span class="bar-text"></span></div>
+                  <div class="status-bar task-bar"><div class="bar-fill"></div><span class="bar-text"></span></div>
+                </div>
                 <div class="zone orchard"></div>
                 <div class="zone lumberyard"></div>
                 <div class="zone meditation"></div>
@@ -263,6 +268,7 @@
               </div>
             </div>
             <div id="sectDiscipleList" class="sect-disciple-list"></div>
+            </div>
             <div class="colony-side">
               <div id="colonyTasksPanel" class="colony-panel"></div>
               <div id="colonyInfoPanel" class="colony-panel"></div>

--- a/script.js
+++ b/script.js
@@ -244,7 +244,7 @@ const DISCIPLE_MAX_HEALTH = 10;
 const REST_TIME_SECONDS = 300; // health fully restored over 5 minutes
 
 const TASK_ICONS = {
-  'Gather Fruit': '🍎',
+  'Gather Fruit': '',
   'Log Pine': '🪵',
   Hunt: '🏹',
   Building: '⚒️',
@@ -792,6 +792,7 @@ let colonyBuildTabButton;
 let colonyResearchTabButton;
 let locationsPanelBtn;
 let sectDisciplesContainer;
+let discipleStatusEl;
 let sectDiscipleListContainer;
 let selectedDiscipleId = null;
 let discipleInfoView = 'status';
@@ -828,7 +829,7 @@ function addDiscoveredLocation(name) {
   if (map && def) {
     const icon = document.createElement('div');
     icon.className = 'location-icon';
-    icon.textContent = '📍';
+    icon.textContent = '';
     icon.style.left = def.x;
     icon.style.top = def.y;
     map.appendChild(icon);
@@ -1040,6 +1041,7 @@ function initTabs() {
   constructLexiconContainer = document.getElementById('constructLexicon');
   sectSummaryDisplay = document.getElementById('sectSummary');
   sectDisciplesContainer = document.getElementById('sectDisciplesContainer');
+  discipleStatusEl = document.getElementById('discipleStatus');
   sectDiscipleListContainer = document.getElementById('sectDiscipleList');
   colonyTasksPanel = document.getElementById('colonyTasksPanel');
   colonyInfoPanel = document.getElementById('colonyInfoPanel');
@@ -1626,6 +1628,52 @@ function updateTaskProgressDisplay() {
   });
 }
 
+function updateDiscipleStatus() {
+  if (!discipleStatusEl) return;
+  const d = speechState.disciples.find(x => x.id === selectedDiscipleId);
+  if (!d) {
+    discipleStatusEl.style.display = 'none';
+    return;
+  }
+  discipleStatusEl.style.display = 'flex';
+  const lifeFill = discipleStatusEl.querySelector('.life-bar .bar-fill');
+  const lifeText = discipleStatusEl.querySelector('.life-bar .bar-text');
+  if (lifeFill) lifeFill.style.width = `${(d.health / DISCIPLE_MAX_HEALTH) * 100}%`;
+  if (lifeText) lifeText.textContent = d.name || `Disciple ${d.id}`;
+  const taskFill = discipleStatusEl.querySelector('.task-bar .bar-fill');
+  const taskText = discipleStatusEl.querySelector('.task-bar .bar-text');
+  const task = d.incapacitated ? 'Resting' : sectState.discipleTasks[d.id] || 'Idle';
+  let pct = 0;
+  if (task === 'Gather Fruit' || task === 'Log Pine') {
+    const progress = sectState.discipleProgress[d.id] || 0;
+    const baseSeconds = task === 'Gather Fruit' ? FRUIT_CYCLE_SECONDS : PINE_LOG_CYCLE_SECONDS;
+    const cycleAmount = task === 'Gather Fruit' ? FRUIT_CYCLE_AMOUNT : PINE_LOG_CYCLE_AMOUNT;
+    const group = TASK_GROUPS[task];
+    const skillXp = sectState.discipleSkills[d.id]?.[group] || 0;
+    const lvl = getTaskSkillProgress(skillXp).level;
+    const yieldMult = 1 + 0.05 * lvl;
+    const gatherAmt = Math.min(cycleAmount * yieldMult, d.inventorySlots);
+    const cycleSeconds = baseSeconds * (gatherAmt / (cycleAmount * yieldMult));
+    pct = ((progress % cycleSeconds) / cycleSeconds);
+  } else if (task === 'Research') {
+    const researcherCount = speechState.disciples.filter(x => sectState.discipleTasks[x.id] === 'Research').length;
+    const rate = researcherCount * 4;
+    const prog = sectState.researchProgress % 500;
+    pct = prog / 500;
+  } else if (task === 'Building') {
+    const buildData = sectState.currentBuild ? BUILDINGS[sectState.currentBuild] : null;
+    pct = buildData ? sectState.buildProgress : 0;
+  } else if (task === 'Hunt') {
+    const progress = sectState.discipleProgress[d.id] || 0;
+    pct = progress / HUNT_CYCLE_SECONDS;
+  } else if (task === 'Exploration') {
+    const progress = sectState.discipleProgress[d.id] || 0;
+    pct = progress / EXPLORATION_CYCLE_SECONDS;
+  }
+  if (taskFill) taskFill.style.width = `${Math.min(pct,1) * 100}%`;
+  if (taskText) taskText.textContent = task;
+}
+
 function updateSectDisplay() {
   if (!sectTabUnlocked || !playerSectPanel) return;
   const total = speechState.disciples.length;
@@ -1637,7 +1685,7 @@ function updateSectDisplay() {
     const upkeep = DAILY_FRUIT_CONSUMPTION * speechState.disciples.length;
     sectSummaryDisplay.innerHTML = `
       <span>👥 ${total - assigned}/${total}</span>
-      <span>🍎 ${sectState.fruits}</span>
+      <span>${sectState.fruits}</span>
       <span>🪵 ${sectState.pineLogs}</span>
       <span>⚖️ -${upkeep}/day (${mm}:${ss})</span>`;
   }
@@ -1700,6 +1748,7 @@ function updateSectDisplay() {
   if (colonyTasksPanel) renderColonyTasks();
   if (colonyInfoPanel) renderColonyInfo();
   if (colonyResourcesPanel) renderColonyResources();
+  updateDiscipleStatus();
 }
 
 function moveDisciple(el) {
@@ -1808,6 +1857,7 @@ function renderColonyTasks() {
       selectedDiscipleId = d.id;
       renderColonyTasks();
       renderColonyInfo();
+      updateDiscipleStatus();
     });
     const icon = document.createElement('span');
     icon.textContent = TASK_ICONS[current] || '⚪️';
@@ -2099,6 +2149,7 @@ function renderDiscipleList() {
       discipleInfoView = 'status';
       renderDiscipleList();
       renderDiscipleDetails();
+      updateDiscipleStatus();
     });
     colonyInfoPanel.appendChild(row);
   });
@@ -2466,7 +2517,7 @@ function openDiscipleOverlay(d) {
   } else {
     discipleOverlayActiveTab = d.lastTab || 'general';
   }
-  discipleOverlay = createOverlay({ className: 'disciple-overlay' });
+  discipleOverlay = createOverlay({ className: 'disciple-overlay', container: sectDisciplesContainer });
   const { box } = discipleOverlay;
 
   const closeBtn = document.createElement('button');

--- a/style.css
+++ b/style.css
@@ -598,18 +598,18 @@ body.darkenshift-mode .tabsContainer button.active {
 .disciple-overlay.overlay {
     background: none;
     backdrop-filter: none;
-    justify-content: flex-end;
+    justify-content: flex-start;
     align-items: flex-start;
     pointer-events: none;
 }
 .disciple-overlay .overlay-box {
-    background: var(--verdantia-parchment);
-    color: #000;
+    background: rgba(0,0,0,0.5);
+    color: #fff;
     border: 1px solid #3a5a3a;
-    box-shadow: 0 2px 6px rgba(0,0,0,0.4);
-    width: 300px;
-    min-height: 260px;
-    font-size: 0.75rem;
+    box-shadow: none;
+    width: 160px;
+    min-height: auto;
+    font-size: 0.55rem;
     position: relative;
     pointer-events: auto;
 }
@@ -3554,6 +3554,47 @@ body.darkenshift-mode .tabsContainer button.active {
     overflow: hidden;
 }
 
+.disciple-status {
+    position: absolute;
+    top: 4px;
+    left: 4px;
+    right: 4px;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    font-size: 0.55rem;
+    pointer-events: none;
+    z-index: 2;
+}
+
+.disciple-status .status-bar {
+    position: relative;
+    width: 100%;
+    height: 6px;
+    background: #222;
+    border: 1px solid #555;
+    border-radius: 3px;
+    overflow: hidden;
+}
+
+.disciple-status .bar-fill {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: 0%;
+    background: var(--core-accent);
+}
+
+.disciple-status .bar-text {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    white-space: nowrap;
+    pointer-events: none;
+}
+
 .sect-disciples-container::before {
     content: "";
     position: absolute;
@@ -3675,8 +3716,15 @@ body.darkenshift-mode .tabsContainer button.active {
 .colony-main {
     flex: 1;
     display: flex;
-    flex-direction: column;
+    flex-direction: row;
     gap: 6px;
+}
+
+.colony-map-area {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    position: relative;
 }
 
 .colony-map {
@@ -3687,10 +3735,11 @@ body.darkenshift-mode .tabsContainer button.active {
 }
 
 .colony-side {
-    width: 100%;
     display: flex;
+    flex-direction: column;
     gap: 6px;
-    flex: 1;
+    width: 160px;
+    flex: 0 0 160px;
 }
 #colonyTasksPanel {
     border-right: 1px solid var(--core-border);
@@ -4186,6 +4235,7 @@ body.darkenshift-mode .tabsContainer button.active {
     padding: 4px 0;
     flex-wrap: nowrap;
     overflow-x: auto;
+    margin-top: 4px;
 }
 .sect-disciple-card {
     position: relative;


### PR DESCRIPTION
## Summary
- place the colony resource panel on the left and let the map fill remaining space
- remove obsolete apple and pin icons
- embed a small disciple status bar inside the map
- tweak overlay size and placement

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68796bbf88a48326abf9d32362f0a95f