### PR TITLE
Set build script and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    name: Build game bundle
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - run: npm install
+      - run: npm run build
+
+  lint:
+    name: Run ESLint
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - run: npm install
+      - run: npm run lint

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "mocha",
     "start": "node script.js",
     "dev": "live-server /storage/emulated/0/Documents/project-start",
-    "build": "echo 'No build step yet — just copying files manually.'",
+    "build": "parcel build index.html",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "simulate": "node simulate.js",
     "simulate:aggressive": "node simulate.js aggressive",


### PR DESCRIPTION
## Summary
- use a real build command in `package.json`
- add CI workflow to run build and lint

## Testing
- `npm test` *(fails: no test files found)*
- `npm run lint` *(fails: lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_687986dc13cc8326b114dca17da1cbeb