### PR TITLE
Move resource panel and add collapse

### DIFF
--- a/index.html
+++ b/index.html
@@ -266,9 +266,12 @@
                 </div>
                 <button id="gateBtn" class="sect-gate">Gate</button>
               </div>
-              <div id="resourceDisplay" class="sect-resource-display">
-                <div id="sectSummary" class="sect-summary"></div>
-              </div>
+                <div id="resourceDisplay" class="sect-resource-display vignette open">
+                  <button class="vignette-toggle">Resources</button>
+                  <div class="vignette-content">
+                    <div id="sectSummary" class="sect-summary"></div>
+                  </div>
+                </div>
             </div>
             <div class="colony-side">
               <div id="colonyTasksPanel" class="colony-panel"></div>

--- a/script.js
+++ b/script.js
@@ -1741,7 +1741,8 @@ function renderColonyResources() {
   colonyResourcesPanel.innerHTML = '';
   renderSectDiscipleList();
   if (sectSummaryDisplay && resourceDisplay) {
-    resourceDisplay.appendChild(sectSummaryDisplay);
+    const content = resourceDisplay.querySelector('.vignette-content');
+    (content || resourceDisplay).appendChild(sectSummaryDisplay);
   }
   checkBuildingUnlock();
 }

--- a/style.css
+++ b/style.css
@@ -3592,7 +3592,7 @@ body.darkenshift-mode .tabsContainer button.active {
 .sect-resource-display {
     position: absolute;
     left: 4px;
-    top: 4px;
+    top: 40px;
     width: 150px;
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
## Summary
- relocate the sect resources display below the season banner
- allow the sect resources panel to be collapsed/expanded

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_687992dd451883269bc51f5aaf179ecb