### PR TITLE
Add resource gain/loss overlay

### DIFF
--- a/docs/00-wireframes.md
+++ b/docs/00-wireframes.md
@@ -52,6 +52,7 @@ This row appears above the sect map. The previous row of disciple cards beneath 
 Left panel (Resource / Items)
 
 Shows stackable resources (fruit, wood, stone, etc.).
+Selecting the Resources nav opens an overlay showing daily gains and losses.
 
 
 Right panel (Navigation)

--- a/game/sect.js
+++ b/game/sect.js
@@ -1,10 +1,11 @@
 import addLog from '../log.js';
 import { refreshMetamorphosis, tickMetamorphosis } from '../metamorphosis.js';
-import { sectState, currentEnemy } from './state.js';
+import { sectState, currentEnemy, FRUIT_GROWTH_RATES } from './state.js';
 import { generateDiscipleAttributes } from '../discipleAttributes.js';
 import Disciple from '../disciple.js';
 import { initializeDisciple } from '../utils/discipleInit.js';
 import { createOverlay } from '../ui/overlay.js';
+import { DAILY_FRUIT_CONSUMPTION } from './constants.js';
 
 export { addDiscoveredLocation } from "./ui.js";
 export const discoveredLocations = [];
@@ -1379,6 +1380,24 @@ export function openWaterRegenPopup() {
 
   box.appendChild(list);
   overlay.appendButton('Close', overlay.close);
+}
+
+export function getDailyResourceDelta() {
+  const fruitGain = FRUIT_GROWTH_RATES[sectSystem.seasonIndex] || 0;
+  const fruitLoss = DAILY_FRUIT_CONSUMPTION * sectSystem.disciples.length;
+  const waterPerDay = sectSystem.gains.water * DAY_LENGTH_SECONDS;
+  return [
+    {
+      name: 'Fruit',
+      gain: fruitGain,
+      loss: fruitLoss
+    },
+    {
+      name: 'Water',
+      gain: waterPerDay >= 0 ? waterPerDay : 0,
+      loss: waterPerDay < 0 ? -waterPerDay : 0
+    }
+  ];
 }
 
 

--- a/style.css
+++ b/style.css
@@ -690,6 +690,29 @@ body.darkenshift-mode .tabsContainer button.active {
     font-weight: bold;
 }
 
+.resource-overlay .overlay-box {
+    max-width: 300px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+.resource-deltas {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    font-size: 0.9rem;
+}
+.resource-delta-row {
+    display: flex;
+    justify-content: space-between;
+}
+.resource-delta-row .gain {
+    color: #8f8;
+}
+.resource-delta-row .loss {
+    color: #f88;
+}
+
 .work-disciples .sect-disciple-card.selected {
     background: #fbf6e0;
     color: #000;

--- a/ui/colonyOverlays.js
+++ b/ui/colonyOverlays.js
@@ -4,7 +4,7 @@ export let explorationListContainer = null;
 export let startDungeonBtn = null;
 
 import { createOverlay } from './overlay.js';
-import { sectSystem, SECT_SCHEDULE, getCurrentSchedule, renderConstructCards } from '../game/sect.js';
+import { sectSystem, SECT_SCHEDULE, getCurrentSchedule, renderConstructCards, getDailyResourceDelta } from '../game/sect.js';
 import { systems, sectState, worldProgress } from '../game/state.js';
 import { createSectDiscipleCard, renderColonyTasks, renderExplorationTab, startExploration, startWorldCombat, discipleGatherPhase } from '../script.js';
 
@@ -232,8 +232,44 @@ export function openPlaceholderOverlay(title) {
   box.appendChild(msg);
 }
 
+let resourceOverlay = null;
 export function openResourceOverlay() {
-  openPlaceholderOverlay('Resources');
+  if (resourceOverlay) return;
+  resourceOverlay = createOverlay({ className: 'resource-overlay' });
+  resourceOverlay.onClose(() => {
+    resourceOverlay = null;
+  });
+  const { box } = resourceOverlay;
+
+  const closeBtn = document.createElement('button');
+  closeBtn.className = 'close-btn';
+  closeBtn.innerHTML = '&times;';
+  closeBtn.addEventListener('click', resourceOverlay.close);
+  box.appendChild(closeBtn);
+
+  const header = document.createElement('div');
+  header.className = 'panel-heading';
+  header.textContent = 'Daily Resource Change';
+  box.appendChild(header);
+
+  const list = document.createElement('div');
+  list.className = 'resource-deltas';
+  box.appendChild(list);
+
+  function render() {
+    list.innerHTML = '';
+    const deltas = getDailyResourceDelta();
+    deltas.forEach(d => {
+      const row = document.createElement('div');
+      row.className = 'resource-delta-row';
+      const gain = d.gain.toFixed(1);
+      const loss = d.loss.toFixed(1);
+      row.innerHTML = `<span>${d.name}</span><span class="gain">+${gain}</span><span class="loss">-${loss}</span>`;
+      list.appendChild(row);
+    });
+  }
+
+  render();
 }
 
 export function openBuildOverlay() {


### PR DESCRIPTION
## Summary
- compute daily resource changes
- implement resources overlay to show daily gains and losses
- style the new overlay
- document the resources overlay in UI wireframes

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687c7c91619483269b50944e5d9debc6