### PR TITLE
Fix disciple badge container centering

### DIFF
--- a/game/badgeBackground.js
+++ b/game/badgeBackground.js
@@ -11,6 +11,7 @@ const parchmentTexture = PIXI.Texture.from(
   new URL('../img/parchment.png', import.meta.url).href
 );
 const PARCHMENT_SCALE = 0.9;
+const BADGE_SIZE = 64;
 
 // only once PIXI is loaded will this run
 function ensureApp() {
@@ -55,12 +56,11 @@ function ensureApp() {
 function updateContainer(objs, el) {
   const r = el.getBoundingClientRect();
   const { container, bamboo, parchment } = objs;
-  Object.assign(container, {
-    x: r.left + r.width / 2,
-    y: r.top + r.height / 2
-  });
-  Object.assign(bamboo, { width: r.width, height: r.height, x: 0, y: 0 });
-  Object.assign(parchment, { width: r.width, height: r.height });
+  container.x = r.left + r.width / 2;
+  container.y = r.top + r.height / 2;
+  container.pivot.set(BADGE_SIZE / 2, BADGE_SIZE / 2);
+  Object.assign(bamboo, { width: BADGE_SIZE, height: BADGE_SIZE, x: 0, y: 0 });
+  Object.assign(parchment, { width: BADGE_SIZE, height: BADGE_SIZE });
   parchment.position = bamboo.position;
   parchment.scale.set(PARCHMENT_SCALE);
 }

--- a/style.css
+++ b/style.css
@@ -2939,7 +2939,7 @@ body.darkenshift-mode .tabsContainer button.active {
     white-space: nowrap;
 }
 .sect-disciple-list .disciple-progress {
-    width: 60px;
+    width: 64px;
     height: 10px;
 }
 .sect-disciple-list .disciple-progress-label {
@@ -3636,7 +3636,7 @@ body.darkenshift-mode .tabsContainer button.active {
   border: 1px solid #7d8b50;
   border-radius: 6px;
   padding: 2px;
-  width: 60px;
+  width: 64px;
   font-size: 0.55rem;
   display: flex;
   flex-direction: column;
@@ -3675,7 +3675,7 @@ body.darkenshift-mode .tabsContainer button.active {
   margin-bottom: 1px;
 }
 .disciple-badge .disciple-progress {
-  width: 60px;
+  width: 64px;
   height: 10px;
 }
 .disciple-badge .disciple-progress-label {


### PR DESCRIPTION
## Summary
- center Pixi badge textures by using a fixed badge size
- adjust CSS badge width to 64px

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687c7d6eb63883269a0a132b2d086d6d