### PR TITLE
fix badge background init check

### DIFF
--- a/game/badgeBackground.js
+++ b/game/badgeBackground.js
@@ -6,15 +6,26 @@ const parchmentTexture = PIXI.Texture.from('img/parchment.jpg');
 
 function ensureApp() {
   if (app) return;
-  if (typeof document === 'undefined' || !globalThis.HTMLCanvasElement) {
-    // Skip if canvas is unavailable (e.g. during server-side tests)
+  if (
+    typeof document === 'undefined' ||
+    !globalThis.HTMLCanvasElement ||
+    typeof PIXI === 'undefined'
+  ) {
+    // Skip if canvas or PIXI is unavailable (e.g. server-side tests)
     return;
   }
-  app = new PIXI.Application({
-    width: window.innerWidth,
-    height: window.innerHeight,
-    transparent: true
-  });
+  const testCanvas = document.createElement('canvas');
+  if (!testCanvas.getContext) return;
+  try {
+    app = new PIXI.Application({
+      width: window.innerWidth,
+      height: window.innerHeight,
+      transparent: true
+    });
+  } catch (e) {
+    console.error('PIXI init failed', e);
+    return;
+  }
   app.view.classList.add('badge-texture-layer');
   app.view.style.position = 'fixed';
   app.view.style.top = '0';


### PR DESCRIPTION
## Summary
- guard PIXI initialization in `badgeBackground.js` to avoid failing when canvas or PIXI is missing

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687c46cc3d408326b6275b8809b3def5