### PR TITLE
Fix runAnimation for invalid elements

### DIFF
--- a/utils/animation.js
+++ b/utils/animation.js
@@ -1,5 +1,15 @@
 export function runAnimation(el, className, timeout) {
   if (!el) return Promise.resolve();
+
+  // Allow passing a NodeList/Array of elements
+  if (typeof el.forEach === 'function' && !el.classList) {
+    return Promise.all(
+      Array.from(el, node => runAnimation(node, className, timeout))
+    );
+  }
+
+  if (!el.classList) return Promise.resolve();
+
   // Restart the animation if the class is already present
   el.classList.remove(className);
   // Force reflow so the removal is applied


### PR DESCRIPTION
## Summary
- guard `runAnimation` against invalid DOM objects

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_687a93abd6a083268cad17081db62b3f