### PR TITLE
Align attribute effects with documentation

### DIFF
--- a/attributes.js
+++ b/attributes.js
@@ -1,46 +1,9 @@
 export const attributes = {
-  Strength: {
-    points: 0,
-    get meleeDamageMultiplier() {
-      return 1 + 0.05 * this.points;
-    },
-    get inventorySlots() {
-      return Math.floor(this.points / 2);
-    }
-  },
-  Endurance: {
-    points: 0,
-    get staminaMultiplier() {
-      return 1 + 0.05 * this.points;
-    },
-    get staminaRegenMultiplier() {
-      return 1 + 0.01 * this.points;
-    },
-    get hpBonus() {
-      return 10 * this.points;
-    }
-  },
-  Dexterity: {
-    points: 0,
-    get attackSpeedMultiplier() {
-      return 1 + 0.05 * this.points;
-    }
-  },
-  Intelligence: {
-    points: 0,
-    get constructPotencyMultiplier() {
-      return 1 + 0.03 * this.points;
-    }
-  },
-  Charisma: {
-    points: 0,
-    get recruitChanceMultiplier() {
-      return 1 + 0.05 * this.points;
-    },
-    get diplomacyBonus() {
-      return 1 + 0.05 * this.points;
-    }
-  },
+  Strength: { points: 0 },
+  Endurance: { points: 0 },
+  Dexterity: { points: 0 },
+  Intelligence: { points: 0 },
+  Charisma: { points: 0 },
   Potential: {
     value: 0,
     get innerCauldronSize() {

--- a/disciple.js
+++ b/disciple.js
@@ -43,9 +43,11 @@ export default class Disciple {
   }
 
   updateCombatStats() {
-    this.damage = this.combatLevel * 3 * (1 + 0.05 * this.strength);
-    this.attackSpeed = 10000 / (1 + 0.05 * this.dexterity);
-    this.defense = (1 + 0.05 * this.endurance) * this.combatLevel;
+    // Combat stats no longer scale with attributes.
+    // Damage and defense grow purely with combat level as documented.
+    this.damage = this.combatLevel * 3;
+    this.attackSpeed = 10000;
+    this.defense = this.combatLevel;
   }
 
   takeDamage(amount) {

--- a/game/state.js
+++ b/game/state.js
@@ -1,4 +1,3 @@
-import { attributes } from '../attributes.js';
 import RateTracker from '../utils/rateTracker.js';
 import { BossTemplates } from '../boss.js';
 
@@ -73,7 +72,6 @@ export const stats = {
   avgProficiencyLevel: 0
 
 };
-stats.combatSlots = stats.combatSlots + attributes.Strength.inventorySlots;
 
 export const systems = {
   buildingUnlocked: false,

--- a/script.js
+++ b/script.js
@@ -31,10 +31,7 @@ import { SECT_SCHEDULE, getCurrentSchedule } from "./game/sect.js";
 import { formatNumber } from "./utils/numberFormat.js";
 import { runAnimation } from "./utils/animation.js";
 import { initMetamorphosis, refreshMetamorphosis } from './metamorphosis.js';
-import {
-  attributes,
-  intelligenceXpMultiplier
-} from './attributes.js';
+import { intelligenceXpMultiplier } from './attributes.js';
 import { createOverlay } from './ui/overlay.js';
 import { showLoadErrorOverlay } from './ui/loadErrorOverlay.js';
 import { openExplorationOverlay, closeExplorationOverlay, openWorkOverlay, openScheduleOverlay, openPlaceholderOverlay, openResourceOverlay, openBuildOverlay, closeDungeonOverlay, locationListContainer, explorationListContainer } from "./ui/colonyOverlays.js";
@@ -1473,24 +1470,22 @@ function buildDiscipleStatusView(d) {
       label: 'Strength',
       value: d.strength,
       base: d.baseStrength ?? 1,
-      effect:
-        `Melee Damage ×${(1 + 0.05 * (d.strength - 1)).toFixed(2)}, ` +
-        `+${Math.floor((d.strength - 1) / 2)} Inventory Slots`,
-      desc: 'Improves woodcutting, hunting & mining yield'
+      effect: `Yield ×${(1 + 0.05 * (d.strength - 1)).toFixed(2)}`,
+      desc: 'Boosts woodcutting, hunting & mining yield'
     },
     {
       label: 'Dexterity',
       value: d.dexterity,
       base: d.baseDexterity ?? 1,
-      effect: `Attack Speed ×${(1 + 0.05 * (d.dexterity - 1)).toFixed(2)}`,
-      desc: 'Increases gathering & hunting yield and discovery chance'
+      effect: `Yield ×${(1 + 0.05 * (d.dexterity - 1)).toFixed(2)}`,
+      desc: 'Raises gathering & hunting yield and discovery chance'
     },
     {
       label: 'Intelligence',
       value: d.intelligence,
       base: d.baseIntelligence ?? 1,
       effect:
-        `Construct Potency ×${(1 + 0.03 * (d.intelligence - 1)).toFixed(2)}, ` +
+        `Potency ×${(1 + 0.03 * (d.intelligence - 1)).toFixed(2)}, ` +
         `Learning ×${learning}`,
       desc: 'Improves Chanting and Research'
     },
@@ -1498,11 +1493,8 @@ function buildDiscipleStatusView(d) {
       label: 'Endurance',
       value: d.endurance,
       base: d.baseEndurance ?? 1,
-      effect:
-        `Stamina ×${(1 + 0.05 * (d.endurance - 1)).toFixed(2)}, ` +
-        `Regen ×${(1 + 0.01 * (d.endurance - 1)).toFixed(2)}, ` +
-        `+${10 * (d.endurance - 1)} HP`,
-      desc: 'Speeds building'
+      effect: `Build Speed ×${(1 + 0.05 * (d.endurance - 1)).toFixed(2)}`,
+      desc: 'Speeds building and farming'
     },
     {
       label: 'Charisma',
@@ -1681,9 +1673,7 @@ function buildDiscipleStatsView(d) {
       label: 'Strength',
       value: d.strength,
       base: d.baseStrength ?? 1,
-      effect:
-        `Melee ×${(1 + 0.05 * (d.strength - 1)).toFixed(2)}, ` +
-        `+${Math.floor((d.strength - 1) / 2)} inventory; woodcutting, hunting & mining yield`,
+      effect: `Yield ×${(1 + 0.05 * (d.strength - 1)).toFixed(2)}; woodcutting, hunting & mining`,
       cls: 'strength'
     },
     {
@@ -1691,7 +1681,7 @@ function buildDiscipleStatsView(d) {
       value: d.dexterity,
       base: d.baseDexterity ?? 1,
       effect:
-        `Speed ×${(1 + 0.05 * (d.dexterity - 1)).toFixed(2)}; gathering & hunting yield, discovery chance`,
+        `Yield ×${(1 + 0.05 * (d.dexterity - 1)).toFixed(2)}; gathering & hunting, discovery chance`,
       cls: 'dexterity'
     },
     {
@@ -1706,10 +1696,7 @@ function buildDiscipleStatsView(d) {
       label: 'Endurance',
       value: d.endurance,
       base: d.baseEndurance ?? 1,
-      effect:
-        `Stamina ×${(1 + 0.05 * (d.endurance - 1)).toFixed(2)}, Regen ×${(
-          1 + 0.01 * (d.endurance - 1)
-        ).toFixed(2)}, +${10 * (d.endurance - 1)} HP; building speed`,
+      effect: `Build Speed ×${(1 + 0.05 * (d.endurance - 1)).toFixed(2)}`,
       cls: 'endurance'
     }
   ];
@@ -2904,7 +2891,7 @@ function updatePlayerStats() {
     stats.avgProficiencyLevel = profTotal / count;
   }
 
-  stats.combatSlots = BASE_STATS.combatSlots + attributes.Strength.inventorySlots;
+  stats.combatSlots = BASE_STATS.combatSlots;
   renderPlayerStats(stats);
 }
 


### PR DESCRIPTION
## Summary
- remove unused combat-related attribute functions
- simplify `updateCombatStats` so attributes no longer influence combat
- show accurate attribute effects in disciple panels
- drop strength bonus from combat slot calculation

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687c1ac98d8883269fd24a1f18bdeb4b