### PR TITLE
Add charisma and potential attributes

### DIFF
--- a/attributes.js
+++ b/attributes.js
@@ -31,6 +31,21 @@ export const attributes = {
     get constructPotencyMultiplier() {
       return 1 + 0.03 * this.points;
     }
+  },
+  Charisma: {
+    points: 0,
+    get recruitChanceMultiplier() {
+      return 1 + 0.05 * this.points;
+    },
+    get diplomacyBonus() {
+      return 1 + 0.05 * this.points;
+    }
+  },
+  Potential: {
+    value: 0,
+    get innerCauldronSize() {
+      return Math.round(this.value * 500);
+    }
   }
 };
 

--- a/disciple.js
+++ b/disciple.js
@@ -16,6 +16,7 @@ export default class Disciple {
     this.endurance = attributes.endurance || 0;
     this.intelligence = attributes.intelligence || 0;
     this.charisma = attributes.charisma || 0;
+    this.potential = attributes.potential || 0;
     this.defense = 1;
     this.lastTab = 'general';
     this.updateCombatStats();

--- a/discipleAttributes.js
+++ b/discipleAttributes.js
@@ -9,5 +9,9 @@ export function generateDiscipleAttributes() {
     const idx = Math.floor(Math.random() * attrs.length);
     result[attrs[idx]] += 1;
   }
+  const socialSkill = Math.floor(Math.random() * 100) + 1; // 1-100
+  result.potential =
+    socialSkill / 20 +
+    (result.strength + result.dexterity + result.endurance + result.intelligence + result.charisma) / 10;
   return result;
 }

--- a/docs/19-attributes.md
+++ b/docs/19-attributes.md
@@ -1,117 +1,35 @@
-Attributes
-
-
-
-Character basic attributes which are difficult to change. Determine many in game mechanics
-
-
-
-
-
-Dexterity 👁️
-
-
-
-Used to determine yield of the following task:
-
-
-
-Gathering, hunting
-
-
-
-Used to determine chance to find locations while travelling:
-
-
-
-Determines % to gain rare items during gathering
-
-
-
-
-
-Endurance 💪
-
-
-
-
-
-Used to determine speed (and yield if applicable) of the following task:
-
-
-
-Building, farming
-
-
-
-Used to determine general health
-
-
-
-Used to determine defense in battle
-
-
-
-Strength ⚔️
-
-
-
-Used to determine yield of the following life skills:
-
-
-
-Woodcutting, hunting, mining
-
-
-
-Intelligence 🧙
-
-
-
-Affects Water sense
-
-
-
-Determines initial learning speed
-
-
-
-Afects chanting and researching
-
-
-
-Charisma 🗣️
-
-
-
-Affects recruiting disciples % and their potential stats for immortals
-
-
-
-Affects diplomacy
-
-
-
-
-
-Potential
-
-
-
-Determined by other stats and a random added number based on the power of the recruiter immortal
-
-Potential= S / 20 + (5 stats summed) / 10
-
-S= social skill from 1-100 
-
-
-
-Determines maximium size of inner cauldron:
-
-Maximum size of Inner Cauldron = Innate Potential * 500 
-
-Min/Max of stat: 0.714 - 9.286 (Inner Cauldron size: 357 - 5143 Max Water)
-
-
-
-
+# 19 – Attributes
+
+Character basic attributes which are difficult to change. They determine many in-game mechanics.
+
+## Dexterity 👁️
+- Determines yield for Gathering and Hunting
+- Determines chance to discover locations while traveling
+- Increases the chance to gain rare items during gathering
+
+## Endurance 💪
+- Determines speed (and yield when applicable) for Building and Farming
+- Governs general health
+- Contributes to defense in battle
+
+## Strength ⚔️
+- Determines yield for Woodcutting, Hunting and Mining
+
+## Intelligence 🧙
+- Affects Water Sense
+- Determines initial learning speed
+- Affects Chanting and Researching
+
+## Charisma 🗣️
+- Improves disciple recruitment chances and influences their potential
+- Affects diplomacy
+
+## Potential
+- Calculated from other attributes and the recruiter's social skill
+- `Potential = S / 20 + (Strength + Dexterity + Endurance + Intelligence + Charisma) / 10`
+  - `S` is the recruiter's social skill from 1–100
+- Determines maximum size of the Inner Cauldron
+  - `Maximum size = Potential × 500`
+  - Range: 0.714–9.286 (Inner Cauldron size 357–5143 Max Water)
+
+> The Inner Cauldron is a cultivation feature that increases a disciple's maximum Water.

--- a/script.js
+++ b/script.js
@@ -2067,6 +2067,20 @@ function buildDiscipleStatusView(d) {
         `Regen ×${(1 + 0.01 * (d.endurance - 1)).toFixed(2)}, ` +
         `+${10 * (d.endurance - 1)} HP`,
       skills: 'Building, Defending & Combat'
+    },
+    {
+      label: 'Charisma',
+      value: d.charisma,
+      base: d.baseCharisma ?? 1,
+      effect: `Recruit Chance ×${(1 + 0.05 * (d.charisma - 1)).toFixed(2)}`,
+      skills: 'Recruiting & Diplomacy'
+    },
+    {
+      label: 'Potential',
+      value: d.potential,
+      base: d.basePotential ?? d.potential,
+      effect: `Inner Cauldron Size ${d.potential * 500}`,
+      skills: 'Cultivation'
     }
   ];
   const attrContainer = document.createElement('div');

--- a/sect.js
+++ b/sect.js
@@ -471,7 +471,9 @@ const constructEffects = {
         strength: 1 + bonus.strength,
         dexterity: 1 + bonus.dexterity,
         endurance: 1 + bonus.endurance,
-        intelligence: 1 + bonus.intelligence
+        intelligence: 1 + bonus.intelligence,
+        charisma: 1 + bonus.charisma,
+        potential: bonus.potential
       };
       const newDisc = new Disciple({ id: targetIdx, name: `Disciple ${targetIdx}`, attributes: attrs });
       initializeDisciple(newDisc);

--- a/utils/discipleInit.js
+++ b/utils/discipleInit.js
@@ -11,6 +11,7 @@ export function initializeDisciple(d) {
   if (d.endurance === undefined) d.endurance = 1;
   if (d.intelligence === undefined) d.intelligence = 1;
   if (d.charisma === undefined) d.charisma = 1;
+  if (d.potential === undefined) d.potential = 1;
   if (d.globalLevel === undefined) d.globalLevel = 0;
   if (d.combatXp === undefined) d.combatXp = 0;
   if (d.baseStrength === undefined) d.baseStrength = d.strength;
@@ -18,6 +19,7 @@ export function initializeDisciple(d) {
   if (d.baseEndurance === undefined) d.baseEndurance = d.endurance;
   if (d.baseIntelligence === undefined) d.baseIntelligence = d.intelligence;
   if (d.baseCharisma === undefined) d.baseCharisma = d.charisma;
+  if (d.basePotential === undefined) d.basePotential = d.potential;
   if (d.incapacitated === undefined) d.incapacitated = false;
   if (!d.name) d.name = `Disciple ${d.id}`;
   if (d.inventorySlots === undefined) d.inventorySlots = 10;


### PR DESCRIPTION
## Summary
- define Charisma and Potential in attributes
- compute potential for new disciples
- include charisma and potential when recruiting disciples
- store potential in disciples and initialization
- show charisma and potential values in the UI
- update attribute documentation with bullet lists and inner cauldron note

## Testing
- `npm run lint`
- `npm test` *(fails: Error: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_6879ca24a4a48326a513963481a2c54a