### PR TITLE
Update sect map layout per wireframe

### DIFF
--- a/index.html
+++ b/index.html
@@ -235,19 +235,19 @@
           <div id="constructLexicon" class="construct-lexicon built-constructs"></div>
         </div>
         <div class="player-sect-panel" style="display:none;">
-          <div class="sect-header">
-            <div id="seasonBanner" class="season-banner"></div>
-            <div id="sectDiscipleList" class="sect-disciple-list"></div>
-          </div>
           <div class="colony-main">
             <div id="colonyMap" class="colony-map">
+              <div class="sect-header">
+                <div id="seasonBanner" class="season-banner"></div>
+                <div id="sectDiscipleList" class="sect-disciple-list"></div>
+              </div>
               <div class="colony-tabs">
                 <button id="colonyTasksTabBtn" style="display:none;">👤</button>
                 <button id="colonyInfoTabBtn" style="display:none;">ℹ️</button>
-                <button id="colonyResourcesTabBtn">🍎</button>
+                <button id="colonyResourcesTabBtn"></button>
                 <button id="colonyBuildTabBtn" style="display:none;">🏠</button>
                 <button id="colonyResearchTabBtn" style="display:none;">🔬</button>
-                <button id="locationsPanelBtn">📍</button>
+                <button id="locationsPanelBtn"></button>
               </div>
               <div id="sectDisciplesContainer" class="sect-disciples-container">
                 <div class="zone orchard"></div>

