### PR TITLE
Display disciple name above life bar

### DIFF
--- a/script.js
+++ b/script.js
@@ -452,12 +452,13 @@ function createSectDiscipleCard(d) {
   const card = document.createElement('div');
   card.className = 'sect-disciple-card';
 
+  const nameLabel = document.createElement('div');
+  nameLabel.className = 'bar-label disciple-name';
+  nameLabel.textContent = d.name || `Disciple ${d.id}`;
+  card.appendChild(nameLabel);
+
   const lifeBar = makeBar(d.health, DISCIPLE_MAX_HEALTH, '#a33');
   lifeBar.classList.add('life-bar');
-  const nameLabel = document.createElement('div');
-  nameLabel.className = 'bar-label';
-  nameLabel.textContent = d.name || `Disciple ${d.id}`;
-  lifeBar.appendChild(nameLabel);
   card.appendChild(lifeBar);
 
   const wrapper = document.createElement('div');

--- a/style.css
+++ b/style.css
@@ -4284,6 +4284,11 @@ body.darkenshift-mode .tabsContainer button.active {
     font-size: 0.55rem;
 }
 
+.sect-disciple-card .disciple-name {
+    font-size: 0.55rem;
+    margin-bottom: 1px;
+}
+
 .disciple-tabs {
     display: flex;
     gap: 4px;


### PR DESCRIPTION
## Summary
- move disciple label above the life bar
- style disciple name on sect cards

## Testing
- `npm run lint`
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68799deb21488326ab845bdc0fcaea01