### PR TITLE
Fix Pixi canvas transparency

### DIFF
--- a/game/badgeBackground.js
+++ b/game/badgeBackground.js
@@ -1,8 +1,8 @@
-import { Application, Sprite, Texture } from 'pixi.min.js';
+/* global PIXI */
 
 let app = null;
 const sprites = new Map();
-let parchmentTexture = null;
+const parchmentTexture = PIXI.Texture.from('img/parchment.jpg');
 
 function ensureApp() {
   if (app) return;
@@ -19,7 +19,7 @@ function ensureApp() {
     app = new PIXI.Application({
       width: window.innerWidth,
       height: window.innerHeight,
-      transparent: true
+      backgroundAlpha: 0
     });
   } catch (e) {
     console.error('PIXI init failed', e);
@@ -52,8 +52,8 @@ function updateAll() {
 
 export function applyBadgeTexture(el) {
   ensureApp();
-  if (!app || !parchmentTexture) return;
-  const sprite = new Sprite(parchmentTexture);
+  if (!app) return;
+  const sprite = new PIXI.Sprite(parchmentTexture);
 
   sprites.set(el, sprite);
   updateSprite(sprite, el);


### PR DESCRIPTION
## Summary
- restore parchment texture loading
- use `backgroundAlpha: 0` for transparent PIXI canvas

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687c54277c40832680072a2e5a325c9c