### PR TITLE
Unify disciple badge UI

### DIFF
--- a/docs/00-wireframes.md
+++ b/docs/00-wireframes.md
@@ -80,7 +80,7 @@ Water Orb widget showing current Water per second.
 Footer
 
 “Gate” button to open the full map/exploration/tasks overlay.
-* Exploration disciple selection now uses bamboo-colored badges with a small mood icon.
+* Exploration and sect disciple lists now use a unified bamboo-colored badge showing the disciple's name, mood, HP bar and current task.
 
 #dicsiple overlay card on pressing disciple
 

--- a/game/badges.js
+++ b/game/badges.js
@@ -1,9 +1,13 @@
+import { makeBar } from './ui.js';
+import { sectState } from './state.js';
+import { DISCIPLE_MAX_HEALTH } from './constants.js';
+
 export function createDiscipleBadge(d) {
   const badge = document.createElement('div');
   badge.className = 'disciple-badge';
 
-  const name = document.createElement('span');
-  name.className = 'badge-name';
+  const name = document.createElement('div');
+  name.className = 'disciple-name';
   name.textContent = d.name || `Disciple ${d.id}`;
   badge.appendChild(name);
 
@@ -11,6 +15,23 @@ export function createDiscipleBadge(d) {
   mood.className = 'mood-icon';
   mood.textContent = d.mood || '🙂';
   badge.appendChild(mood);
+
+  const lifeBar = makeBar(d.health, DISCIPLE_MAX_HEALTH, '#a33');
+  lifeBar.classList.add('life-bar');
+  badge.appendChild(lifeBar);
+
+  const wrapper = document.createElement('div');
+  wrapper.id = `disciple-task-${d.id}`;
+  wrapper.className = 'disciple-progress';
+  const fill = document.createElement('div');
+  fill.className = 'disciple-progress-fill';
+  wrapper.appendChild(fill);
+  const label = document.createElement('div');
+  label.className = 'disciple-progress-label';
+  const curTask = d.incapacitated ? 'Resting' : sectState.discipleTasks[d.id] || 'Idle';
+  label.textContent = curTask;
+  wrapper.appendChild(label);
+  badge.appendChild(wrapper);
 
   return badge;
 }

--- a/script.js
+++ b/script.js
@@ -278,32 +278,9 @@ function createDiscipleCard(d) {
 }
 
 // Simplified card used in the sect overview list
- export function createSectDiscipleCard(d) {
-  const card = document.createElement('div');
-  card.className = 'sect-disciple-card';
-
-  const nameLabel = document.createElement('div');
-  nameLabel.className = 'bar-label disciple-name';
-  nameLabel.textContent = d.name || `Disciple ${d.id}`;
-  card.appendChild(nameLabel);
-
-  const lifeBar = makeBar(d.health, DISCIPLE_MAX_HEALTH, '#a33');
-  lifeBar.classList.add('life-bar');
-  card.appendChild(lifeBar);
-
-  const wrapper = document.createElement('div');
-  wrapper.id = `disciple-task-${d.id}`;
-  wrapper.className = 'disciple-progress';
-  const fill = document.createElement('div');
-  fill.className = 'disciple-progress-fill';
-  wrapper.appendChild(fill);
-  const label = document.createElement('div');
-  label.className = 'disciple-progress-label';
-  const curTask = d.incapacitated ? 'Resting' : sectState.discipleTasks[d.id] || 'Idle';
-  label.textContent = curTask;
-  wrapper.appendChild(label);
-  card.appendChild(wrapper);
-
+export function createSectDiscipleCard(d) {
+  const card = createDiscipleBadge(d);
+  card.classList.add('sect-disciple-card');
   return card;
 }
 

--- a/style.css
+++ b/style.css
@@ -3478,47 +3478,12 @@ body.darkenshift-mode .tabsContainer button.active {
     overflow-x: auto;
 }
 .sect-disciple-card {
-    position: relative;
-    border: 1px solid #b4b89f;
-    padding: 2px;
-    width: 60px;
-    font-size: 0.55rem;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
     cursor: pointer;
-    background: rgba(0,0,0,0.5);
-    box-shadow: none;
 }
 .sect-disciple-card:hover {
-    background: #fbf6e0;
     box-shadow: 0 0 8px rgba(0,0,0,0.4);
 }
 .disciple-icon { display: none; }
-.sect-disciple-card .bar {
-    width: 100%;
-    height: 4px;
-    background: #444;
-    border: 1px solid #222;
-    margin-top: 1px;
-    position: relative;
-}
-.sect-disciple-card .bar-fill {
-    position: absolute;
-    top: 0;
-    left: 0;
-    height: 100%;
-    width: 0%;
-    background: var(--verdantia-jade);
-}
-.life-bar .bar-label {
-    font-size: 0.55rem;
-}
-
-.sect-disciple-card .disciple-name {
-    font-size: 0.55rem;
-    margin-bottom: 1px;
-}
 
 .disciple-tabs {
     display: flex;
@@ -3732,9 +3697,11 @@ body.darkenshift-mode .tabsContainer button.active {
   color: #000;
   border: 1px solid #7d8b50;
   border-radius: 6px;
-  padding: 2px 4px;
-  font-size: 0.7rem;
-  display: inline-flex;
+  padding: 2px;
+  width: 60px;
+  font-size: 0.55rem;
+  display: flex;
+  flex-direction: column;
   align-items: center;
   position: relative;
   gap: 2px;
@@ -3747,4 +3714,31 @@ body.darkenshift-mode .tabsContainer button.active {
 }
 .disciple-badge.selected {
   box-shadow: 0 0 4px #8fa16c;
+}
+.disciple-badge .bar {
+  width: 100%;
+  height: 4px;
+  background: #444;
+  border: 1px solid #222;
+  margin-top: 1px;
+  position: relative;
+}
+.disciple-badge .bar-fill {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 0%;
+  background: var(--verdantia-jade);
+}
+.disciple-badge .disciple-name {
+  font-size: 0.55rem;
+  margin-bottom: 1px;
+}
+.disciple-badge .disciple-progress {
+  width: 60px;
+  height: 10px;
+}
+.disciple-badge .disciple-progress-label {
+  font-size: 0.55rem;
 }


### PR DESCRIPTION
## Summary
- render disciple badge with bamboo style name, mood, HP bar and task
- reuse badge for sect display via `createSectDiscipleCard`
- update UI styles for unified badges
- document unified disciple badge in wireframes

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687bf1c473848326a001cc9d2bb1e0ff