### PR TITLE
Add sect work overlay

### DIFF
--- a/attributes.js
+++ b/attributes.js
@@ -35,7 +35,7 @@ export const attributes = {
 };
 
 export function strengthXpMultiplier(task) {
-  const affected = ['Log Pine', 'Mining', 'Smithing'];
+  const affected = ['Gather Softwood', 'Mining', 'Smithing'];
   return affected.includes(task) ? 1 + attributes.Strength.points * 0.1 : 1;
 }
 
@@ -45,7 +45,7 @@ export function enduranceXpMultiplier(task) {
 }
 
 export function dexterityXpMultiplier(task) {
-  const affected = ['Woodcutting', 'Gather Fruit'];
+  const affected = ['Gather Softwood', 'Gather Fruit'];
   return affected.includes(task) ? 1 + attributes.Dexterity.points * 0.1 : 1;
 }
 

--- a/docs/09-skill-proficiency.md
+++ b/docs/09-skill-proficiency.md
@@ -6,7 +6,7 @@
 | Task         | Base XP/s  |
 |--------------|-----------:|
 | Gather Fruit | 0.005      |
-| Log Pine     | 0.0047     |
+| Gather Softwood     | 0.0047     |
 | Research     | 0.008      |
 | Chant        | 0.333      |
 | Building     | 1.000      |
@@ -15,7 +15,7 @@
 | Task        | To Lv 10   | To Lv 30    |
 |-------------|-----------:|------------:|
 | Gather Fruit| ~3 days    | ~137 days   |
-| Log Pine    | ~3 days 5 h| ~146 days   |
+| Gather Softwood    | ~3 days 5 h| ~146 days   |
 | Research    | ~1 day 21 h| ~85 days    |
 | Chant       | ~1 h       | ~2 days     |
 | Building    | ~21 min    | ~16 h       |

