### PR TITLE
Improve day/night visuals

### DIFF
--- a/docs/00-wireframes.md
+++ b/docs/00-wireframes.md
@@ -74,7 +74,7 @@ Zones are sized to **26%** of the main canvas so they no longer overlap.
 The Water Orb now sits at the exact center, with the housing zone forming the tip
 of a loose triangle above the lower zones.
 
-Water Orb widget shows current Water per second.
+Water Orb displays its regen rate within the orb itself and glows softly at night.
 
 
 Footer

--- a/docs/16-water-orb.md
+++ b/docs/16-water-orb.md
@@ -6,3 +6,5 @@
 - Low‑food disciples divert to orb to replenish (+0.383 food/s) at cost of Water input.
 - Orb distributes Water as global energy; buildings can boost its output.
 - Disciples can direct % of personal Water to orb.
+- The orb is now larger and displays its regeneration rate centered within.
+- At night the orb glows brightly, illuminating nearby terrain.

--- a/index.html
+++ b/index.html
@@ -164,7 +164,6 @@
             <div class="zone research"></div>
             <div id="mistLayer" class="mist-trails"></div>
             <div class="sect-orbs" id="sectOrbs"></div>
-            <div id="waterRate" class="water-rate"></div>
             <div id="sectBasket" class="sect-basket"></div>
             <div id="sectBohio" class="sect-bohio"></div>
             <div id="fruitPatch" class="fruit-patch">

--- a/script.js
+++ b/script.js
@@ -895,16 +895,12 @@ function updateSectDisplay() {
       orb.style.top = p.top;
       if (p.cls === 'water') {
         orb.addEventListener('click', openWaterRegenPopup);
+        const rateEl = document.createElement('div');
+        rateEl.className = 'orb-regen';
+        rateEl.textContent = `${sectSystem.gains.water.toFixed(2)}/s`;
+        orb.appendChild(rateEl);
       }
       orbs.appendChild(orb);
-      if (p.cls === 'water') {
-        const rateEl = document.getElementById('waterRate');
-        if (rateEl) {
-          const orbSize = mobile ? 30 : 50;
-          rateEl.style.top = `calc(${p.top} + ${orbSize / 2 + 4}px)`;
-          rateEl.textContent = `${sectSystem.gains.water.toFixed(2)}/s`;
-        }
-      }
     });
   }
 
@@ -947,6 +943,7 @@ function updateMapBrightness(phase) {
     Night: 0.3
   };
   map.style.filter = `brightness(${values[phase] || 1})`;
+  map.classList.toggle('night', phase === 'Night');
 }
 
 function feedDisciples() {

--- a/style.css
+++ b/style.css
@@ -2240,13 +2240,15 @@ body.darkenshift-mode .tabsContainer button.active {
 }
 
 .orb-regen {
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    width: 100%;
     font-size: 0.6rem;
     text-align: center;
-    color: #aaa;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 2px;
+    color: #fff;
+    pointer-events: none;
 }
 
 .construct-orb {
@@ -2859,6 +2861,7 @@ body.darkenshift-mode .tabsContainer button.active {
     position: relative;
     min-height: 200px;
     height: 100%;
+    transition: filter 2s linear;
 }
 
 .colony-side {
@@ -2969,8 +2972,8 @@ body.darkenshift-mode .tabsContainer button.active {
 }
 .sect-orb {
     position: absolute;
-    width: 50px;
-    height: 50px;
+    width: 100px;
+    height: 100px;
     border-radius: 50%;
     opacity: 0.9;
     box-shadow: 0 0 4px rgba(255, 255, 255, 0.6);
@@ -2993,14 +2996,8 @@ body.darkenshift-mode .tabsContainer button.active {
     color: #7fd9ff;
 }
 .sect-orb.water .orb-fill { background: rgba(127,217,255,0.6); }
-.water-rate {
-    position: absolute;
-    left: 50%;
-    transform: translateX(-50%);
-    color: #fff;
-    text-shadow: 0 0 4px #000;
-    font-size: 0.75rem;
-    pointer-events: none;
+.colony-map.night .sect-orb.water {
+    box-shadow: 0 0 20px rgba(127,217,255,0.8), 0 0 60px rgba(127,217,255,0.6);
 }
 .sect-basket {
     position: absolute;
@@ -3250,7 +3247,7 @@ body.darkenshift-mode .tabsContainer button.active {
 
 /* Mobile adjustments */
 @media (max-width: 600px) {
-  .sect-orb { width: 30px; height: 30px; }
+  .sect-orb { width: 60px; height: 60px; }
   .disciple-orb { width: 12px; height: 12px; }
   .sect-disciple { width: 3px; height: 3px; font-size: 0; }
   .sect-basket { width: 6px; height: 4px; }
@@ -3260,7 +3257,7 @@ body.darkenshift-mode .tabsContainer button.active {
 
 /* Desktop scaling */
 @media (min-width: 1024px) {
-  .sect-orb { width: 70px; height: 70px; }
+  .sect-orb { width: 140px; height: 140px; }
   .disciple-orb { width: 20px; height: 20px; }
   .sect-disciple { width: 7px; height: 7px; }
   .sect-basket { width: 12px; height: 8px; }


### PR DESCRIPTION
## Summary
- add smooth filter transition for day/night map updates
- double the Water Orb size and center regen text
- glow orb at night for visibility
- remove redundant waterRate element
- document new orb behavior

## Testing
- `npm install`
- `npm run build` *(fails: Bus error)*
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c3d07e8a08326a2aed7e91be771fc