### PR TITLE
Fix construct load error

### DIFF
--- a/game/sect.js
+++ b/game/sect.js
@@ -669,6 +669,7 @@ export function unlockConstruct(name) {
 }
 
 export function renderConstructCards() {
+  if (!panel) return;
   const cont = panel.querySelector('#modalCardContainer');
   const slotCont = panel.querySelector('#memorySlotsDisplay');
   if (!cont || !slotCont) return;


### PR DESCRIPTION
## Summary
- guard `renderConstructCards` when sect panel isn't present

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687c1825b04483268ec5ffb5afa35ba3