### PR TITLE
feat: add bamboo border layer

### DIFF
--- a/docs/00-wireframes.md
+++ b/docs/00-wireframes.md
@@ -80,7 +80,9 @@ Water Orb displays its regen rate within the orb itself and glows softly at nigh
 Footer
 
 “Gate” button to open the full map/exploration/tasks overlay.
-* Exploration and sect disciple lists now use a unified bamboo-colored badge showing the disciple's name, mood, HP bar and current task.
+* Exploration and sect disciple lists now use a unified badge built in PixiJS.
+  Each badge layers a bamboo border beneath a parchment background, with the
+  disciple's name, mood, HP bar and current task rendered on top.
 
 #dicsiple overlay card on pressing disciple
 

--- a/game/badgeBackground.js
+++ b/game/badgeBackground.js
@@ -1,8 +1,11 @@
 /* global PIXI */
 
 let app = null;
+// track containers for each badge element
 const sprites = new Map();
-const parchmentTexture = PIXI.Texture.from('img/parchment.jpg');
+// load textures for bamboo border and parchment background
+const bambooTexture = PIXI.Texture.from('img/bamboo.png');
+const parchmentTexture = PIXI.Texture.from('img/parchment.png');
 
 // only once PIXI is loaded will this run
 function ensureApp() {
@@ -44,18 +47,22 @@ function ensureApp() {
   window.addEventListener('scroll', updateAll);
 }
 
-function updateSprite(sprite, el) {
+function updateContainer(objs, el) {
   const r = el.getBoundingClientRect();
-  Object.assign(sprite, {
-    x: r.left,
-    y: r.top,
-    width:  r.width,
-    height: r.height
+  const { container, bamboo, parchment } = objs;
+  Object.assign(container, { x: r.left, y: r.top });
+  Object.assign(bamboo, { width: r.width, height: r.height });
+  const pad = 4;
+  Object.assign(parchment, {
+    x: pad,
+    y: pad,
+    width: Math.max(0, r.width - pad * 2),
+    height: Math.max(0, r.height - pad * 2)
   });
 }
 
 function updateAll() {
-  sprites.forEach((spr, el) => updateSprite(spr, el));
+  sprites.forEach((objs, el) => updateContainer(objs, el));
 }
 
 export function applyBadgeTexture(el) {
@@ -63,12 +70,19 @@ export function applyBadgeTexture(el) {
 
   if (!app) return;
 
-  const sprite = new PIXI.Sprite(parchmentTexture);
+  const container = new PIXI.Container();
+  const bamboo = new PIXI.Sprite(bambooTexture);
+  const parchment = new PIXI.Sprite(parchmentTexture);
 
-  sprites.set(el, sprite);
-  updateSprite(sprite, el);
-  app.stage.addChild(sprite);
+  container.addChild(bamboo);
+  container.addChild(parchment);
 
-  new ResizeObserver(() => updateSprite(sprite, el))
+  const objs = { container, bamboo, parchment };
+
+  sprites.set(el, objs);
+  updateContainer(objs, el);
+  app.stage.addChild(container);
+
+  new ResizeObserver(() => updateContainer(objs, el))
     .observe(el);
 }

--- a/style.css
+++ b/style.css
@@ -3638,6 +3638,7 @@ body.darkenshift-mode .tabsContainer button.active {
   flex-direction: column;
   align-items: center;
   position: relative;
+  z-index: 1;
   gap: 2px;
 }
 .disciple-badge .mood-icon {
@@ -3682,5 +3683,5 @@ body.darkenshift-mode .tabsContainer button.active {
   position: fixed;
   top: 0;
   left: 0;
-  z-index: 2;
+  z-index: 0;
 }


### PR DESCRIPTION
## Summary
- render disciples badges with bamboo border and parchment background
- keep badge textures behind DOM elements
- document new badge layering

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687c6c65caec8326a99f606f450939e2