### PR TITLE
Fix missing functions and constants

### DIFF
--- a/game/state.js
+++ b/game/state.js
@@ -43,10 +43,14 @@ export const systems = {
   explorationUnlocked: false
 };
 
+// Fruit gathering and growth configuration
+export const FRUIT_MAX_CAP = 120;
+export const FRUIT_GROWTH_RATES = [60, 40, 30, 20, 0];
+
 export const sectState = {
   fruits: 0,
   softwood: 0,
-  availableFruits: 120,
+  availableFruits: FRUIT_MAX_CAP,
   animals: { Chicken: 3, Boar: 1, Deer: 0 },
   discipleTasks: {},
   taskTimers: { gatherFruits: 0 },

--- a/game/ui.js
+++ b/game/ui.js
@@ -45,7 +45,7 @@ export function updateDealerLifeDisplay(currentEnemy) {
   renderDealerLifeBarFill(currentEnemy);
 }
 
-function updateDiscipleStatsDisplay(d) {
+export function updateDiscipleStatsDisplay(d) {
   if (!d.statsElement) return;
   d.statsElement.innerHTML = '';
 }

--- a/script.js
+++ b/script.js
@@ -87,7 +87,8 @@ import {
   updateDealerLifeBar,
   removeDealerLifeBar,
   updateDealerLifeDisplay,
-  renderCombatDisciples
+  renderCombatDisciples,
+  updateDiscipleStatsDisplay
 } from "./game/ui.js";
 // disciple selection for combat
 import {
@@ -109,7 +110,9 @@ import {
   stageData,
   FAST_MODE_SCALE,
   timeScale,
-  setTimeScale
+  setTimeScale,
+  FRUIT_MAX_CAP,
+  FRUIT_GROWTH_RATES
 } from "./game/state.js";
 
 


### PR DESCRIPTION
## Summary
- export `updateDiscipleStatsDisplay` from UI module
- restore fruit constants and use them in `sectState`
- import the constants and function where needed

## Testing
- `npm test` *(fails: No test files found)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687ae036e4ec8326a08ad4ba261f29b6