### PR TITLE
Refactor combat state

### DIFF
--- a/game/combat.js
+++ b/game/combat.js
@@ -1,1 +1,45 @@
+import { currentEnemy, stageData } from '../script.js';
+import { dealerLifeDisplay } from './ui.js';
+import { renderDealerLifeBarFill } from '../rendering.js';
+import { formatNumber } from '../utils/numberFormat.js';
+import { activeDisciples } from './disciples.js';
+
 export function init() {}
+
+export let discipleAttackTimers = {};
+export let enemyAttackProgress = 0;
+export function setEnemyAttackProgress(val) {
+  enemyAttackProgress = val;
+}
+
+export function attack(deltaTime = 0) {
+  const enemy = currentEnemy;
+  if (!enemy) return;
+
+  activeDisciples.forEach(d => {
+    if (!discipleAttackTimers[d.id]) discipleAttackTimers[d.id] = 0;
+    discipleAttackTimers[d.id] += deltaTime;
+
+    if (d.attackFill) {
+      const pratio = Math.min(1, discipleAttackTimers[d.id] / d.attackSpeed);
+      d.attackFill.style.width = `${pratio * 100}%`;
+    }
+
+    if (discipleAttackTimers[d.id] >= d.attackSpeed && !enemy.isDefeated()) {
+      enemy.takeDamage(d.damage);
+      discipleAttackTimers[d.id] = 0;
+      if (d.attackFill) d.attackFill.style.width = '0%';
+    }
+  });
+
+  stageData.dealerLifeCurrent = enemy.currentHp;
+
+  if (enemy.isDefeated()) {
+    enemy.onDefeat?.();
+  } else {
+    dealerLifeDisplay.textContent = `Life: ${formatNumber(Math.floor(
+      enemy.currentHp
+    ))}/${formatNumber(enemy.maxHp)}`;
+    renderDealerLifeBarFill(enemy);
+  }
+}

--- a/game/disciples.js
+++ b/game/disciples.js
@@ -1,4 +1,5 @@
-import { stats, discipleAttackTimers } from "../script.js";
+import { stats } from "../script.js";
+import { discipleAttackTimers } from "./combat.js";
 import { handContainer, renderCombatDisciples } from "./ui.js";
 
 export function init() {}

--- a/script.js
+++ b/script.js
@@ -69,7 +69,13 @@ import {
   updateBloodSplat
 } from "./rendering.js";
 
-import { init as initCombat } from "./game/combat.js";
+import {
+  init as initCombat,
+  discipleAttackTimers,
+  enemyAttackProgress,
+  setEnemyAttackProgress,
+  attack
+} from "./game/combat.js";
 import {
   init as initUi,
   handContainer,
@@ -700,8 +706,6 @@ const dpsDisplay = document.getElementById("dpsDisplay");
 // attack progress bars
 let playerAttackFill = null;
 let enemyAttackFill = null;
-export let discipleAttackTimers = {}; // map disciple id -> elapsed attack time
-let enemyAttackProgress = 0; // carryover ratio of enemy attack timer
 let worldProgressTimer = 0;
 let discipleEtaTimer = 0;
 //let sanityTimer = 0;
@@ -3707,7 +3711,9 @@ export function respawnDealerStage() {
 function onDealerDefeat() {
   if (!currentEnemy) return;
   // capture remaining attack progress before resetting
-  enemyAttackProgress = currentEnemy.attackTimer / currentEnemy.attackInterval;
+  setEnemyAttackProgress(
+    currentEnemy.attackTimer / currentEnemy.attackInterval
+  );
   // clear enemy immediately to prevent repeated callbacks
   currentEnemy = null;
   combatXp(calculateKillXp(stageData.stage, stageData.world));
@@ -3753,7 +3759,7 @@ function onSpeakerDefeat() {
 // Called when the player defeats a boss enemy
 function onBossDefeat(boss) {
   // capture remaining attack progress before resetting
-  enemyAttackProgress = boss.attackTimer / boss.attackInterval;
+  setEnemyAttackProgress(boss.attackTimer / boss.attackInterval);
   const data = worldProgress[stageData.world];
   data.bossDefeated = true;
   data.rewardClaimed = false;
@@ -4179,7 +4185,7 @@ function spawnPlayer() {
 }
 
 function respawnPlayer() {
-  enemyAttackProgress = 0;
+  setEnemyAttackProgress(0);
   playerStats.hasDied = false;
   Object.assign(stats, BASE_STATS);
   stats.cardSlots = BASE_STATS.cardSlots + attributes.Strength.inventorySlots;
@@ -4261,39 +4267,6 @@ location.reload();
 // Shuffle all current cards back into the deck and draw a new hand
 // redraw logic moved to cardManagement.js
 
-// Player auto-attack; deals combined damage to the current enemy
-function attack(deltaTime = 0) {
-  const enemy = currentEnemy;
-  if (!enemy) return;
-
-  activeDisciples.forEach(d => {
-    if (!discipleAttackTimers[d.id]) discipleAttackTimers[d.id] = 0;
-    discipleAttackTimers[d.id] += deltaTime;
-
-    if (d.attackFill) {
-      const pratio = Math.min(1, discipleAttackTimers[d.id] / d.attackSpeed);
-      d.attackFill.style.width = `${pratio * 100}%`;
-    }
-
-    if (discipleAttackTimers[d.id] >= d.attackSpeed && !enemy.isDefeated()) {
-      enemy.takeDamage(d.damage);
-      discipleAttackTimers[d.id] = 0;
-      if (d.attackFill) d.attackFill.style.width = '0%';
-    }
-
-  });
-
-  stageData.dealerLifeCurrent = enemy.currentHp;
-
-  if (enemy.isDefeated()) {
-    enemy.onDefeat?.();
-  } else {
-    dealerLifeDisplay.textContent = `Life: ${formatNumber(Math.floor(
-      enemy.currentHp
-    ))}/${formatNumber(enemy.maxHp)}`;
-    renderDealerLifeBarFill(enemy);
-  }
-}
 
 
 


### PR DESCRIPTION
## Summary
- move disciple attack timers and attack logic into `game/combat.js`
- expose helper to set `enemyAttackProgress`
- import combat helpers in `script.js`
- adjust disciple module to read timers from combat module

## Testing
- `npm run lint`
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_687ad7e822988326b7851ec28ed35519