### PR TITLE
Fix Pixi badge import causing black screen

### DIFF
--- a/game/badgeBackground.js
+++ b/game/badgeBackground.js
@@ -1,4 +1,4 @@
-import { Application, Sprite, Texture } from 'pixi.min.js';
+/* global PIXI */
 
 let app = null;
 const sprites = new Map();
@@ -53,7 +53,7 @@ function updateAll() {
 export function applyBadgeTexture(el) {
   ensureApp();
   if (!app || !parchmentTexture) return;
-  const sprite = new Sprite(parchmentTexture);
+  const sprite = new PIXI.Sprite(parchmentTexture);
 
   sprites.set(el, sprite);
   updateSprite(sprite, el);


### PR DESCRIPTION
## Summary
- update `badgeBackground.js` to rely on global `PIXI` rather than missing import

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687c54277c40832680072a2e5a325c9c