### PR TITLE
Add daily output display in work overlay

### DIFF
--- a/game/badgeBackground.js
+++ b/game/badgeBackground.js
@@ -11,7 +11,6 @@ const parchmentTexture = PIXI.Texture.from(
   new URL('../img/parchment.png', import.meta.url).href
 );
 const PARCHMENT_SCALE = 0.9;
-const BADGE_SIZE = 64;
 
 // only once PIXI is loaded will this run
 function ensureApp() {

--- a/game/sect.js
+++ b/game/sect.js
@@ -5,7 +5,16 @@ import { generateDiscipleAttributes } from '../discipleAttributes.js';
 import Disciple from '../disciple.js';
 import { initializeDisciple } from '../utils/discipleInit.js';
 import { createOverlay } from '../ui/overlay.js';
-import { DAILY_FRUIT_CONSUMPTION } from './constants.js';
+import {
+  DAILY_FRUIT_CONSUMPTION,
+  GATHER_WORK_SECONDS,
+  MIN_TRAVEL_SECONDS,
+  TRAVEL_SECONDS_PER_UNIT,
+  GATHER_SPOTS,
+  TASK_GROUPS,
+  ATTRIBUTE_FOR_GROUP
+} from './constants.js';
+import { getTaskSkillProgress } from '../utils/skills.js';
 
 export { addDiscoveredLocation } from "./ui.js";
 export const discoveredLocations = [];
@@ -1380,6 +1389,29 @@ export function openWaterRegenPopup() {
 
   box.appendChild(list);
   overlay.appendButton('Close', overlay.close);
+}
+
+export function getDiscipleDailyOutput(d) {
+  const task = sectState.discipleTasks[d.id];
+  if (task === 'Gather Fruit' || task === 'Gather Softwood') {
+    const group = TASK_GROUPS[task];
+    const skillXp = sectState.discipleSkills[d.id]?.[group] || 0;
+    const lvl = getTaskSkillProgress(skillXp).level;
+    const spot = GATHER_SPOTS[task];
+    const attr = ATTRIBUTE_FOR_GROUP[group];
+    const yieldMult = 1 + 0.05 * (d[attr] || 0) + 0.02 * lvl;
+    const gatherAmt = spot.baseYield * yieldMult * GATHER_WORK_SECONDS;
+    const travel = Math.max(
+      MIN_TRAVEL_SECONDS,
+      spot.travel * TRAVEL_SECONDS_PER_UNIT
+    );
+    const cycleSeconds = travel * 2 + GATHER_WORK_SECONDS;
+    const perSecond = gatherAmt / cycleSeconds;
+    return perSecond * DAY_LENGTH_SECONDS;
+  } else if (task === 'Research') {
+    return 4 * DAY_LENGTH_SECONDS;
+  }
+  return 0;
 }
 
 export function getDailyResourceDelta() {

--- a/style.css
+++ b/style.css
@@ -656,6 +656,19 @@ body.darkenshift-mode .tabsContainer button.active {
     max-height: 300px;
     overflow-y: auto;
 }
+.work-entry {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+}
+.work-task {
+    min-width: 80px;
+    font-size: 0.7rem;
+}
+.work-output {
+    font-size: 0.7rem;
+    color: #ddd;
+}
 
 .work-overlay .close-btn {
     position: absolute;

--- a/ui/colonyOverlays.js
+++ b/ui/colonyOverlays.js
@@ -4,7 +4,7 @@ export let explorationListContainer = null;
 export let startDungeonBtn = null;
 
 import { createOverlay } from './overlay.js';
-import { sectSystem, SECT_SCHEDULE, getCurrentSchedule, renderConstructCards, getDailyResourceDelta } from '../game/sect.js';
+import { sectSystem, SECT_SCHEDULE, getCurrentSchedule, renderConstructCards, getDailyResourceDelta, getDiscipleDailyOutput } from '../game/sect.js';
 import { systems, sectState, worldProgress } from '../game/state.js';
 import { createSectDiscipleCard, renderColonyTasks, renderExplorationTab, startExploration, startWorldCombat, discipleGatherPhase } from '../script.js';
 
@@ -137,13 +137,30 @@ export function openWorkOverlay() {
   function render() {
     left.innerHTML = '';
     sectSystem.disciples.forEach(d => {
+      const entry = document.createElement('div');
+      entry.className = 'work-entry';
+
       const card = createSectDiscipleCard(d);
       if (d.id === workOverlaySelected) card.classList.add('selected');
       card.addEventListener('click', () => {
         workOverlaySelected = d.id;
         render();
       });
-      left.appendChild(card);
+
+      const taskLabel = document.createElement('div');
+      taskLabel.className = 'work-task';
+      const task = sectState.discipleTasks[d.id] || 'Idle';
+      taskLabel.textContent = task;
+
+      const output = getDiscipleDailyOutput(d);
+      const outLabel = document.createElement('div');
+      outLabel.className = 'work-output';
+      outLabel.textContent = output > 0 ? `+${output.toFixed(1)}/day` : '';
+
+      entry.appendChild(card);
+      entry.appendChild(taskLabel);
+      entry.appendChild(outLabel);
+      left.appendChild(entry);
     });
 
     right.innerHTML = '';


### PR DESCRIPTION
## Summary
- clean up unused `BADGE_SIZE` constant
- compute disciple daily output in `sect.js`
- show task and daily output next to badges in the Work overlay
- style entries in the Work overlay

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687c8662b21c83268c87c410a73264e3