### PR TITLE
Add bamboo exploration badges

### DIFF
--- a/docs/00-wireframes.md
+++ b/docs/00-wireframes.md
@@ -80,6 +80,7 @@ Water Orb widget showing current Water per second.
 Footer
 
 “Gate” button to open the full map/exploration/tasks overlay.
+* Exploration disciple selection now uses bamboo-colored badges with a small mood icon.
 
 #dicsiple overlay card on pressing disciple
 

--- a/game/badges.js
+++ b/game/badges.js
@@ -1,0 +1,16 @@
+export function createDiscipleBadge(d) {
+  const badge = document.createElement('div');
+  badge.className = 'disciple-badge';
+
+  const name = document.createElement('span');
+  name.className = 'badge-name';
+  name.textContent = d.name || `Disciple ${d.id}`;
+  badge.appendChild(name);
+
+  const mood = document.createElement('span');
+  mood.className = 'mood-icon';
+  mood.textContent = d.mood || '🙂';
+  badge.appendChild(mood);
+
+  return badge;
+}

--- a/script.js
+++ b/script.js
@@ -39,6 +39,7 @@ import {
 import { createOverlay } from './ui/overlay.js';
 import { showLoadErrorOverlay } from './ui/loadErrorOverlay.js';
 import { openExplorationOverlay, closeExplorationOverlay, openWorkOverlay, openScheduleOverlay, openPlaceholderOverlay, openResourceOverlay, openBuildOverlay, locationListContainer, explorationListContainer } from "./ui/colonyOverlays.js";
+import { createDiscipleBadge } from "./game/badges.js";
 import { calculateKillXp, XP_EFFICIENCY } from './utils/xp.js';
 import { initTooltip } from './game/tooltip.js';
 import {
@@ -2099,12 +2100,19 @@ function buildDiscipleSkillsList(d) {
     cb.type = 'checkbox';
     cb.value = d.id;
     cb.checked = explorationParty.has(d.id);
+    const badge = createDiscipleBadge(d);
+    if (cb.checked) badge.classList.add('selected');
     cb.addEventListener('change', () => {
-      if (cb.checked) explorationParty.add(d.id);
-      else explorationParty.delete(d.id);
+      if (cb.checked) {
+        explorationParty.add(d.id);
+        badge.classList.add('selected');
+      } else {
+        explorationParty.delete(d.id);
+        badge.classList.remove('selected');
+      }
     });
     row.appendChild(cb);
-    row.appendChild(createDiscipleCard(d));
+    row.appendChild(badge);
     explorationListContainer.appendChild(row);
   });
 }

--- a/style.css
+++ b/style.css
@@ -3711,3 +3711,24 @@ body.darkenshift-mode .tabsContainer button.active {
   gap: 8px;
 }
 
+.disciple-badge {
+  background: #d4e4b0;
+  color: #000;
+  border: 1px solid #7d8b50;
+  border-radius: 6px;
+  padding: 2px 4px;
+  font-size: 0.7rem;
+  display: inline-flex;
+  align-items: center;
+  position: relative;
+  gap: 2px;
+}
+.disciple-badge .mood-icon {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  font-size: 0.6rem;
+}
+.disciple-badge.selected {
+  box-shadow: 0 0 4px #8fa16c;
+}


### PR DESCRIPTION
## Summary
- create `disciple-badge` element module
- style bamboo-themed badges with mood icons
- use badges in exploration tab instead of full cards
- document new badge look in wireframes

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687be800544c8326a9282650747ce213