### PR TITLE
UI tweaks for sect summary

### DIFF
--- a/script.js
+++ b/script.js
@@ -847,13 +847,14 @@ function updateSectDisplay() {
   if (!sectTabUnlocked || !playerSectPanel) return;
   const total = sectSystem.disciples.length;
   const assigned = Object.values(sectState.discipleTasks).filter(t => t && t !== 'Idle').length;
+  const idle = total - assigned;
   if (sectSummaryDisplay) {
     const remaining = Math.max(0, DAY_LENGTH_SECONDS - sectSystem.seasonTimer);
     const mm = String(Math.floor(remaining / 60)).padStart(2, '0');
     const ss = String(Math.floor(remaining % 60)).padStart(2, '0');
     const upkeep = DAILY_FRUIT_CONSUMPTION * sectSystem.disciples.length;
     sectSummaryDisplay.innerHTML = `
-      <span>👥 ${total - assigned}/${total} / ${sectState.maxDisciples}</span>
+      <span>👥 ${total}/${sectState.maxDisciples} (Idle: ${idle})</span>
       <span>${sectState.fruits}</span>
       <span>🪵 ${sectState.softwood}</span>`;
     const timer = document.getElementById('resourceTimer');

--- a/style.css
+++ b/style.css
@@ -2647,7 +2647,7 @@ body.darkenshift-mode .tabsContainer button.active {
     position: absolute;
     left: 4px;
     top: 40px;
-    width: 120px; /* reduced by ~20% */
+    width: fit-content;
     display: flex;
     flex-direction: column;
     gap: 4px;
@@ -3249,7 +3249,7 @@ body.darkenshift-mode .tabsContainer button.active {
   .sect-bohio { width: 36px; height: 28px; }
   .sect-nav-panel button { width: 32px; height: 32px; font-size: 0.65rem; }
   .sect-nav-panel button svg { width: 20px; height: 20px; }
-  .sect-resource-display { width: 160px; }
+  .sect-resource-display { width: fit-content; }
   .sect-summary { font-size: 0.7rem; }
 }
 


### PR DESCRIPTION
## Summary
- trim the width of the sect resource overlay so its background only fits the text
- clarify the disciple summary to display total/max with idle count

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687c1f867cc0832690db24061af04d43