### PR TITLE
Remove endurance from stamina calc

### DIFF
--- a/docs/00-wireframes.md
+++ b/docs/00-wireframes.md
@@ -110,7 +110,7 @@ Here’s the updated **Disciple Overlay UI wireframe** with the added `Cultivati
 ├────────────────────────────────────────────────────┤
 │ **Attributes**                                     │
 │ DEX: 8   – (affects movement, crit rate, evade)    │
-│ END: 6   – (max stamina, stamina regen)            │
+│ END: 6   – (affects building and farming speed)    │
 │ STR: 5   – (physical damage, mining power)         │
 │ INT: 9   – (learning rate, spell potency)          │
 │ CHA: 4   – (affects persuasion, mood sharing)      │
@@ -158,7 +158,7 @@ Here’s the updated **Disciple Overlay UI wireframe** with the added `Cultivati
 │ 🙂 Inspired      (+10% cultivation speed)           │
 │ 😴 Tired         (–20% work speed)                  │
 │ 🍽 Hungry        (–50% happiness; seeks food)       │
-│ ⚡ Energized     (+5 stamina/sec regen)             │
+│ ⚡ Energized     (faster stamina regen)             │
 └────────────────────────────────────────────────────┘
 ```
 

--- a/script.js
+++ b/script.js
@@ -232,7 +232,7 @@ function createDiscipleCard(d) {
 
   card.appendChild(createLabeledBar('❤️', d.health, DISCIPLE_MAX_HEALTH, '#a33'));
   card.appendChild(
-    createLabeledBar('⚡', d.stamina, calculateMaxStamina(d.endurance), '#cc3')
+    createLabeledBar('⚡', d.stamina, calculateMaxStamina(), '#cc3')
   );
   card.appendChild(createLabeledBar('🍖', d.hunger, 20, '#996633'));
 
@@ -1503,7 +1503,7 @@ function buildDiscipleStatusView(d) {
       label: 'Stamina',
       color: '#cc3',
       value: d.stamina,
-      max: calculateMaxStamina(d.endurance)
+      max: calculateMaxStamina()
     },
     { label: 'Hunger', color: '#cc3', value: d.hunger, max: 20 }
   ];
@@ -1671,11 +1671,11 @@ function buildDiscipleGeneralView(d) {
   const staminaRow = makeStatRow(
     'Stamina',
     d.stamina,
-    calculateMaxStamina(d.endurance),
+    calculateMaxStamina(),
     'linear-gradient(90deg,#3b3,#7f7)'
   );
   const stamRate = document.createElement('span');
-  stamRate.textContent = ` (+${calculateStaminaRegen(d.endurance).toFixed(2)}/s)`;
+  stamRate.textContent = ` (+${calculateStaminaRegen().toFixed(2)}/s)`;
   staminaRow.appendChild(stamRate);
   vit.appendChild(staminaRow);
   const waterLvl = getTaskSkillProgress(
@@ -2164,8 +2164,8 @@ function init() {
   document.addEventListener('day-passed', () => {
     sectSystem.disciples.forEach(d => {
       d.stamina = Math.min(
-        calculateMaxStamina(d.endurance),
-        d.stamina + calculateStaminaRegen(d.endurance)
+        calculateMaxStamina(),
+        d.stamina + calculateStaminaRegen()
       );
     });
     sectState.availableFruits = Math.min(

--- a/utils/stamina.js
+++ b/utils/stamina.js
@@ -1,10 +1,10 @@
 export const BASE_STAMINA = 10;
 export const BASE_REGEN_PER_SEC = 0.1;
 
-export function calculateMaxStamina(endurance) {
-  return BASE_STAMINA * (1 + 0.05 * (endurance - 1));
+export function calculateMaxStamina() {
+  return BASE_STAMINA;
 }
 
-export function calculateStaminaRegen(endurance) {
-  return BASE_REGEN_PER_SEC * (1 + 0.01 * (endurance - 1));
+export function calculateStaminaRegen() {
+  return BASE_REGEN_PER_SEC;
 }


### PR DESCRIPTION
## Summary
- make stamina and stamina regen constants
- remove endurance param from stamina functions
- update displays to show new stamina calculation
- update docs to describe endurance as building/farming speed instead of stamina

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687c12c19128832684d29cdf243ff73c