### PR TITLE
Add building task to work menu

### DIFF
--- a/script.js
+++ b/script.js
@@ -2792,6 +2792,7 @@ function openWorkOverlay() {
 
     right.innerHTML = '';
     const tasks = ['Gather Fruit', 'Gather Softwood'];
+    if (systems.buildingUnlocked) tasks.push('Building');
     tasks.forEach(t => {
       const btn = document.createElement('button');
       btn.textContent = t;


### PR DESCRIPTION
## Summary
- allow disciples to be assigned to *Building* from the Work overlay once buildings are unlocked

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_687a4558786c8326a57e3383b3fd0f12