### PR TITLE
Update core tab to show tadpole metamorphosis

### DIFF
--- a/core.js
+++ b/core.js
@@ -16,14 +16,13 @@ let mindValEl;
 export function initCore() {
   container = document.getElementById('coreTabContent');
   if (!container) return;
-const bodyPath = `M200 140
-               C185 140, 180 120, 200 120
-               C220 120, 215 140, 200 140
-               M190 140
-               C170 160, 170 190, 185 200
-               C170 210, 170 240, 200 240
-               C230 240, 230 210, 215 200
-               C230 190, 230 160, 210 140
+const bodyPath = `M200 150
+               m -25 0
+               a25 25 0 1 0 50 0
+               a25 25 0 1 0 -50 0
+               m25 20
+               c60 20 90 60 50 110
+               c-30 -40 -70 -70 -100 -80
                Z`;
   container.innerHTML = `
     <div id="voiceLevelDisplay" class="voice-level-display">Voice Level: <span id="voiceLevelValue" class="voice-level-value"></span></div>

--- a/docs/00-wireframes.md
+++ b/docs/00-wireframes.md
@@ -262,8 +262,8 @@ You can adjust button labels, add icons, or tweak layout widths to fit your fina
 │ [Room 1]   [Room 2]   [Room 3]        Room 1 Selected                        │
 │                                                                              │
 │ ┌───────────────────────┐   ┌─────────────────────────┐   ┌─────────────────┐ │
-│ │       Body Figure     │   │     Progress:          │   │ Assigned to     │ │
-│ │   (disciple silhouette │   │   25 000 / 25 000      │   │   Li Xuan       │ │
+│ │     Tadpole Figure    │   │     Progress:          │   │ Assigned to     │ │
+│ │   (tadpole silhouette │   │   25 000 / 25 000      │   │   Li Xuan       │ │
 │ │    with fill overlay) │   │   (fill bar here)      │   │                 │ │
 │ └───────────────────────┘   └─────────────────────────┘   └─────────────────┘ │
 │                                                                              │
@@ -280,7 +280,7 @@ You can adjust button labels, add icons, or tweak layout widths to fit your fina
 
 Top: room‐selector tabs & currently selected label.
 
-Center‐left: disciple “body” silhouette with fill overlay showing cultivation progress.
+Center‐left: disciple “tadpole” silhouette with fill overlay showing metamorphosis progress.
 
 Center‐middle: numeric & bar progress (current/target).
 
@@ -289,4 +289,6 @@ Right: which disciple is assigned.
 Below main: two‐column stats panel (room vs. cultivation).
 
 Footer: method buttons plus a “Path Progress” link to open path menu.
+
+Rooms are unlocked further in the game and can be assigned as they are created. For now no rooms are available to select.
 


### PR DESCRIPTION
## Summary
- replace body figure path with a tadpole silhouette in `core.js`
- document metamorphosis overlay update with new tadpole reference

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687c088d099083269cdea6b37007d5a6