### PR TITLE
Remove player combat stats

### DIFF
--- a/debugTools.js
+++ b/debugTools.js
@@ -54,10 +54,10 @@ export const devTools = {
     const mult = parseFloat(
       document.getElementById('debugDamageMult').value
     );
-    if (!isNaN(mult)) {
-      stats.damageMultiplier = mult;
-      renderPlayerStats(stats);
-    }
+    if (isNaN(mult)) return;
+    activeDisciples.forEach(d => {
+      d.damage = Math.round(d.damage * mult);
+    });
   },
   addManaRegen: () => {
     const amt = parseFloat(document.getElementById('debugManaRegen').value) || 0;

--- a/game/constants.js
+++ b/game/constants.js
@@ -1,29 +1,12 @@
 // Centralized configuration values used across the game
 
 export const BASE_STATS = {
-  pDamage: 0,
-  pRegen: 0,
-  damageMultiplier: 1,
   combatSlots: 3,
-  attackSpeed: 10000,
-  hpPerKill: 1,
-  avgCombatLevel: 0,
-  avgProficiencyLevel: 0,
-  baseCardHpBoost: 0,
   maxMana: 0,
   mana: 0,
   manaRegen: 0,
-  healOnRedraw: 0,
-  abilityPower: 1,
-  spadeDamageMultiplier: 1,
-  playerShield: 0,
-  abilityCooldownReduction: 0,
-  jokerCooldownReduction: 0,
-  redrawCooldownReduction: 0,
-  hpMultiplier: 1,
-  extraDamageMultiplier: 1,
-  damageBuffMultiplier: 1,
-  damageBuffExpiration: 0
+  avgCombatLevel: 0,
+  avgProficiencyLevel: 0
 };
 
 export const HUNT_CYCLE_SECONDS = 200;

--- a/game/state.js
+++ b/game/state.js
@@ -6,29 +6,12 @@ export function setCurrentEnemy(val) {
 }
 
 export const stats = {
-  pDamage: 0,
-  pRegen: 0,
-  damageMultiplier: 1,
   combatSlots: 3,
-  attackSpeed: 10000,
-  hpPerKill: 1,
-  avgCombatLevel: 0,
-  avgProficiencyLevel: 0,
-  baseCardHpBoost: 0,
   maxMana: 0,
   mana: 0,
   manaRegen: 0,
-  healOnRedraw: 0,
-  abilityPower: 1,
-  spadeDamageMultiplier: 1,
-  playerShield: 0,
-  abilityCooldownReduction: 0,
-  jokerCooldownReduction: 0,
-  redrawCooldownReduction: 0,
-  hpMultiplier: 1,
-  extraDamageMultiplier: 1,
-  damageBuffMultiplier: 1,
-  damageBuffExpiration: 0
+  avgCombatLevel: 0,
+  avgProficiencyLevel: 0
 };
 stats.combatSlots = stats.combatSlots + attributes.Strength.inventorySlots;
 

--- a/index.html
+++ b/index.html
@@ -77,26 +77,14 @@
           <button class="vignette-toggle">Stats</button>
           <div class="vignette-content">
             <div class="statsSidePanel casino-section">
-              <div id="damageDisplay">
-                Damage: 0
-              </div>
               <div id="combatLevelDisplay">
-                Combat Lv: 1
+                Avg Combat Lv: 1
               </div>
               <div id="avgProfDisplay">
                 Avg Skill Lv: 0
               </div>
-              <div id="hpPerKillDisplay">
-                HP per Kill: 1
-              </div>
-              <div id="attackSpeedDisplay">
-                Attack Speed: 10
-              </div>
               <div id="manaRegenDisplay">
                 Mana Regen: 0/s
-              </div>
-              <div id="dpsDisplay">
-                DPS: 0
               </div>
             </div>
           </div>

--- a/script.js
+++ b/script.js
@@ -537,8 +537,7 @@ const dom = {
   manaBar: document.getElementById("manaBar"),
   manaFill: document.getElementById("manaFill"),
   manaText: document.getElementById("manaText"),
-  manaRegenDisplay: document.getElementById("manaRegenDisplay"),
-  dpsDisplay: document.getElementById("dpsDisplay")
+  manaRegenDisplay: document.getElementById("manaRegenDisplay")
 };
 //const stageProgressFill = document.getElementById("stageProgressFill");
 //const stageProgressBar = document.getElementById("stageProgressBar");
@@ -2694,29 +2693,17 @@ export function renderStageInfo() {
 }
 
 export function renderPlayerStats(stats) {
-  const damageDisplay = document.getElementById("damageDisplay");
-  const hpPerKillDisplay = document.getElementById("hpPerKillDisplay");
-  const attackSpeedDisplay = document.getElementById("attackSpeedDisplay");
   const combatLevelDisplay = document.getElementById("combatLevelDisplay");
   const avgProfDisplay = document.getElementById("avgProfDisplay");
 
-  damageDisplay.textContent = `Damage: ${formatNumber(Math.floor(stats.pDamage))}`;
-  combatLevelDisplay.textContent = `Combat Lv: ${stats.avgCombatLevel.toFixed(1)}`;
+  if (combatLevelDisplay) {
+    combatLevelDisplay.textContent = `Avg Combat Lv: ${stats.avgCombatLevel.toFixed(1)}`;
+  }
   if (avgProfDisplay) {
     avgProfDisplay.textContent = `Avg Skill Lv: ${stats.avgProficiencyLevel.toFixed(1)}`;
   }
-  attackSpeedDisplay.textContent = `Attack Speed: ${(stats.attackSpeed / 1000).toFixed(1)}s`;
   if (dom.manaRegenDisplay) {
     dom.manaRegenDisplay.textContent = `Mana Regen: ${stats.manaRegen.toFixed(2)}/s`;
-  }
-  if (dom.dpsDisplay) {
-    const dps = stats.pDamage / (stats.attackSpeed / 1000);
-    dom.dpsDisplay.textContent = `DPS: ${dps.toFixed(2)}`;
-  }
-
-  // Update HP per kill display
-  if (hpPerKillDisplay) {
-    hpPerKillDisplay.textContent = `HP per Kill: ${formatNumber(stats.hpPerKill)}`;
   }
 }
 
@@ -3268,11 +3255,6 @@ export function cDealerDamage(damageAmount = null, ability = null, source = "dea
   Math.floor(Math.random() * (maxDamage - minDamage + 1)) + minDamage;
 
   let finalDamage = dDamage;
-  if (stats.playerShield > 0) {
-    const absorbed = Math.min(stats.playerShield, finalDamage);
-    stats.playerShield -= absorbed;
-    finalDamage -= absorbed;
-  }
 
   // randomly target one of the available targets
   const idx = Math.floor(Math.random() * targets.length);
@@ -3470,9 +3452,9 @@ function openCamp(onCloseCallback = null) {
   const statsRow = document.createElement('div');
   statsRow.classList.add('overlay-stats');
   statsRow.innerHTML = `
-    <div>Damage: ${formatNumber(Math.floor(stats.pDamage))}</div>
-    <div>Attack: ${(stats.attackSpeed / 1000).toFixed(1)}s</div>
-    <div>HP/kill: ${stats.hpPerKill}</div>`;
+    <div>Avg Combat Lv: ${stats.avgCombatLevel.toFixed(1)}</div>
+    <div>Avg Skill Lv: ${stats.avgProficiencyLevel.toFixed(1)}</div>
+  `;
   box.appendChild(statsRow);
 
 
@@ -3686,37 +3668,20 @@ location.reload();
 
 // Recalculate combat stats based on cards currently drawn
 function updatePlayerStats() {
-  // Reset base stats
-  stats.pDamage = 0;
-  stats.damageMultiplier = stats.extraDamageMultiplier;
-  stats.pRegen = 0;
   stats.avgCombatLevel = 0;
   stats.avgProficiencyLevel = 0;
-  stats.attackSpeed = 0;
 
-  if (stats.damageBuffExpiration && Date.now() > stats.damageBuffExpiration) {
-    stats.damageBuffMultiplier = 1;
-  }
-
-
-
-  // Calculate average proficiency level of disciples
-  if (sectSystem && Array.isArray(sectSystem.disciples)) {
-    let total = 0;
+  if (sectSystem && Array.isArray(sectSystem.disciples) && sectSystem.disciples.length > 0) {
+    let combatTotal = 0;
+    let profTotal = 0;
     sectSystem.disciples.forEach(d => {
-      total += d.globalLevel || 0;
+      combatTotal += d.combatLevel || 0;
+      profTotal += d.globalLevel || 0;
     });
-    if (sectSystem.disciples.length > 0) {
-      stats.avgProficiencyLevel = total / sectSystem.disciples.length;
-    }
+    const count = sectSystem.disciples.length;
+    stats.avgCombatLevel = combatTotal / count;
+    stats.avgProficiencyLevel = profTotal / count;
   }
-
-  stats.pDamage *=
-    stats.damageMultiplier *
-    stats.damageBuffMultiplier *
-    attributes.Strength.meleeDamageMultiplier;
-
-  stats.attackSpeed = BASE_STATS.attackSpeed;
 
   stats.combatSlots = BASE_STATS.combatSlots + attributes.Strength.inventorySlots;
   renderPlayerStats(stats);


### PR DESCRIPTION
## Summary
- trim `BASE_STATS` and `stats` to remove player combat-specific fields
- drop shield mechanics and player DPS UI
- compute combat averages directly from disciples
- clean debug helper for damage multiplier

## Testing
- `npm test` *(fails: Error: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_687b1980e1dc83269657e59604eff384