### PR TITLE
Add Water Sense skill and water stat for disciples

### DIFF
--- a/docs/20-skills.md
+++ b/docs/20-skills.md
@@ -7,11 +7,15 @@ Each skill has its own progression, yield formula, and spot data. Skills gain XP
 
 09.1 Water Sense
 
+Base Water: 100, 1 Water/s regen
+
 Max Water Bonus: +2.4% of base Max Water per level
 
-Water Absorption: +5% of max absorption rate per level
+Water Absorption: +5% of Regen rate
 
 Cultivation Speed: +4% of base speed per level
+
+Skill XP gained by cultivating
 
 
 

--- a/script.js
+++ b/script.js
@@ -47,6 +47,10 @@ import {
   calculateMaxStamina,
   calculateStaminaRegen
 } from './utils/stamina.js';
+import {
+  calculateMaxWater,
+  calculateWaterRegen
+} from './utils/water.js';
 import { initializeDisciple } from './utils/discipleInit.js';
 import { initializeSect } from './utils/sectInit.js';
 import {
@@ -487,7 +491,8 @@ function ensureDiscipleSkills(id) {
       Building: 0,
       Researching: 0,
       Chanting: 0,
-      Exploration: 0
+      Exploration: 0,
+      WaterSense: 0
     };
   }
 }