--- a/script.js
+++ b/script.js
@@ -450,30 +450,27 @@ function createDiscipleCard(d) {
 function createSectDiscipleCard(d) {
   const card = document.createElement('div');
   card.className = 'sect-disciple-card';
-  const icon = document.createElement('div');
-  icon.className = 'disciple-icon';
-  icon.textContent = (d.name || `Disciple ${d.id}`).charAt(0);
-  card.appendChild(icon);
 
-  const name = document.createElement('div');
-  name.textContent = d.name || `Disciple ${d.id}`;
-  card.appendChild(name);
+  const lifeBar = makeBar(d.health, DISCIPLE_MAX_HEALTH, '#a33');
+  lifeBar.classList.add('life-bar');
+  const nameLabel = document.createElement('div');
+  nameLabel.className = 'bar-label';
+  nameLabel.textContent = d.name || `Disciple ${d.id}`;
+  lifeBar.appendChild(nameLabel);
+  card.appendChild(lifeBar);
 
+  const wrapper = document.createElement('div');
+  wrapper.id = `disciple-task-${d.id}`;
+  wrapper.className = 'disciple-progress';
+  const fill = document.createElement('div');
+  fill.className = 'disciple-progress-fill';
+  wrapper.appendChild(fill);
+  const label = document.createElement('div');
+  label.className = 'disciple-progress-label';
   const curTask = d.incapacitated ? 'Resting' : sectState.discipleTasks[d.id] || 'Idle';
-  const task = document.createElement('div');
-  task.className = 'disciple-task';
-  task.textContent = curTask;
-  card.appendChild(task);
-
-  const bars = [
-    { val: d.health, max: DISCIPLE_MAX_HEALTH, color: '#a33' },
-    { val: d.stamina, max: calculateMaxStamina(d.endurance), color: '#cc3' },
-    { val: d.hunger, max: 20, color: '#996633' }
-  ];
-  bars.forEach(b => {
-    const bar = makeBar(b.val, b.max, b.color);
-    card.appendChild(bar);
-  });
+  label.textContent = curTask;
+  wrapper.appendChild(label);
+  card.appendChild(wrapper);
 
   return card;
 }
@@ -786,7 +783,6 @@ function addDiscoveredLocation(name) {
   if (map && def) {
     const icon = document.createElement('div');
     icon.className = 'location-icon';
-    icon.textContent = '📍';
     icon.style.left = def.x;
     icon.style.top = def.y;
     map.appendChild(icon);
@@ -1446,7 +1442,7 @@ function updateSectDisplay() {
     const upkeep = DAILY_FRUIT_CONSUMPTION * sectSystem.disciples.length;
     sectSummaryDisplay.innerHTML = `
       <span>👥 ${total - assigned}/${total}</span>
-      <span>🍎 ${sectState.fruits}</span>
+      <span>${sectState.fruits}</span>
       <span>🪵 ${sectState.pineLogs}</span>
       <span>⚖️ -${upkeep}/day (${mm}:${ss})</span>`;
   }

--- a/style.css
+++ b/style.css
@@ -3535,6 +3535,7 @@ body.darkenshift-mode .tabsContainer button.active {
     width: 100%;
 }
 .player-sect-panel {
+    position: relative;
     display: flex;
     flex-direction: column;
     flex: 1;
@@ -3575,10 +3576,11 @@ body.darkenshift-mode .tabsContainer button.active {
 }
 .sect-summary {
     display: flex;
-    justify-content: center;
-    gap: 16px;
-    padding: 6px 8px;
-    font-size: 0.8rem;
+    flex-direction: column;
+    justify-content: flex-start;
+    gap: 4px;
+    padding: 4px;
+    font-size: 0.7rem;
     background: rgba(0,0,0,0.25);
     box-shadow: 0 2px 6px rgba(0,0,0,0.4);
     border-top: 1px solid rgba(0,0,0,0.6);
@@ -3587,12 +3589,12 @@ body.darkenshift-mode .tabsContainer button.active {
     display: flex;
     align-items: center;
     gap: 4px;
-    padding: 0 4px;
+    padding: 0 2px;
 }
 
 .sect-resource-display {
     position: absolute;
-    right: 4px;
+    left: 4px;
     top: 4px;
     width: 150px;
     display: flex;
@@ -3704,27 +3706,32 @@ body.darkenshift-mode .tabsContainer button.active {
     display: flex;
     flex-direction: column;
     gap: 6px;
+    height: 100%;
 }
 
 .sect-header {
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    right: 2px;
     display: flex;
     justify-content: space-between;
-    align-items: center;
-    gap: 8px;
+    align-items: flex-start;
+    gap: 4px;
+    pointer-events: none;
 }
+.sect-header > * { pointer-events: auto; }
 
 .colony-map {
     flex: 1;
     width: 100%;
     position: relative;
     min-height: 200px;
+    height: 100%;
 }
 
 .colony-side {
-    width: 100%;
-    display: flex;
-    gap: 6px;
-    flex: 1;
+    display: none;
 }
 #colonyTasksPanel {
     border-right: 1px solid var(--core-border);
@@ -3792,6 +3799,13 @@ body.darkenshift-mode .tabsContainer button.active {
     color: #fff;
     pointer-events: none;
     white-space: nowrap;
+}
+.sect-disciple-list .disciple-progress {
+    width: 60px;
+    height: 4px;
+}
+.sect-disciple-list .disciple-progress-label {
+    font-size: 0.55rem;
 }
 .disciple-task-rate {
     min-width: 50px;
@@ -4234,51 +4248,35 @@ body.darkenshift-mode .tabsContainer button.active {
 /* Sect disciple list cards */
 .sect-disciple-list {
     display: flex;
-    justify-content: center;
-    gap: 8px;
-    padding: 4px 0;
+    gap: 2px;
+    padding: 0;
     flex-wrap: nowrap;
     overflow-x: auto;
 }
 .sect-disciple-card {
     position: relative;
     border: 1px solid #b4b89f;
-    padding: 4px;
-    padding-top: 22px;
-    width: 90px;
-    font-size: 0.7rem;
+    padding: 2px;
+    width: 60px;
+    font-size: 0.55rem;
     display: flex;
     flex-direction: column;
     align-items: center;
     cursor: pointer;
-    background: var(--verdantia-parchment);
-    box-shadow: 0 2px 6px rgba(0,0,0,0.4);
-    transition: box-shadow 0.2s, background 0.2s;
+    background: rgba(0,0,0,0.5);
+    box-shadow: none;
 }
 .sect-disciple-card:hover {
     background: #fbf6e0;
     box-shadow: 0 0 8px rgba(0,0,0,0.4);
 }
-.disciple-icon {
-    position: absolute;
-    top: 2px;
-    left: 2px;
-    width: 18px;
-    height: 18px;
-    border-radius: 50%;
-    background: #eee;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 0.65rem;
-    box-shadow: 0 0 2px rgba(0,0,0,0.5);
-}
+.disciple-icon { display: none; }
 .sect-disciple-card .bar {
     width: 100%;
-    height: 6px;
+    height: 4px;
     background: #444;
     border: 1px solid #222;
-    margin-top: 2px;
+    margin-top: 1px;
     position: relative;
 }
 .sect-disciple-card .bar-fill {
@@ -4288,6 +4286,9 @@ body.darkenshift-mode .tabsContainer button.active {
     height: 100%;
     width: 0%;
     background: var(--verdantia-jade);
+}
+.life-bar .bar-label {
+    font-size: 0.55rem;
 }
 
 .disciple-tabs {


### PR DESCRIPTION
## Summary
- reposition sect header inside the map
- list resources vertically on the left
- hide unused icons and adjust disciple cards
- make map fill the available space

## Testing
- `npm test` *(fails: No test files found)*
- `npm run lint` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6879841496408326afdc2b0d2abe2176