### PR TITLE
Implement manual breakthroughs and path selection

### DIFF
--- a/docs/13-metamorphosis-stages-&-methods.md
+++ b/docs/13-metamorphosis-stages-&-methods.md
@@ -32,6 +32,8 @@ Potential = 5
 → `0.4 × 25 = 10 XP/s`  
 → `25,000 ÷ 10 = 2,500s ≈ 41.7 minutes` real-time work
 
+When the required XP is reached, progress pauses and a **Breakthrough** button appears. The disciple cannot gain additional XP until you press the button. Completing the Egg stage opens the Path selection screen, where you may choose from the available starter Paths.
+
 ---
 
 ### 2. 🐛 Tadpole Stage *(Water shaping)*

--- a/docs/17-paths.md
+++ b/docs/17-paths.md
@@ -13,6 +13,7 @@ Path of the Ember	Fire (火)	Mage	Combat Spells, Water generation, culture speed
 Path of the Emerald	Wood (木)	Ranger	Travel speed, gathering, stat boosts
 Path of the Azure Saint	Water (水)	Healer	Healing, crowd control, weather control
 Path of the Searing Shield	Fire (火)	Tank	Defense, resilience, frontline combat
+At the start of the game only the first three starter Paths can be chosen.
 
 
 

--- a/game/pathOverlay.js
+++ b/game/pathOverlay.js
@@ -1,0 +1,20 @@
+import { createOverlay } from '../ui/overlay.js';
+import { STARTER_PATHS } from './paths.js';
+
+export function showPathOverlay({ onSelect, available = 3 } = {}) {
+  const overlay = createOverlay({ className: 'path-overlay' });
+  const { box, close } = overlay;
+  const title = document.createElement('h2');
+  title.textContent = 'Choose a Path';
+  box.appendChild(title);
+  STARTER_PATHS.slice(0, available).forEach(name => {
+    const btn = document.createElement('button');
+    btn.textContent = name;
+    btn.addEventListener('click', () => {
+      if (onSelect) onSelect(name);
+      close();
+    });
+    box.appendChild(btn);
+  });
+  return overlay;
+}

--- a/game/paths.js
+++ b/game/paths.js
@@ -1,0 +1,6 @@
+export const STARTER_PATHS = [
+  'Path of the Ember',
+  'Path of the Emerald',
+  'Path of the Azure Saint',
+  'Path of the Searing Shield'
+];

