### PR TITLE
Add schedule-aware task display

### DIFF
--- a/game/constants.js
+++ b/game/constants.js
@@ -46,7 +46,10 @@ export const TASK_ICONS = {
   Chant: '🎶',
   Exploration: '🧭',
   Idle: '💤',
-  Resting: '🛌'
+  Resting: '🛌',
+  Training: '🥋',
+  Eat: '🍽️',
+  Sleep: '💤'
 };
 
 export const TASK_GROUPS = {

--- a/script.js
+++ b/script.js
@@ -808,9 +808,18 @@ function updateTaskProgressDisplay() {
     const fill = wrapper.querySelector('.disciple-progress-fill');
     const label = wrapper.querySelector('.disciple-progress-label');
     const rateEl = wrapper.querySelector('.disciple-task-rate');
+    const phase = getCurrentSchedule().action;
     const taskName = d.incapacitated
       ? 'Resting'
-      : sectState.discipleTasks[d.id] || 'Idle';
+      : phase !== 'Work'
+        ? phase
+        : sectState.discipleTasks[d.id] || 'Idle';
+    if (phase !== 'Work' && taskName !== 'Resting') {
+      if (fill) fill.style.width = '0%';
+      if (label) label.textContent = taskName;
+      if (rateEl) rateEl.textContent = '';
+      return;
+    }
     if (taskName === 'Gather Fruit' || taskName === 'Gather Softwood') {
       const progress = sectState.discipleProgress[d.id] || 0;
       const group = TASK_GROUPS[taskName];
@@ -1121,9 +1130,12 @@ function startDiscipleMovement() {
     const row = document.createElement('div');
     row.className = 'task-entry';
     if (d.id === selectedDiscipleId) row.classList.add('selected');
+    const phase = getCurrentSchedule().action;
     const current = d.incapacitated
       ? 'Resting'
-      : sectState.discipleTasks[d.id] || 'Idle';
+      : phase !== 'Work'
+        ? phase
+        : sectState.discipleTasks[d.id] || 'Idle';
     if (current === 'Idle') row.classList.add('idle');
     row.addEventListener('click', () => {
       selectedDiscipleId = d.id;

--- a/utils/sectInit.js
+++ b/utils/sectInit.js
@@ -1,5 +1,6 @@
 import Disciple from '../disciple.js';
 import { initializeDisciple } from './discipleInit.js';
+import { sectState } from '../game/state.js';
 
 export function initializeSect() {
   const disciples = [1, 2, 3].map(id => {
@@ -7,5 +8,6 @@ export function initializeSect() {
     initializeDisciple(d);
     return d;
   });
+  sectState.fruits = 100;
   return { disciples };
 }


### PR DESCRIPTION
## Summary
- start each sect with 100 fruit
- show disciple schedule state on task rows when not in work phase
- update task progress display to respect schedule
- add icons for Training/Eat/Sleep

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687bf847156083269e8d3f7d2f044575