### PR TITLE
Start game in sect

### DIFF
--- a/script.js
+++ b/script.js
@@ -830,9 +830,9 @@ function initTabs() {
       // economy stats removed
     });
 
-  showTab(playerTab); // Start with construct panel visible
+  showTab(playerTab); // Start with sect panel visible
   setActiveTabButton(playerTabButton);
-  if (playerConstructSubTabButton) playerConstructSubTabButton.click();
+  if (playerSectSubTabButton) playerSectSubTabButton.click();
 }
 
 function initPollen() {
@@ -2145,6 +2145,7 @@ function buildDiscipleSkillsList(d) {
     currentExplorationParty.forEach(id => {
       const d = sectSystem.disciples.find(x => x.id === id);
       if (d) {
+        d.currentHp = d.maxHp;
         selectDisciple(d);
       }
     });
@@ -2248,12 +2249,7 @@ function init() {
   });
   showColonyTab('resources');
   updatePlayerStats(stats);
-  // Start or resume the game after loading
-  spawnPlayer();
-  respawnDealerStage();
-  renderDealerCard();
-  resetStageCashStats();
-  renderStageInfo();
+  // Game starts in sect view; exploration initiates combat
   renderWorldsMenu();
 
   if (dom.nextStageArea) {


### PR DESCRIPTION
## Summary
- default to sect screen in tab init
- remove combat start logic from initialization
- heal disciples before starting exploration

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687bdb1ba36083268738fbb22729e2fe