### PR TITLE
Fix sect disciple list overlay

### DIFF
--- a/style.css
+++ b/style.css
@@ -3719,6 +3719,7 @@ body.darkenshift-mode .tabsContainer button.active {
     align-items: flex-start;
     gap: 4px;
     pointer-events: none;
+    z-index: 2;
 }
 .sect-header > * { pointer-events: auto; }
 


### PR DESCRIPTION
## Summary
- ensure disciple cards remain visible above sect map overlay

## Testing
- `npm test` *(fails: no test files found)*
- `npm run lint` *(fails: 409 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68798867e31c8326a8410644c486fdcb