### PR TITLE
Update season banner layout

### DIFF
--- a/docs/00-wireframes.md
+++ b/docs/00-wireframes.md
@@ -43,7 +43,8 @@ Header
 
 inside sect tab:
 
-left top: current season, date, weather.
+left top: current season, date, weather. The season banner now shows the day and
+weather icon side‑by‑side for quick reference.
 
 center top: disciple list with name, task and fill for each bar.
 This row appears above the sect map. The previous row of disciple cards beneath the map has been removed for clarity.

--- a/game/sect.js
+++ b/game/sect.js
@@ -984,13 +984,16 @@ function renderOrbs() {
 function renderSeasonBanner() {
   const banner = document.getElementById('seasonBanner');
   if (!banner) return;
+  const textEl = banner.querySelector('.season-text');
+  const weatherEl = banner.querySelector('.weather-icon');
   const idx = sectSystem.seasonIndex;
   const season = seasons[idx];
   setSeasonBackdrop(season.name);
   const day = sectSystem.seasonDay + 1;
   const daysLeft = SEASON_LENGTH_DAYS - day;
   const temp = seasonTemps[idx];
-  banner.textContent = `${season.name} Day ${day} (${daysLeft}d) ${temp}°C`;
+  if (textEl) textEl.textContent = `${season.name} Day ${day} (${daysLeft}d) ${temp}°C`;
+  if (weatherEl) weatherEl.textContent = sectSystem.weather ? sectSystem.weather.icon : '';
   banner.className = `season-banner ${seasonClasses[idx]}`;
   if (container) {
     seasonClasses.forEach(cls => container.classList.remove(cls));
@@ -1000,9 +1003,6 @@ function renderSeasonBanner() {
     } else {
       container.classList.remove('verdantia-bg');
     }
-  }
-  if (sectSystem.weather) {
-    banner.innerHTML = `${season.name} Day ${day} (${daysLeft}d) ${temp}°C<span class="weather-icon">${sectSystem.weather.icon}</span>`;
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -143,7 +143,10 @@
       <div class="colony-main">
         <div id="colonyMap" class="colony-map">
           <div class="sect-header">
-            <div id="seasonBanner" class="season-banner"></div>
+            <div id="seasonBanner" class="season-banner">
+              <span class="season-text"></span>
+              <span class="weather-icon"></span>
+            </div>
             <div id="sectDiscipleList" class="sect-disciple-list"></div>
           </div>
           <div class="colony-tabs">

--- a/style.css
+++ b/style.css
@@ -3236,13 +3236,17 @@ body.darkenshift-mode .tabsContainer button.active {
 }
 
 .season-banner {
-    text-align: center;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
     font-weight: bold;
     font-size: 0.75rem;
-    padding: 2px 0;
+    padding: 2px 4px;
     border-radius: 4px;
     margin-bottom: 4px;
+    min-width: 120px;
 }
+.season-banner .season-text { flex: 1; }
 .season-banner.spring { background: #4caf50; }
 .season-banner.summer { background: #d4af37; color: #000; }
 .season-banner.autumn { background: #e09028; }


### PR DESCRIPTION
## Summary
- restructure the season banner markup to include day text and weather icon
- style season banner as flexbox for left/right layout
- update renderSeasonBanner to populate new elements
- document banner layout in wireframes

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687c7030783883268dac6d5d784b302e