### PR TITLE
Implement metamorphosis disciple selection

### DIFF
--- a/docs/13-metamorphosis-stages-&-methods.md
+++ b/docs/13-metamorphosis-stages-&-methods.md
@@ -12,6 +12,7 @@ Each disciple evolves through frog-like spiritual metamorphosis. Accessible via 
 - **Tadpole silhouette** with animated fill toward next breakthrough. replacing body figure.
 - **Progress bar** showing XP and % toward next phase
 - **metamorphosis Stats**: method modifiers, room/building multipliers, season, humidity, and training bonuses
+- **Left panel disciple list** for selecting which coquí's progress to view
 
 ---
 

--- a/game/constants.js
+++ b/game/constants.js
@@ -82,3 +82,5 @@ export const LOCATION_DEFS = [
   { name: 'Exoteric Dungeon', reqDistance: 100, baseChance: 1.0, x: '60%', y: '25%' },
   { name: 'Ancient Ruins', reqDistance: 800, baseChance: 0.05, x: '80%', y: '10%' }
 ];
+
+export const METAMORPHOSIS_STAGE_REQ = 25000;

--- a/game/sect.js
+++ b/game/sect.js
@@ -1,5 +1,5 @@
 import addLog from '../log.js';
-import { refreshMetamorphosis } from '../metamorphosis.js';
+import { refreshMetamorphosis, tickMetamorphosis } from '../metamorphosis.js';
 import { sectState, currentEnemy } from './state.js';
 import { generateDiscipleAttributes } from '../discipleAttributes.js';
 import Disciple from '../disciple.js';
@@ -1281,6 +1281,7 @@ export function tickSectSystem(delta) {
     }
   }
   tickActiveConstructs(dt);
