### PR TITLE
Add navigation panel to sect tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -271,7 +271,15 @@
                     <div id="sectSummary" class="sect-summary"></div>
                   </div>
                 </div>
-            </div>
+            <div id="sectNavPanel" class="sect-nav-panel">
+  <button id="sectNavWorkBtn" title="Work"><i data-lucide="hammer"/></button>
+  <button id="sectNavChantBtn" title="Chanting"><i data-lucide="mic-2"/></button>
+  <button id="sectNavMapBtn" title="Map"><i data-lucide="map"/></button>
+  <button id="sectNavInfluenceBtn" title="Influence"><i data-lucide="users"/></button>
+  <button id="sectNavResearchBtn" title="Research"><i data-lucide="flask-conical"/></button>
+  <button id="sectNavCultivationBtn" title="Cultivation"><i data-lucide="sprout"/></button>
+</div>
+</div>
             <div class="colony-side">
               <div id="colonyTasksPanel" class="colony-panel"></div>
               <div id="colonyInfoPanel" class="colony-panel"></div>

--- a/script.js
+++ b/script.js
@@ -762,6 +762,13 @@ let statsOverviewSubTabButton;
 let statsEconomySubTabButton;
 let statsOverviewContainer;
 let statsEconomyContainer;
+let sectNavWorkBtn;
+let sectNavChantBtn;
+let sectNavMapBtn;
+let sectNavInfluenceBtn;
+let sectNavResearchBtn;
+let sectNavCultivationBtn;
+
 const discoveredLocations = [];
 const explorationParty = new Set();
 let currentExplorationParty = [];
@@ -989,6 +996,12 @@ function initTabs() {
   colonyResearchTabButton = document.getElementById('colonyResearchTabBtn');
   locationsPanelBtn = document.getElementById('locationsPanelBtn');
   gateBtn = document.getElementById('gateBtn');
+  sectNavWorkBtn = document.getElementById("sectNavWorkBtn");
+  sectNavChantBtn = document.getElementById("sectNavChantBtn");
+  sectNavMapBtn = document.getElementById("sectNavMapBtn");
+  sectNavInfluenceBtn = document.getElementById("sectNavInfluenceBtn");
+  sectNavResearchBtn = document.getElementById("sectNavResearchBtn");
+  sectNavCultivationBtn = document.getElementById("sectNavCultivationBtn");
   statsOverviewSubTabButton = document.querySelector('.statsOverviewSubTabButton');
   statsEconomySubTabButton = document.querySelector('.statsEconomySubTabButton');
   statsOverviewContainer = document.getElementById('statsOverviewContainer');
@@ -1033,6 +1046,17 @@ function initTabs() {
       }
       openExplorationOverlay();
     });
+  const navButtons = [sectNavWorkBtn, sectNavChantBtn, sectNavMapBtn, sectNavInfluenceBtn, sectNavResearchBtn, sectNavCultivationBtn];
+  function setActiveNavBtn(btn) {
+    navButtons.forEach(b => b && b.classList.remove("active"));
+    if (btn) btn.classList.add("active");
+  }
+  if (sectNavWorkBtn) sectNavWorkBtn.addEventListener("click", () => { setActiveNavBtn(sectNavWorkBtn); openWorkOverlay(); });
+  if (sectNavChantBtn) sectNavChantBtn.addEventListener("click", () => { setActiveNavBtn(sectNavChantBtn); openPlaceholderOverlay("Chanting"); });
+  if (sectNavMapBtn) sectNavMapBtn.addEventListener("click", () => { setActiveNavBtn(sectNavMapBtn); openExplorationOverlay(); });
+  if (sectNavInfluenceBtn) sectNavInfluenceBtn.addEventListener("click", () => { setActiveNavBtn(sectNavInfluenceBtn); openPlaceholderOverlay("Influence"); });
+  if (sectNavResearchBtn) sectNavResearchBtn.addEventListener("click", () => { setActiveNavBtn(sectNavResearchBtn); openPlaceholderOverlay("Research"); });
+  if (sectNavCultivationBtn) sectNavCultivationBtn.addEventListener("click", () => { setActiveNavBtn(sectNavCultivationBtn); openPlaceholderOverlay("Cultivation"); });
   if (startDungeonBtn)
     startDungeonBtn.addEventListener('click', startExploration);
   if (playerCoreSubTabButton)
@@ -2644,8 +2668,49 @@ function openExplorationOverlay() {
   }
 
   update();
+
 }
 
+let workOverlay = null;
+function openWorkOverlay() {
+  if (workOverlay) return;
+  workOverlay = createOverlay({ className: "work-overlay" });
+  workOverlay.onClose(() => { workOverlay = null; });
+  const { box } = workOverlay;
+  const closeBtn = document.createElement("button");
+  closeBtn.className = "close-btn";
+  closeBtn.innerHTML = "&times;";
+  closeBtn.addEventListener("click", workOverlay.close);
+  box.appendChild(closeBtn);
+  const header = document.createElement("div");
+  header.className = "panel-heading";
+  header.textContent = "Work";
+  box.appendChild(header);
+  const gf = document.createElement("button");
+  gf.textContent = "Gather Fruit";
+  gf.addEventListener("click", () => {
+    sectSystem.disciples.forEach(d => {
+      sectState.discipleTasks[d.id] = "Gather Fruit";
+    });
+    if (typeof renderColonyTasks === "function") renderColonyTasks();
+    if (typeof renderColonyInfo === "function") renderColonyInfo();
+    workOverlay.close();
+  });
+  box.appendChild(gf);
+}
+
+function openPlaceholderOverlay(title) {
+  const ov = createOverlay({});
+  const { box } = ov;
+  const closeBtn = document.createElement("button");
+  closeBtn.className = "close-btn";
+  closeBtn.innerHTML = "&times;";
+  closeBtn.addEventListener("click", ov.close);
+  box.appendChild(closeBtn);
+  const msg = document.createElement("div");
+  msg.textContent = `${title} coming soon`;
+  box.appendChild(msg);
+}
 function triggerOrbFlash() {
   const orbs = document.querySelectorAll('#sectOrbs .sect-orb');
   orbs.forEach(o => {
@@ -2685,6 +2750,8 @@ document.addEventListener("DOMContentLoaded", () => {
     sectSystem.disciples.forEach(d => {
       if (sectState.fruits >= DAILY_FRUIT_CONSUMPTION) {
         sectState.fruits -= DAILY_FRUIT_CONSUMPTION;
+
+
         d.hunger = 20;
       } else {
         d.hunger = Math.max(0, d.hunger - 1);

--- a/style.css
+++ b/style.css
@@ -3599,6 +3599,35 @@ body.darkenshift-mode .tabsContainer button.active {
     gap: 4px;
     z-index: 5;
 }
+.sect-nav-panel {
+    position: absolute;
+    right: 4px;
+    top: 40px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    z-index: 5;
+}
+
+.sect-nav-panel button {
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    background: rgba(0,0,0,0.5);
+    border: 1px solid var(--verdantia-highlight);
+    color: var(--verdantia-parchment);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.75rem;
+}
+
+.sect-nav-panel button.active {
+    background: var(--verdantia-jade);
+    color: #fff;
+    box-shadow: 0 0 6px var(--verdantia-highlight);
+}
+
 
 .zone {
     position: absolute;


### PR DESCRIPTION
## Summary
- implement sect navigation panel in sect map
- style navigation buttons as circular icons
- hook up work button to task overlay and map button to exploration overlay
- add placeholder overlays for other nav buttons

## Testing
- `npm install`
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_6879c04390bc83269d6720b98186049c