### PR TITLE
Fix badge texture on headless envs

### DIFF
--- a/game/badgeBackground.js
+++ b/game/badgeBackground.js
@@ -6,6 +6,10 @@ const parchmentTexture = PIXI.Texture.from('img/parchment.jpg');
 
 function ensureApp() {
   if (app) return;
+  if (typeof document === 'undefined' || !globalThis.HTMLCanvasElement) {
+    // Skip if canvas is unavailable (e.g. during server-side tests)
+    return;
+  }
   app = new PIXI.Application({
     width: window.innerWidth,
     height: window.innerHeight,
@@ -38,6 +42,7 @@ function updateAll() {
 
 export function applyBadgeTexture(el) {
   ensureApp();
+  if (!app) return;
   const sprite = new PIXI.Sprite(parchmentTexture);
   sprites.set(el, sprite);
   updateSprite(sprite, el);


### PR DESCRIPTION
## Summary
- handle missing canvas when applying badge textures

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687c437c532083268d2a893b18781963