@@ -1194,6 +1199,11 @@ function tickSect(delta) {
   sectSystem.disciples.forEach(d => {
     ensureDiscipleSkills(d.id);
     ensureDiscipleConstructXp(d.id);
+    const waterXp = sectState.discipleSkills[d.id].WaterSense || 0;
+    const waterLvl = getTaskSkillProgress(waterXp).level;
+    const maxWater = calculateMaxWater(waterLvl);
+    const waterRegen = calculateWaterRegen(waterLvl);
+    d.water = Math.min(maxWater, Math.max(0, d.water + waterRegen * dt));
     const maxStamina = calculateMaxStamina(d.endurance);
     const regenRate = calculateStaminaRegen(d.endurance);
     d.stamina = Math.min(maxStamina, Math.max(0, d.stamina));
@@ -2179,6 +2189,19 @@ function buildDiscipleGeneralView(d) {
   stamRate.textContent = ` (+${calculateStaminaRegen(d.endurance).toFixed(2)}/s)`;
   staminaRow.appendChild(stamRate);
   vit.appendChild(staminaRow);
+  const waterLvl = getTaskSkillProgress(
+    sectState.discipleSkills[d.id]?.WaterSense || 0
+  ).level;
+  const waterRow = makeStatRow(
+    'Water',
+    d.water,
+    calculateMaxWater(waterLvl),
+    'linear-gradient(90deg,#39f,#6cf)'
+  );
+  const waterRate = document.createElement('span');
+  waterRate.textContent = ` (+${calculateWaterRegen(waterLvl).toFixed(2)}/s)`;
+  waterRow.appendChild(waterRate);
+  vit.appendChild(waterRow);
   const hungerRow = makeStatRow(
     'Hunger',
     d.hunger,
@@ -2315,14 +2338,16 @@ function buildDiscipleProficiencyView(d) {
     Logging: ['Gather Softwood'],
     Building: ['Building'],
     Chanting: ['Chant'],
-    Researching: ['Research']
+    Researching: ['Research'],
+    WaterSense: []
   };
   const effects = {
     Gathering: 'yield',
     Logging: 'yield',
     Building: 'speed',
     Chanting: 'potency',
-    Researching: 'research pts'
+    Researching: 'research pts',
+    WaterSense: 'water'
   };
   Object.entries(groups).forEach(([name, tasks]) => {
     const xp = sectState.discipleSkills[d.id]?.[name] || 0;
@@ -2427,14 +2452,16 @@ function openDiscipleOverlay(d) {
       const view = buildDiscipleGeneralView(d);
       content.appendChild(view);
       const rows = view.querySelectorAll('.stat-row');
-      if (rows.length >= 3) {
+      if (rows.length >= 4) {
         discipleOverlayData.bars = {
           healthFill: rows[0].querySelector('.bar-fill'),
           healthVal: rows[0].lastElementChild,
           staminaFill: rows[1].querySelector('.bar-fill'),
           staminaVal: rows[1].lastElementChild,
-          hungerFill: rows[2].querySelector('.bar-fill'),
-          hungerVal: rows[2].lastElementChild
+          waterFill: rows[2].querySelector('.bar-fill'),
+          waterVal: rows[2].lastElementChild,
+          hungerFill: rows[3].querySelector('.bar-fill'),
+          hungerVal: rows[3].lastElementChild
         };
       }
     } else if (active === 'proficiency') {
@@ -2491,6 +2518,10 @@ function updateDiscipleOverlayBars() {
   if (!data.disciple || !data.bars) return;
   const d = data.disciple;
   const maxStamina = calculateMaxStamina(d.endurance);
+  const waterLvl = getTaskSkillProgress(
+    sectState.discipleSkills[d.id]?.WaterSense || 0
+  ).level;
+  const maxWater = calculateMaxWater(waterLvl);
   if (data.bars.healthFill)
     data.bars.healthFill.style.width = `${(d.health / DISCIPLE_MAX_HEALTH) * 100}%`;
   if (data.bars.healthVal)
@@ -2499,6 +2530,10 @@ function updateDiscipleOverlayBars() {
     data.bars.staminaFill.style.width = `${(d.stamina / maxStamina) * 100}%`;
   if (data.bars.staminaVal)
     data.bars.staminaVal.textContent = `${Math.round(d.stamina)}/${Math.round(maxStamina)}`;
+  if (data.bars.waterFill)
+    data.bars.waterFill.style.width = `${(d.water / maxWater) * 100}%`;
+  if (data.bars.waterVal)
+    data.bars.waterVal.textContent = `${Math.round(d.water)}/${Math.round(maxWater)}`;
   if (data.bars.hungerFill)
     data.bars.hungerFill.style.width = `${(d.hunger / 20) * 100}%`;
   if (data.bars.hungerVal)

--- a/utils/discipleInit.js
+++ b/utils/discipleInit.js
@@ -1,9 +1,12 @@
 import Disciple from '../disciple.js';
+import { calculateMaxWater } from './water.js';
 
 export function initializeDisciple(d) {
   if (!d) return d;
   if (d.health === undefined) d.health = 10;
   if (d.stamina === undefined) d.stamina = 10;
+  if (d.water === undefined) d.water = calculateMaxWater(0);
+  if (d.waterSenseXp === undefined) d.waterSenseXp = 0;
   if (d.hunger === undefined) d.hunger = 20;
   if (d.power === undefined) d.power = 1;
   if (d.strength === undefined) d.strength = 1;

--- a/utils/water.js
+++ b/utils/water.js
@@ -1,0 +1,14 @@
+export const BASE_WATER = 100;
+export const BASE_REGEN_PER_SEC = 1;
+
+export function calculateMaxWater(waterSenseLevel = 0) {
+  return BASE_WATER * (1 + 0.024 * waterSenseLevel);
+}
+
+export function calculateWaterRegen(waterSenseLevel = 0) {
+  return BASE_REGEN_PER_SEC * (1 + 0.05 * waterSenseLevel);
+}
+
+export function cultivationSpeedMultiplier(waterSenseLevel = 0) {
+  return 1 + 0.04 * waterSenseLevel;
+}


### PR DESCRIPTION
## Summary
- introduce a Water Sense skill with base water rules
- create water stat utilities and initialize water for disciples
- render water bar in disciple overlay
- regenerate and display disciple water based on Water Sense level
- document Water Sense skill

## Testing
- `npm test` *(fails: No test files found)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687a3270a2e88326ad9985e37e605e8f