+  tickMetamorphosis(dt);
   ins.current = Math.min(ins.max, Math.max(0, ins.current));
   if (hasUI) {
     updateCooldownOverlays();

--- a/game/state.js
+++ b/game/state.js
@@ -96,6 +96,7 @@ export const sectState = {
   discipleProgress: {},
   discipleSkills: {},
   discipleConstructXp: {},
+  discipleMetamorphosis: {},
   chantAssignments: {},
   discipleRest: {},
   maxDisciples: 3,

--- a/metamorphosis.js
+++ b/metamorphosis.js
@@ -1,18 +1,22 @@
 import { sectSystem } from './game/sect.js';
+import { sectState } from './game/state.js';
+import { createDiscipleBadge } from './game/badges.js';
+import { METAMORPHOSIS_STAGE_REQ } from './game/constants.js';
 
 export const metamorphosisState = {
-  meditationProgress: 0,
-  meditating: false,
-  requirement: 100000
+  requirement: METAMORPHOSIS_STAGE_REQ
 };
 
 let container;
 let meditateBtn;
 let progressFill;
 let progressText;
+let listContainer;
+let selectedDiscipleId = null;
 
 export function initMetamorphosis() {
   container = document.getElementById('metamorphosisTabContent');
+  listContainer = document.getElementById('metamorphosisDiscipleList');
   if (!container) return;
 const bodyPath = `M200 150
                m -25 0
@@ -47,6 +51,7 @@ const bodyPath = `M200 150
   meditateBtn = container.querySelector('#meditateMetamorphosisBtn');
   progressFill = container.querySelector('#metamorphosisBarFill');
   progressText = container.querySelector('#metamorphosisProgressText');
+  selectedDiscipleId = sectSystem.disciples[0]?.id || null;
   window.addEventListener('orbs-changed', renderMetamorphosis);
   meditateBtn.addEventListener('click', toggleMeditation);
   meditateBtn.addEventListener('mouseenter', e => {
@@ -54,30 +59,72 @@ const bodyPath = `M200 150
   });
   meditateBtn.addEventListener('mouseleave', window.hideTooltip);
   if (window.lucide) window.lucide.createIcons({ icons: window.lucide.icons });
+  document.addEventListener('disciple-gained', refreshMetamorphosis);
+  renderDiscipleList();
   renderMetamorphosis();
+}
+
+function ensureMeta(id) {
+  if (!sectState.discipleMetamorphosis[id]) {
+    sectState.discipleMetamorphosis[id] = { xp: 0, stage: 0, meditating: false };
+  }
+}
+
+function renderDiscipleList() {
+  if (!listContainer) return;
+  listContainer.innerHTML = '';
+  const list = document.createElement('div');
+  list.className = 'sect-disciple-list';
+  sectSystem.disciples.forEach(d => {
+    ensureMeta(d.id);
+    const card = createDiscipleBadge(d);
+    card.classList.add('sect-disciple-card');
+    if (d.id === selectedDiscipleId) card.classList.add('selected');
+    card.addEventListener('click', () => {
+      selectedDiscipleId = d.id;
+      renderDiscipleList();
+      renderMetamorphosis();
+    });
+    list.appendChild(card);
+  });
+  listContainer.appendChild(list);
 }
 
 
 function toggleMeditation() {
-  if (metamorphosisState.meditationProgress >= metamorphosisState.requirement) {
+  if (!selectedDiscipleId) return;
+  const meta = sectState.discipleMetamorphosis[selectedDiscipleId];
+  if (!meta) return;
+  if (meta.xp >= metamorphosisState.requirement) {
     breakthrough();
     return;
   }
-  metamorphosisState.meditating = !metamorphosisState.meditating;
-  meditateBtn.textContent = metamorphosisState.meditating ? 'Meditating...' : 'Meditate';
+  meta.meditating = !meta.meditating;
+  meditateBtn.textContent = meta.meditating ? 'Meditating...' : 'Meditate';
 }
 
 function breakthrough() {
-  metamorphosisState.meditationProgress = 0;
-  // requirement could scale later; keep constant for now
+  if (!selectedDiscipleId) return;
+  const meta = sectState.discipleMetamorphosis[selectedDiscipleId];
+  if (!meta) return;
+  meta.xp = 0;
+  meta.stage += 1;
   sectSystem.orbs.water.current = 0;
+  meta.meditating = false;
   meditateBtn.textContent = 'Meditate';
   renderMetamorphosis();
 }
 
 function renderMetamorphosis() {
   if (!container) return;
-  const coreFill = Math.min(1, metamorphosisState.meditationProgress / metamorphosisState.requirement);
+  if (!selectedDiscipleId) {
+    if (progressText) progressText.textContent = '';
+    if (progressFill) progressFill.style.width = '0%';
+    return;
+  }
+  const meta = sectState.discipleMetamorphosis[selectedDiscipleId];
+  const d = sectSystem.disciples.find(x => x.id === selectedDiscipleId);
+  const coreFill = Math.min(1, (meta?.xp || 0) / metamorphosisState.requirement);
 
   const updateRect = (id, cx, cy, r, fill) => {
     const rect = container.querySelector(id);
@@ -90,20 +137,34 @@ function renderMetamorphosis() {
 
   updateRect('#bodyFill', 200, 180, 60, coreFill);
 
-  if (progressText) progressText.textContent = `${Math.floor(metamorphosisState.meditationProgress)}/${metamorphosisState.requirement}`;
+  if (progressText) progressText.textContent = `${Math.floor(meta.xp)}/${metamorphosisState.requirement}`;
   if (progressFill) progressFill.style.width = `${coreFill * 100}%`;
-  if (metamorphosisState.meditationProgress >= metamorphosisState.requirement) {
+  if (meta.xp >= metamorphosisState.requirement) {
     meditateBtn.textContent = 'Breakthrough';
   } else {
-    meditateBtn.textContent = metamorphosisState.meditating ? 'Meditating...' : 'Meditate';
+    meditateBtn.textContent = meta.meditating ? 'Meditating...' : 'Meditate';
   }
   meditateBtn.disabled = false;
 
   const halo = container.querySelector('#metamorphosisHalo');
-  if (halo) halo.setAttribute('opacity', metamorphosisState.meditationProgress >= metamorphosisState.requirement ? '1' : '0');
+  if (halo) halo.setAttribute('opacity', meta.xp >= metamorphosisState.requirement ? '1' : '0');
+
+  const label = container.querySelector('#assignedDisciple');
+  if (label && d) label.textContent = d.name || `Disciple ${d.id}`;
 }
 
 export function refreshMetamorphosis() {
   renderMetamorphosis();
+}
+
+export function tickMetamorphosis(dt) {
+  sectSystem.disciples.forEach(d => {
+    ensureMeta(d.id);
+    const meta = sectState.discipleMetamorphosis[d.id];
+    if (meta.meditating && meta.xp < metamorphosisState.requirement) {
+      const rate = 0.4 * d.potential * d.potential;
+      meta.xp = Math.min(metamorphosisState.requirement, meta.xp + rate * dt);
+    }
+  });
 }
 

--- a/utils/discipleInit.js
+++ b/utils/discipleInit.js
@@ -1,5 +1,6 @@
 import Disciple from '../disciple.js';
 import { calculateMaxWater } from './water.js';
+import { sectState } from '../game/state.js';
 
 export function initializeDisciple(d) {
   if (!d) return d;
@@ -32,6 +33,13 @@ export function initializeDisciple(d) {
   if (d.currentHp === undefined) d.currentHp = d.maxHp;
   if (d.foundationXp === undefined) d.foundationXp = 0;
   if (d.lastTab === undefined) d.lastTab = 'general';
+  if (!sectState.discipleMetamorphosis[d.id]) {
+    sectState.discipleMetamorphosis[d.id] = {
+      xp: 0,
+      stage: 0,
+      meditating: false
+    };
+  }
   Object.setPrototypeOf(d, Disciple.prototype);
   if (typeof d.updateCombatStats === 'function') d.updateCombatStats();
   return d;


### PR DESCRIPTION
## Summary
- track metamorphosis data per disciple
- list disciples in the metamorphosis tab and allow selecting one
- tick disciple meditation progress each frame
- expose metamorphosis requirement constant
- document new disciple list UI

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687c1e25f64483268c2af9fc22f72493