### PR TITLE
docs: clarify disciple modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,4 +42,6 @@ This is not a standard Wuxia knockoff — **Taino and Caribbean mysticism** blen
 - Disciples battle system with a dynamic simulation loop
 - Branches organized per feature (e.g. `sect-ui`, `resource-loop`, `card-art`)
 - See `docs/module-structure.md` for an overview of the game modules.
+- The `Disciple` class lives in `disciple.js` while `game/disciples.js` tracks
+  which disciples are currently participating in combat.
 

--- a/disciple.js
+++ b/disciple.js
@@ -1,3 +1,6 @@
+// Core class representing an individual disciple. Instances of this
+// class are created by systems across the game and store combat and
+// attribute information for a single coquí.
 import { generateDiscipleAttributes } from './discipleAttributes.js';
 import { xpRequirement } from './utils/xp.js';
 import { runAnimation } from './utils/animation.js';

--- a/docs/module-structure.md
+++ b/docs/module-structure.md
@@ -3,6 +3,7 @@
 The project organizes game logic under the `game/` directory.
 
 - **game/state.js** – central store for global state like `stats`, `systems`, `sectState`, and the current enemy. Also exposes time scaling helpers.
+- **disciple.js** – defines the `Disciple` class representing a single frog disciple.
 - **game/disciples.js** – manages which disciples are active in combat.
 - **game/ui.js** – renders combat UI elements such as bars and disciple cards.
 - **game/combat.js** – centralizes all combat logic including damage

--- a/game/disciples.js
+++ b/game/disciples.js
@@ -1,3 +1,6 @@
+// Maintains the list of disciples currently engaged in combat.
+// Selecting or deselecting disciples here controls who participates
+// in battles rendered by other modules.
 import { stats } from './state.js';
 import { discipleAttackTimers } from "./combat.js";
 import { handContainer, renderCombatDisciples } from "./ui.js";


### PR DESCRIPTION
## Summary
- document difference between `disciple.js` and `game/disciples.js`
- add header comments to both modules for clarity

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687c1686af1c83269cb5f31e8d555554