### PR TITLE
Update XP gain rules

### DIFF
--- a/attributes.js
+++ b/attributes.js
@@ -49,22 +49,18 @@ export const attributes = {
   }
 };
 
-export function strengthXpMultiplier(task) {
-  const affected = ['Gather Softwood', 'Mining', 'Smithing'];
-  return affected.includes(task) ? 1 + attributes.Strength.points * 0.1 : 1;
+export function strengthXpMultiplier() {
+  return 1;
 }
 
-export function enduranceXpMultiplier(task) {
-  const affected = ['Building', 'Defending', 'Combat'];
-  return affected.includes(task) ? 1 + attributes.Endurance.points * 0.1 : 1;
+export function enduranceXpMultiplier() {
+  return 1;
 }
 
-export function dexterityXpMultiplier(task) {
-  const affected = ['Gather Softwood', 'Gather Fruit'];
-  return affected.includes(task) ? 1 + attributes.Dexterity.points * 0.1 : 1;
+export function dexterityXpMultiplier() {
+  return 1;
 }
 
-export function intelligenceXpMultiplier(task) {
-  const affected = ['Chant', 'Research'];
-  return affected.includes(task) ? 1 + attributes.Intelligence.points * 0.1 : 1;
+export function intelligenceXpMultiplier() {
+  return 0.5 + 0.15 * attributes.Intelligence.points;
 }

--- a/docs/09-skill-proficiency.md
+++ b/docs/09-skill-proficiency.md
@@ -22,5 +22,9 @@
 
 ### Affinity & Intelligence Example
 - **Formula**: `XP = BaseXP × IntMultiplier × Affinity`
-- E.g. Int=5 → 1.5×, Gathering affinity=3× → total **4.5×**  
+- E.g. Int=5 → 1.5×, Gathering affinity=3× → total **4.5×**
   – 10 XP action → 45 XP actual
+
+Each disciple rolls two random skill affinities when created. These grant either
+1.5× or 3× XP for the chosen skills. Attributes other than Intelligence do not
+affect proficiency gain.

--- a/docs/19-attributes.md
+++ b/docs/19-attributes.md
@@ -19,6 +19,7 @@ Character basic attributes which are difficult to change. They determine many in
 - Affects Water Sense
 - Determines initial learning speed
 - Affects Chanting and Researching
+- Only Intelligence modifies skill XP gain. Other attributes no longer increase proficiency XP rates.
 
 ## Charisma 🗣️
 - Improves disciple recruitment chances and influences their potential

--- a/script.js
+++ b/script.js
@@ -34,9 +34,6 @@ import { runAnimation } from "./utils/animation.js";
 import { initCore, refreshCore } from './core.js';
 import {
   attributes,
-  strengthXpMultiplier,
-  enduranceXpMultiplier,
-  dexterityXpMultiplier,
   intelligenceXpMultiplier
 } from './attributes.js';
 import { createOverlay } from './ui/overlay.js';
@@ -204,12 +201,12 @@ const SOFTWOOD_CYCLE_SECONDS = 215;
 const SOFTWOOD_CYCLE_AMOUNT = 10;
 const DAILY_FRUIT_CONSUMPTION = 20; // fruits eaten by each disciple per day
 
-// XP earned for disciple tasks
-const FRUIT_XP_PER_CYCLE = 25;
-const LOG_XP_PER_CYCLE = 25;
-const BUILD_XP_RATE = 0.1; // per second
-const RESEARCH_XP_PER_CYCLE = 20;
-const CHANT_XP_PER_CYCLE = 0.5;
+// XP earned for disciple tasks (BaseXP × cycle length)
+const FRUIT_XP_PER_CYCLE = 1; // 0.005 XP/s × 200s
+const LOG_XP_PER_CYCLE = 1; // 0.0047 XP/s × 215s ≈ 1
+const BUILD_XP_RATE = 1; // per second
+const RESEARCH_XP_PER_CYCLE = 1; // 0.008 XP/s × ~125s ≈ 1
+const CHANT_XP_PER_CYCLE = 1.665; // 0.333 XP/s × 5s
 const EXPLORATION_CYCLE_SECONDS = 150;
 const STAMINA_DRAIN_PER_EXPLORATION = 1;
 const DISCIPLE_MAX_HEALTH = 10;
@@ -1277,11 +1274,7 @@ function tickSect(delta) {
           sectState.softwood += deposit;
         }
         checkBuildingUnlock();
-        const mult =
-          strengthXpMultiplier(task) *
-          enduranceXpMultiplier(task) *
-          dexterityXpMultiplier(task) *
-          intelligenceXpMultiplier(task);
+        const mult = intelligenceXpMultiplier();
         const baseXp = task === 'Gather Fruit' ? FRUIT_XP_PER_CYCLE : LOG_XP_PER_CYCLE;
         const groupKey = TASK_GROUPS[task];
         addSkillXp(d, groupKey, cycles * baseXp * mult);
@@ -1302,7 +1295,7 @@ function tickSect(delta) {
         addSkillXp(
           d,
           'Researching',
-          ptsBase * RESEARCH_XP_PER_CYCLE
+          ptsBase * RESEARCH_XP_PER_CYCLE * intelligenceXpMultiplier()
         );
         if (!systems.researchUnlocked) {
           systems.researchUnlocked = true;
@@ -1323,7 +1316,7 @@ function tickSect(delta) {
           const lvl = getTaskSkillProgress(xp).level;
           const pot = 0.3 * (1 + 0.02 * lvl) * attributes.Intelligence.constructPotencyMultiplier;
           castConstruct(target, null, pot, d.id);
-          addSkillXp(d, 'Chanting', CHANT_XP_PER_CYCLE);
+            addSkillXp(d, 'Chanting', CHANT_XP_PER_CYCLE * intelligenceXpMultiplier());
         }
       }
       const spend = Math.min(sectSystem.resources.water.current, dt);
@@ -1831,7 +1824,7 @@ function tickBuilding(dt) {
       const xp = sectState.discipleSkills[d.id]['Building'];
       const lvl = getTaskSkillProgress(xp).level;
       speed += 1 + 0.02 * lvl;
-      addSkillXp(d, 'Building', BUILD_XP_RATE * dt);
+        addSkillXp(d, 'Building', BUILD_XP_RATE * dt * intelligenceXpMultiplier());
     }
   });
   if (speed === 0) return;


### PR DESCRIPTION
## Summary
- refactor skill XP multipliers to rely solely on Intelligence
- adjust XP constants to match base XP values
- document new Intelligence-only XP rules and explain affinities

## Testing
- `npm run lint`
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_687a44847cb88326a24d19263fb75480