### PR TITLE
Add minimal game modules

### DIFF
--- a/debugTools.js
+++ b/debugTools.js
@@ -17,7 +17,8 @@ import {
   loadGame,
   startNewGame,
   currentEnemy,
-  cDealerDamage
+  cDealerDamage,
+  setTimeScale
 } from './script.js';
 
 export const devTools = {
@@ -62,7 +63,7 @@ export const devTools = {
     renderPlayerStats(stats);
   },
   toggleFastMode: () => {
-    timeScale = timeScale === 1 ? FAST_MODE_SCALE : 1;
+    setTimeScale(timeScale === 1 ? FAST_MODE_SCALE : 1);
   },
   unlockExploration: () => {
     systems.explorationUnlocked = true;

--- a/game/combat.js
+++ b/game/combat.js
@@ -1,0 +1,1 @@
+export function init() {}

--- a/game/debug.js
+++ b/game/debug.js
@@ -1,0 +1,1 @@
+export function init() {}

--- a/game/disciples.js
+++ b/game/disciples.js
@@ -1,0 +1,1 @@
+export function init() {}

--- a/game/ui.js
+++ b/game/ui.js
@@ -1,0 +1,1 @@
+export function init() {}

--- a/script.js
+++ b/script.js
@@ -70,6 +70,11 @@ import {
   updateBloodSplat
 } from "./rendering.js";
 
+import { init as initCombat } from "./game/combat.js";
+import { init as initUi } from "./game/ui.js";
+import { init as initDisciples } from "./game/disciples.js";
+import { init as initDebug } from "./game/debug.js";
+
 
 
 // --- Game State ---
@@ -638,6 +643,9 @@ const playerStats = {
 // Debug time scaling
 export const FAST_MODE_SCALE = 10;
 export let timeScale = 1;
+export function setTimeScale(value) {
+  timeScale = value;
+}
 
 // Definitions for purchasable upgrades and their effects are
 // centralized in cardUpgrades.js
@@ -3107,6 +3115,10 @@ document.addEventListener("DOMContentLoaded", () => {
   initSect();
   initTabs();
   initPollen();
+  initCombat();
+  initUi();
+  initDisciples();
+  initDebug();
   window.addEventListener('location-discovered', e => addDiscoveredLocation(e.detail.name));
   loadGame();
   if (sectSystem.disciples.length === 0) {


### PR DESCRIPTION
## Summary
- scaffold empty modules in `game/`
- import new modules in `script.js`
- hook module `init()` functions on DOMContentLoaded
- expose `setTimeScale()` setter and update dev tools

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687acdbb568c8326a6e16bd5f0776be9