### PR TITLE
Fix missing overlays error

### DIFF
--- a/script.js
+++ b/script.js
@@ -40,7 +40,7 @@ import {
 import { createOverlay } from './ui/overlay.js';
 import { showRestartScreen } from './ui/restartOverlay.js';
 import { showLoadErrorOverlay } from './ui/loadErrorOverlay.js';
-import { openExplorationOverlay, closeExplorationOverlay, openWorkOverlay, openScheduleOverlay, openPlaceholderOverlay, locationListContainer, explorationListContainer } from "./ui/colonyOverlays.js";
+import { openExplorationOverlay, closeExplorationOverlay, openWorkOverlay, openScheduleOverlay, openPlaceholderOverlay, openResourceOverlay, openBuildOverlay, locationListContainer, explorationListContainer } from "./ui/colonyOverlays.js";
 import { calculateKillXp, XP_EFFICIENCY } from './utils/xp.js';
 import {
   calculateMaxStamina,

--- a/ui/colonyOverlays.js
+++ b/ui/colonyOverlays.js
@@ -225,3 +225,11 @@ export function openPlaceholderOverlay(title) {
   msg.textContent = `${title} coming soon`;
   box.appendChild(msg);
 }
+
+export function openResourceOverlay() {
+  openPlaceholderOverlay('Resources');
+}
+
+export function openBuildOverlay() {
+  openPlaceholderOverlay('Build');
+}


### PR DESCRIPTION
## Summary
- add placeholder overlays for Resources and Build
- import these overlays where used

## Testing
- `npm test` *(fails: No test files found)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687aeb382fe88326b6d54bb2e04ce4ac