### PR TITLE
fix: ensure sect map fills tab

### DIFF
--- a/style.css
+++ b/style.css
@@ -2680,6 +2680,7 @@ body.darkenshift-mode .tabsContainer button.active {
     gap: 6px;
     padding: 6px;
     overflow: hidden;
+    height: 100vh;
 }
 .sect-disciples-container {
     flex: 1;


### PR DESCRIPTION
## Summary
- ensure sect map uses full viewport height

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687bee30764483269dc2ebc8ed1f4461