--- a/game/state.js
+++ b/game/state.js
@@ -95,6 +95,7 @@ export const sectState = {
   discipleSkills: {},
   discipleConstructXp: {},
   discipleMetamorphosis: {},
+  disciplePaths: {},
   chantAssignments: {},
   discipleRest: {},
   maxDisciples: 3,

--- a/metamorphosis.js
+++ b/metamorphosis.js
@@ -2,6 +2,7 @@ import { sectSystem, getCurrentSchedule } from './game/sect.js';
 import { sectState } from './game/state.js';
 import { createDiscipleBadge } from './game/badges.js';
 import { METAMORPHOSIS_STAGE_REQ } from './game/constants.js';
+import { showPathOverlay } from './game/pathOverlay.js';
 
 export const metamorphosisState = {
   requirement: METAMORPHOSIS_STAGE_REQ
@@ -13,6 +14,7 @@ let progressText;
 let ringFill;
 let ringWrapper;
 let listContainer;
+let breakthroughBtn;
 let selectedDiscipleId = null;
 const RING_RADIUS = 80;
 const RING_CIRCUMFERENCE = 2 * Math.PI * RING_RADIUS;
@@ -53,6 +55,7 @@ const bodyPath = `M200 150
         <div id="metamorphosisProgressText" class="progress-text"></div>
         <div class="progress-bar"><div id="metamorphosisBarFill" class="progress-fill"></div></div>
       </div>
+      <button id="breakthroughBtn" class="breakthrough-btn" style="display:none;">Breakthrough</button>
       <div class="assigned-disciple">Assigned to <span id="assignedDisciple">disciple 1</span></div>
     </div>
   `;
@@ -60,6 +63,12 @@ const bodyPath = `M200 150
   progressText = container.querySelector('#metamorphosisProgressText');
   ringFill = container.querySelector('#metamorphosisRing');
   ringWrapper = container.querySelector('.metamorphosis-progress');
+  breakthroughBtn = container.querySelector('#breakthroughBtn');
+  if (breakthroughBtn) {
+    breakthroughBtn.addEventListener('click', () => {
+      if (selectedDiscipleId) breakthrough(selectedDiscipleId);
+    });
+  }
   selectedDiscipleId = sectSystem.disciples[0]?.id || null;
   window.addEventListener('orbs-changed', renderMetamorphosis);
   if (window.lucide) window.lucide.createIcons({ icons: window.lucide.icons });
@@ -101,6 +110,9 @@ function breakthrough(id) {
   meta.xp = 0;
   meta.stage += 1;
   sectSystem.orbs.water.current = 0;
+  if (meta.stage === 1) {
+    showPathOverlay({ onSelect: path => { sectState.disciplePaths[id] = path; } });
+  }
   renderMetamorphosis();
 }
 
@@ -145,6 +157,10 @@ function renderMetamorphosis() {
   const halo = container.querySelector('#metamorphosisHalo');
   if (halo) halo.setAttribute('opacity', meta.xp >= metamorphosisState.requirement ? '1' : '0');
 
+  if (breakthroughBtn) {
+    breakthroughBtn.style.display = meta.xp >= metamorphosisState.requirement ? 'block' : 'none';
+  }
+
   const label = container.querySelector('#assignedDisciple');
   if (label && d) label.textContent = d.name || `Disciple ${d.id}`;
 }
@@ -168,9 +184,6 @@ export function tickMetamorphosis(dt) {
         getCultivationSpeed(d) *
         getSeasonMultiplier();
       meta.xp = Math.min(metamorphosisState.requirement, meta.xp + rate * dt);
-        if (meta.xp >= metamorphosisState.requirement) {
-          breakthrough(d.id);
-      }
     }
   });
 }

--- a/style.css
+++ b/style.css
@@ -543,6 +543,13 @@ body.darkenshift-mode .tabsContainer button.active {
     flex-direction: column;
 }
 
+.path-overlay {
+    flex-direction: column;
+}
+.path-overlay button {
+    margin: 4px;
+}
+
 .camp-overlay button {
     font-size: 1rem;
     padding: 6px 10px;
@@ -1943,6 +1950,7 @@ body.darkenshift-mode .tabsContainer button.active {
     justify-content: flex-start;
     gap: 10px;
     flex: 1;
+    height: 100vh;
     background: var(--core-bg);
     border: 1px solid var(--core-border);
     border-radius: 8px;
@@ -1994,6 +2002,7 @@ body.darkenshift-mode .tabsContainer button.active {
     gap: 6px;
     position: relative;
     width: 100%;
+    height: 100%;
 }
 #metamorphosisTabContent svg {
     max-width: 360px;
@@ -2030,6 +2039,19 @@ body.darkenshift-mode .tabsContainer button.active {
 .metamorphosis-progress:hover .progress-ring-fill,
 .metamorphosis-progress.near-complete .progress-ring-fill {
     filter: drop-shadow(0 0 6px gold) drop-shadow(0 0 4px cyan);
+}
+.breakthrough-btn {
+    padding: 6px 12px;
+    border: 2px solid var(--core-accent);
+    background: var(--core-bg);
+    color: var(--core-text);
+    border-radius: 6px;
+    cursor: pointer;
+    box-shadow: 0 0 8px var(--core-glow);
+    font-size: 0.8rem;
+}
+.breakthrough-btn:hover {
+    box-shadow: 0 0 12px var(--core-glow);
 }
 .construct-main {
     display: flex;

--- a/utils/discipleInit.js
+++ b/utils/discipleInit.js
@@ -40,6 +40,9 @@ export function initializeDisciple(d) {
       meditating: false
     };
   }
+  if (sectState.disciplePaths[d.id] === undefined) {
+    sectState.disciplePaths[d.id] = null;
+  }
   Object.setPrototypeOf(d, Disciple.prototype);
   if (typeof d.updateCombatStats === 'function') d.updateCombatStats();
   return d;


### PR DESCRIPTION
## Summary
- expand metamorphosis panel height
- add breakthrough button that appears at max XP
- pause XP gain until breakthrough
- open path selection overlay after Egg stage
- store selected paths per disciple
- document new flow and starter path limitation

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687c7c45459083268d998f96d0490972