### PR TITLE
Reduce zone size to avoid overlaps

### DIFF
--- a/docs/00-wireframes.md
+++ b/docs/00-wireframes.md
@@ -68,6 +68,8 @@ Zones curve around the Water Orb in an ellipse:
 - Research Zone
 - Housing Zone (between the upper zones)
 
+Zones are sized to **26%** of the main canvas so they no longer overlap.
+
 The Water Orb now sits at the exact center, with the housing zone forming the tip
 of a loose triangle above the lower zones.
 

--- a/style.css
+++ b/style.css
@@ -40,7 +40,7 @@ body {
     --verdantia-highlight: #c5f2d4;
     --verdantia-jade: #52795c;
     --verdantia-parchment: #fefae0;
-    --zone-size: 36.8%;
+    --zone-size: 26%;
 }
 
 body.darkenshift-mode {


### PR DESCRIPTION
## Summary
- shrink sect zone size in CSS so that zone markers don't overlap
- document updated zone size

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687c25e1240c832699147616f8bb17e3