--- a/script.js
+++ b/script.js
@@ -213,7 +213,7 @@ const REST_TIME_SECONDS = 300; // health fully restored over 5 minutes
 
 const TASK_ICONS = {
   'Gather Fruit': '🍎',
-  'Log Pine': '🪵',
+  'Gather Softwood': '🪵',
   Hunt: '🏹',
   Building: '⚒️',
   Research: '🔬',
@@ -225,7 +225,7 @@ const TASK_ICONS = {
 
 const TASK_GROUPS = {
   'Gather Fruit': 'Gathering',
-  'Log Pine': 'Logging',
+  'Gather Softwood': 'Logging',
   Hunt: 'Hunting',
   'Building': 'Building',
   'Research': 'Researching',
@@ -353,7 +353,7 @@ function createLabeledBar(icon, value, max, color) {
 
 function getTaskEta(d) {
   const task = d.incapacitated ? 'Resting' : sectState.discipleTasks[d.id] || 'Idle';
-  if (task === 'Gather Fruit' || task === 'Log Pine') {
+  if (task === 'Gather Fruit' || task === 'Gather Softwood') {
     const progress = sectState.discipleProgress[d.id] || 0;
     const baseSeconds = task === 'Gather Fruit' ? FRUIT_CYCLE_SECONDS : PINE_LOG_CYCLE_SECONDS;
     const cycleAmount = task === 'Gather Fruit' ? FRUIT_CYCLE_AMOUNT : PINE_LOG_CYCLE_AMOUNT;
@@ -1222,7 +1222,7 @@ function tickSect(delta) {
     } else {
       d.stamina = Math.min(maxStamina, d.stamina + regenRate * dt);
     }
-    if (task === 'Gather Fruit' || task === 'Log Pine') {
+    if (task === 'Gather Fruit' || task === 'Gather Softwood') {
       if (!sectState.discipleProgress[d.id]) sectState.discipleProgress[d.id] = 0;
       sectState.discipleProgress[d.id] += dt;
       const baseSeconds = task === 'Gather Fruit' ? FRUIT_CYCLE_SECONDS : PINE_LOG_CYCLE_SECONDS;
@@ -1397,7 +1397,7 @@ function updateTaskProgressDisplay() {
     const taskName = d.incapacitated
       ? 'Resting'
       : sectState.discipleTasks[d.id] || 'Idle';
-    if (taskName === 'Gather Fruit' || taskName === 'Log Pine') {
+    if (taskName === 'Gather Fruit' || taskName === 'Gather Softwood') {
       const progress = sectState.discipleProgress[d.id] || 0;
       const baseSeconds =
         taskName === 'Gather Fruit' ? FRUIT_CYCLE_SECONDS : PINE_LOG_CYCLE_SECONDS;
@@ -1564,9 +1564,9 @@ function updateDiscipleGather(id, el) {
   const progress = sectState.discipleProgress[id] || 0;
   const task = sectState.discipleTasks[id];
   const baseSeconds =
-    task === 'Log Pine' ? PINE_LOG_CYCLE_SECONDS : FRUIT_CYCLE_SECONDS;
+    task === 'Gather Softwood' ? PINE_LOG_CYCLE_SECONDS : FRUIT_CYCLE_SECONDS;
   const cycleAmount =
-    task === 'Log Pine' ? PINE_LOG_CYCLE_AMOUNT : FRUIT_CYCLE_AMOUNT;
+    task === 'Gather Softwood' ? PINE_LOG_CYCLE_AMOUNT : FRUIT_CYCLE_AMOUNT;
   const d = sectSystem.disciples.find(x => x.id === id);
   const group = TASK_GROUPS[task];
   const lvl = getTaskSkillProgress(
@@ -1623,7 +1623,7 @@ function startDiscipleMovement() {
       } else {
         el.classList.remove('incapacitated');
         const task = sectState.discipleTasks[d.id];
-        if (task === 'Gather Fruit' || task === 'Log Pine')
+        if (task === 'Gather Fruit' || task === 'Gather Softwood')
           updateDiscipleGather(d.id, el);
         else moveDisciple(el);
       }
@@ -1709,7 +1709,7 @@ function renderColonyInfo() {
   }
   const taskList = document.createElement('div');
   taskList.className = 'disciple-skill-list';
-  const tasks = ['Idle', 'Gather Fruit', 'Log Pine', 'Hunt', 'Building'];
+  const tasks = ['Idle', 'Gather Fruit', 'Gather Softwood', 'Hunt', 'Building'];
   if (sectState.buildings.researchTable > 0) tasks.push('Research');
   if (sectState.buildings.chantingHall > 0) tasks.push('Chant');
   if (systems.explorationUnlocked) tasks.push('Exploration');
@@ -2042,14 +2042,14 @@ function buildDiscipleStatusView(d) {
       effect:
         `Melee Damage ×${(1 + 0.05 * (d.strength - 1)).toFixed(2)}, ` +
         `+${Math.floor((d.strength - 1) / 2)} Inventory Slots`,
-      skills: 'Log Pine, Mining & Smithing'
+      skills: 'Gather Softwood, Mining & Smithing'
     },
     {
       label: 'Dexterity',
       value: d.dexterity,
       base: d.baseDexterity ?? 1,
       effect: `Attack Speed ×${(1 + 0.05 * (d.dexterity - 1)).toFixed(2)}`,
-      skills: 'Woodcutting & Gather Fruit'
+      skills: 'Gather Softwood & Gather Fruit'
     },
     {
       label: 'Intelligence',
@@ -2086,7 +2086,7 @@ function buildDiscipleLifeStatsView(d) {
   const skillMap = sectState.discipleSkills[d.id] || {};
   const tasks = [
     { name: 'Gather Fruit', effect: 'yield' },
-    { name: 'Log Pine', effect: 'yield' },
+    { name: 'Gather Softwood', effect: 'yield' },
     { name: 'Building', effect: 'speed' },
     { name: 'Research', effect: 'research pts' },
     { name: 'Chant', effect: 'potency' }
@@ -2096,7 +2096,7 @@ function buildDiscipleLifeStatsView(d) {
     const xp = skillMap[groupKey] || 0;
     const prog = getTaskSkillProgress(xp);
     const row = document.createElement('div');
-    const isGather = t.name === 'Gather Fruit' || t.name === 'Log Pine';
+    const isGather = t.name === 'Gather Fruit' || t.name === 'Gather Softwood';
     const mult = 1 + (isGather ? 0.05 : 0.02) * prog.level;
     row.textContent = `${t.name} Lv ${prog.level} (×${mult.toFixed(2)} ${t.effect})`;
     body.appendChild(row);
@@ -2293,7 +2293,7 @@ function buildDiscipleProficiencyView(d) {
   const container = document.createElement('div');
   const groups = {
     Gathering: ['Gather Fruit'],
-    Logging: ['Log Pine'],
+    Logging: ['Gather Softwood'],
     Building: ['Building'],
     Chanting: ['Chant'],
     Researching: ['Research']
@@ -2490,7 +2490,7 @@ function buildDiscipleSkillsList(d) {
   const container = document.createElement('div');
   const groups = {
     Gathering: ['Gather Fruit'],
-    Logging: ['Log Pine'],
+    Logging: ['Gather Softwood'],
     Building: ['Building'],
     Chanting: ['Chant'],
     Researching: ['Research']
@@ -2672,31 +2672,74 @@ function openExplorationOverlay() {
 }
 
 let workOverlay = null;
+let workOverlaySelected = null;
 function openWorkOverlay() {
   if (workOverlay) return;
-  workOverlay = createOverlay({ className: "work-overlay" });
-  workOverlay.onClose(() => { workOverlay = null; });
-  const { box } = workOverlay;
-  const closeBtn = document.createElement("button");
-  closeBtn.className = "close-btn";
-  closeBtn.innerHTML = "&times;";
-  closeBtn.addEventListener("click", workOverlay.close);
-  box.appendChild(closeBtn);
-  const header = document.createElement("div");
-  header.className = "panel-heading";
-  header.textContent = "Work";
-  box.appendChild(header);
-  const gf = document.createElement("button");
-  gf.textContent = "Gather Fruit";
-  gf.addEventListener("click", () => {
-    sectSystem.disciples.forEach(d => {
-      sectState.discipleTasks[d.id] = "Gather Fruit";
-    });
-    if (typeof renderColonyTasks === "function") renderColonyTasks();
-    if (typeof renderColonyInfo === "function") renderColonyInfo();
-    workOverlay.close();
+  workOverlay = createOverlay({ className: 'work-overlay' });
+  workOverlay.onClose(() => {
+    workOverlay = null;
+    workOverlaySelected = null;
   });
-  box.appendChild(gf);
+  const { box } = workOverlay;
+  const closeBtn = document.createElement('button');
+  closeBtn.className = 'close-btn';
+  closeBtn.innerHTML = '&times;';
+  closeBtn.addEventListener('click', workOverlay.close);
+  box.appendChild(closeBtn);
+
+  const header = document.createElement('div');
+  header.className = 'panel-heading';
+  header.textContent = 'Work';
+  box.appendChild(header);
+
+  const content = document.createElement('div');
+  content.className = 'work-content';
+  box.appendChild(content);
+
+  const left = document.createElement('div');
+  left.className = 'work-disciples';
+  content.appendChild(left);
+
+  const right = document.createElement('div');
+  right.className = 'work-tasks';
+  content.appendChild(right);
+
+  function render() {
+    left.innerHTML = '';
+    sectSystem.disciples.forEach(d => {
+      const card = createSectDiscipleCard(d);
+      if (d.id === workOverlaySelected) card.classList.add('selected');
+      card.addEventListener('click', () => {
+        workOverlaySelected = d.id;
+        render();
+      });
+      left.appendChild(card);
+    });
+
+    right.innerHTML = '';
+    const tasks = ['Gather Fruit', 'Gather Softwood'];
+    tasks.forEach(t => {
+      const btn = document.createElement('button');
+      btn.textContent = t;
+      btn.addEventListener('click', () => {
+        if (workOverlaySelected == null) return;
+        const prev = sectState.discipleTasks[workOverlaySelected];
+        sectState.discipleTasks[workOverlaySelected] = t;
+        discipleGatherPhase[workOverlaySelected] = -1;
+        if (prev === 'Chant' && t !== 'Chant') {
+          delete sectState.chantAssignments[workOverlaySelected];
+          if (typeof renderConstructCards === 'function') {
+            renderConstructCards();
+          }
+        }
+        if (typeof renderColonyTasks === 'function') renderColonyTasks();
+        render();
+      });
+      right.appendChild(btn);
+    });
+  }
+
+  render();
 }
 
 function openPlaceholderOverlay(title) {

--- a/style.css
+++ b/style.css
@@ -666,6 +666,48 @@ body.darkenshift-mode .tabsContainer button.active {
     justify-content: space-between;
 }
 
+.work-overlay .overlay-box {
+    max-width: 600px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.work-content {
+    display: flex;
+    gap: 8px;
+}
+
+.work-disciples, .work-tasks {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    max-height: 300px;
+    overflow-y: auto;
+}
+
+.work-overlay .close-btn {
+    position: absolute;
+    top: 4px;
+    right: 4px;
+    width: 16px;
+    height: 16px;
+    background: #c33;
+    color: #fff;
+    border: none;
+    border-radius: 50%;
+    font-size: 12px;
+    line-height: 14px;
+    text-align: center;
+    cursor: pointer;
+}
+
+.work-disciples .sect-disciple-card.selected {
+    background: #fbf6e0;
+    color: #000;
+}
+
 .water-row.negative {
     color: #ff8888;
 }


### PR DESCRIPTION
## Summary
- rename the woodcutting task to **Gather Softwood**
- adjust attribute multipliers for the renamed task
- update skill proficiency docs
- implement a task management overlay for the Work nav button
- add styles for the new overlay

## Testing
- `npm run lint`
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_6879c73665288326b86b5378aba49db6