### PR TITLE
World overlay via exploration

### DIFF
--- a/docs/00-wireframes.md
+++ b/docs/00-wireframes.md
@@ -217,6 +217,9 @@ Here’s the updated **Disciple Overlay UI wireframe** with the added `Cultivati
 │ └───────────────────────────────┘  │ [ Send ▶ ]  [ Back ]       │ │
 │                                    └────────────────────────────┘ │
 └───────────────────────────────────────────────────────────────────┘
+- Selecting the new *Exoteric Dungeon* entry opens a world screen displaying
+  progress bars for each unlocked world. From there you choose which disciples
+  to send and begin combat.
 
 
 # Woodcutting Locations Tab

--- a/game/constants.js
+++ b/game/constants.js
@@ -76,5 +76,6 @@ export const LOCATION_DEFS = [
   { name: 'Firewood Grove', reqDistance: 100, baseChance: 0.2, x: '30%', y: '70%' },
   { name: 'Crystal Cavern', reqDistance: 300, baseChance: 0.15, x: '70%', y: '40%' },
   { name: 'Esoteric Dungeon', reqDistance: 100, baseChance: 1.0, x: '50%', y: '20%' },
+  { name: 'Exoteric Dungeon', reqDistance: 100, baseChance: 1.0, x: '60%', y: '25%' },
   { name: 'Ancient Ruins', reqDistance: 800, baseChance: 0.05, x: '80%', y: '10%' }
 ];

--- a/index.html
+++ b/index.html
@@ -43,7 +43,6 @@
 
     <!---tabs container--->
       <div class="tabsContainer">
-        <button class="playerTabButton">real</button>
         <button class="playerStatsTabButton">stats</button>
         <button class="playerCoreTabButton">core</button>
         <button class="playerLexiconTabButton">lexicon</button>
@@ -53,10 +52,6 @@
 
     <!--------------main tab panel----------------->
     <div class="mainTab">
-      <div class="imaginary-subtabs">
-        <button class="cardSubTabButton active">cards</button>
-        <button class="worldSubTabButton">worlds</button>
-      </div>
       <div class="cardSubTab">
         <div class="dealerContainer casino-section">
           <div id="stage">
@@ -120,10 +115,6 @@
         </div>
         <div class="handContainer casino-section"></div>
       </div>
-      </div>
-      <div class="worldsTab" style="display:none;">
-        <span id="worldProgressPerSecDisplay">Avg World Progress/sec: 0%</span>
-        <div class="worldsContainer casino-section"></div>
       </div>
     </div>
     <!-- close mainTab -->

--- a/script.js
+++ b/script.js
@@ -38,7 +38,7 @@ import {
 } from './attributes.js';
 import { createOverlay } from './ui/overlay.js';
 import { showLoadErrorOverlay } from './ui/loadErrorOverlay.js';
-import { openExplorationOverlay, closeExplorationOverlay, openWorkOverlay, openScheduleOverlay, openPlaceholderOverlay, openResourceOverlay, openBuildOverlay, locationListContainer, explorationListContainer } from "./ui/colonyOverlays.js";
+import { openExplorationOverlay, closeExplorationOverlay, openWorkOverlay, openScheduleOverlay, openPlaceholderOverlay, openResourceOverlay, openBuildOverlay, closeDungeonOverlay, locationListContainer, explorationListContainer } from "./ui/colonyOverlays.js";
 import { createDiscipleBadge } from "./game/badges.js";
 import { calculateKillXp, XP_EFFICIENCY } from './utils/xp.js';
 import { initTooltip } from './game/tooltip.js';
@@ -464,16 +464,12 @@ const saveInterval = setInterval(saveGame, 30000);
 
 let playerStatsTabButton;
 let worldSubTabButton;
-let cardSubTabButton;
-let playerTabButton;
 export let explorationTabButton;
 export let locationTabButton;
 let logTabButton;
 export let mainTab;
-export let cardSubTab;
 export let starChartTab;
 export let playerStatsTab;
-export let worldsTab;
 export let coreTab;
 export let lexiconTab;
 export let sectTab;
@@ -536,13 +532,6 @@ function setupTabHandlers() {
         renderGlobalStats();
         showTab(playerStatsTab);
         setActiveTabButton(playerStatsTabButton);
-      }
-    },
-    {
-      buttonSelector: '.playerTabButton',
-      onClick: () => {
-        showTab(mainTab);
-        setActiveTabButton(playerTabButton);
       }
     },
     {
@@ -650,17 +639,12 @@ function initTabs() {
   if (typeof document === 'undefined') return;
 
   playerStatsTabButton = document.querySelector('.playerStatsTabButton');
-  cardSubTabButton = document.querySelector('.cardSubTabButton');
-  worldSubTabButton = document.querySelector('.worldSubTabButton');
-  playerTabButton = document.querySelector('.playerTabButton');
   explorationTabButton = document.querySelector('.explorationTabButton');
   locationTabButton = document.querySelector('.locationTabButton');
   logTabButton = document.querySelector('.logTabButton');
   mainTab = document.querySelector('.mainTab');
-  cardSubTab = document.querySelector('.cardSubTab');
   starChartTab = document.querySelector('.starChartTab');
   playerStatsTab = document.querySelector('.playerStatsTab');
-  worldsTab = document.querySelector('.worldsTab');
   coreTab = document.querySelector('.coreTab');
   lexiconTab = document.querySelector('.lexiconTab');
   sectTab = document.querySelector('.sectTab');
@@ -718,23 +702,7 @@ function initTabs() {
   if (colonyResearchTabButton) colonyResearchTabButton.addEventListener('click', () => showColonyTab('research'));
 
 
-  if (worldSubTabButton) {
-    worldSubTabButton.addEventListener("click", () => {
-      renderWorldsMenu();
-      if (cardSubTab) cardSubTab.style.display = "none";
-      if (worldsTab) worldsTab.style.display = "";
-      worldSubTabButton.classList.add("active");
-      if (cardSubTabButton) cardSubTabButton.classList.remove("active");
-    });
-  }
-  if (cardSubTabButton) {
-    cardSubTabButton.addEventListener("click", () => {
-      if (worldsTab) worldsTab.style.display = "none";
-      if (cardSubTab) cardSubTab.style.display = "";
-      cardSubTabButton.classList.add("active");
-      if (worldSubTabButton) worldSubTabButton.classList.remove("active");
-    });
-  }
+
 
 
   if (locationsPanelBtn)
@@ -2114,7 +2082,7 @@ function buildDiscipleSkillsList(d) {
   });
 }
 
- export function startExploration() {
+export function startExploration() {
   if (!explorationListContainer) return;
   explorationParty.clear();
   explorationListContainer
@@ -2132,9 +2100,25 @@ function buildDiscipleSkillsList(d) {
     });
     closeExplorationOverlay();
     showTab(mainTab);
-    setActiveTabButton(playerTabButton);
     respawnDealerStage();
   }
+}
+
+export function startWorldCombat(worldId, party) {
+  if (!Array.isArray(party) || party.length === 0) return;
+  goToWorld(worldId);
+  clearActiveDisciples();
+  party.forEach(id => {
+    const d = sectSystem.disciples.find(x => x.id === id);
+    if (d) {
+      d.currentHp = d.maxHp;
+      selectDisciple(d);
+    }
+  });
+  closeDungeonOverlay?.();
+  closeExplorationOverlay?.();
+  showTab(mainTab);
+  respawnDealerStage();
 }
 
  function triggerOrbFlash() {
@@ -2157,7 +2141,6 @@ function init() {
     mainTab,
     starChartTab,
     playerStatsTab,
-    worldsTab,
     coreTab,
     lexiconTab,
     sectTab,
@@ -2476,7 +2459,7 @@ function updateWorldProgressUI(id) {
   }
 }
 
-function renderWorldsMenu() {
+export function renderWorldsMenu() {
   const container = document.querySelector(".worldsContainer");
   if (!container) return;
   container.innerHTML = "";
@@ -2534,7 +2517,6 @@ function renderWorldsMenu() {
 
 // Highlight the Worlds tab when rewards can be claimed or a new world is unlocked
 function updateWorldTabNotification() {
-  if (!worldSubTabButton) return;
   let highestUnlocked = 0;
   let rewardAvailable = false;
   Object.entries(worldProgress).forEach(([id, data]) => {
@@ -2544,7 +2526,9 @@ function updateWorldTabNotification() {
   });
   const newWorldAvailable = highestUnlocked > stageData.world;
   const shouldGlow = rewardAvailable || newWorldAvailable;
-  worldSubTabButton.classList.toggle("glow-notify", shouldGlow);
+  if (worldSubTabButton) {
+    worldSubTabButton.classList.toggle("glow-notify", shouldGlow);
+  }
 }
 
 // Show cards eligible for job assignment in the Deck tab
@@ -2746,9 +2730,7 @@ function onSpeakerDefeat() {
     showSpeakerQuote("Words don’t just describe. They make.");
   } else if (idx === 3) {
     showSpeakerQuote("The soul is the only prison you’ve never tried to break.");
-    if (playerTabButton) playerTabButton.style.display = "inline-block";
     showTab(mainTab);
-    setActiveTabButton(playerTabButton);
   }
   dealerDeathAnimation();
   dealerBarDeathAnimation(() => {

--- a/style.css
+++ b/style.css
@@ -628,6 +628,13 @@ body.darkenshift-mode .tabsContainer button.active {
     gap: 8px;
 }
 
+.dungeon-overlay .overlay-box {
+    max-width: 600px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
 .work-content {
     display: flex;
     gap: 8px;
@@ -656,6 +663,14 @@ body.darkenshift-mode .tabsContainer button.active {
     line-height: 14px;
     text-align: center;
     cursor: pointer;
+}
+
+.location-entry {
+    cursor: pointer;
+    padding: 4px;
+}
+.location-entry:hover {
+    background: rgba(255,255,255,0.1);
 }
 
 .schedule-overlay .overlay-box {

--- a/ui/colonyOverlays.js
+++ b/ui/colonyOverlays.js
@@ -5,8 +5,8 @@ export let startDungeonBtn = null;
 
 import { createOverlay } from './overlay.js';
 import { sectSystem, SECT_SCHEDULE, getCurrentSchedule, renderConstructCards } from '../game/sect.js';
-import { systems, sectState } from '../game/state.js';
-import { createSectDiscipleCard, renderColonyTasks, renderExplorationTab, startExploration, discipleGatherPhase } from '../script.js';
+import { systems, sectState, worldProgress } from '../game/state.js';
+import { createSectDiscipleCard, renderColonyTasks, renderExplorationTab, startExploration, startWorldCombat, discipleGatherPhase } from '../script.js';
 
 let explorationOverlay = null;
 let explorationOverlayActiveTab = 'explore';
@@ -64,6 +64,11 @@ export function openExplorationOverlay() {
   // exploration tab elements
   locationListContainer = document.createElement('div');
   locationListContainer.className = 'location-list casino-section';
+  const exoRow = document.createElement('div');
+  exoRow.className = 'location-entry';
+  exoRow.textContent = 'Exoteric Dungeon';
+  exoRow.addEventListener('click', openDungeonOverlay);
+  locationListContainer.appendChild(exoRow);
   explorationListContainer = document.createElement('div');
   explorationListContainer.className = 'exploration-list casino-section';
   startDungeonBtn = document.createElement('button');
@@ -233,4 +238,64 @@ export function openResourceOverlay() {
 
 export function openBuildOverlay() {
   openPlaceholderOverlay('Build');
+}
+
+let dungeonOverlay = null;
+export function closeDungeonOverlay() {
+  if (dungeonOverlay) dungeonOverlay.close();
+}
+
+export function openDungeonOverlay() {
+  if (dungeonOverlay) return;
+  dungeonOverlay = createOverlay({ className: 'dungeon-overlay' });
+  dungeonOverlay.onClose(() => { dungeonOverlay = null; });
+  const { box } = dungeonOverlay;
+
+  const closeBtn = document.createElement('button');
+  closeBtn.className = 'close-btn';
+  closeBtn.innerHTML = '&times;';
+  closeBtn.addEventListener('click', dungeonOverlay.close);
+  box.appendChild(closeBtn);
+
+  const partyList = document.createElement('div');
+  partyList.className = 'exploration-list casino-section';
+  box.appendChild(partyList);
+
+  const worldsContainer = document.createElement('div');
+  worldsContainer.className = 'worldsContainer casino-section';
+  box.appendChild(worldsContainer);
+
+  sectSystem.disciples.forEach(d => {
+    const row = document.createElement('label');
+    row.className = 'exploration-entry';
+    const cb = document.createElement('input');
+    cb.type = 'checkbox';
+    cb.value = d.id;
+    const badge = createSectDiscipleCard(d);
+    row.appendChild(cb);
+    row.appendChild(badge);
+    partyList.appendChild(row);
+  });
+
+  Object.entries(worldProgress).forEach(([id, data]) => {
+    if (!data.unlocked) return;
+    const entry = document.createElement('div');
+    entry.className = 'world-entry';
+    entry.innerHTML = `<div>World ${id} (Lv ${data.level})</div>`;
+    const progress = document.createElement('div');
+    progress.className = 'world-progress';
+    const fill = document.createElement('div');
+    fill.className = 'world-progress-fill';
+    fill.style.width = `${Math.min(100, (data.progress / data.progressTarget) * 100)}%`;
+    progress.appendChild(fill);
+    entry.appendChild(progress);
+    const btn = document.createElement('button');
+    btn.textContent = 'Enter';
+    btn.addEventListener('click', () => {
+      const ids = Array.from(partyList.querySelectorAll('input:checked')).map(n => parseInt(n.value));
+      startWorldCombat(parseInt(id), ids);
+    });
+    entry.appendChild(btn);
+    worldsContainer.appendChild(entry);
+  });
 }


### PR DESCRIPTION
## Summary
- add Exoteric Dungeon to location defs
- remove Real, Card, and World tabs from UI
- add world selection overlay reachable from the exploration overlay
- allow picking disciples and entering any unlocked world
- document new dungeon flow

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687bee05f5808326947aa52103698f8e