### PR TITLE
Add parchment box style and apply to overlays

### DIFF
--- a/docs/00-wireframes.md
+++ b/docs/00-wireframes.md
@@ -85,6 +85,7 @@ Footer
 * Exploration and sect disciple lists now use a unified badge styled purely via CSS.
   Each badge displays a parchment background inside a bamboo border along with the
   disciple's name, mood, HP bar and current task.
+* All overlays now use the same parchment-style box for a consistent look.
 
 #dicsiple overlay card on pressing disciple
 

--- a/game/badges.js
+++ b/game/badges.js
@@ -4,7 +4,7 @@ import { DISCIPLE_MAX_HEALTH } from './constants.js';
 
 export function createDiscipleBadge(d) {
   const badge = document.createElement('div');
-  badge.className = 'disciple-badge';
+  badge.className = 'disciple-badge parchment-box';
 
   const name = document.createElement('div');
   name.className = 'disciple-name';

--- a/game/pathOverlay.js
+++ b/game/pathOverlay.js
@@ -2,7 +2,8 @@ import { createOverlay } from '../ui/overlay.js';
 import { STARTER_PATHS } from './paths.js';
 
 export function showPathOverlay({ onSelect, available = 3 } = {}) {
-  const overlay = createOverlay({ className: 'path-overlay' });
+  const overlay = createOverlay({ className: 'path-overlay', boxClass: 'parchment-box' });
+  overlay.box.classList.add('parchment-box');
   const { box, close } = overlay;
   const title = document.createElement('h2');
   title.textContent = 'Choose a Path';

--- a/game/sect.js
+++ b/game/sect.js
@@ -1316,7 +1316,8 @@ function showConstructCloud(text, target, color) {
 }
 
 export function openWaterRegenPopup() {
-  const overlay = createOverlay({ className: 'water-regen-overlay' });
+  const overlay = createOverlay({ className: 'water-regen-overlay', boxClass: 'parchment-box' });
+  overlay.box.classList.add('parchment-box');
   const box = overlay.box;
   const header = document.createElement('h2');
   header.textContent = 'Water Regeneration';

--- a/script.js
+++ b/script.js
@@ -1784,7 +1784,8 @@ function openDiscipleOverlay(d) {
       discipleOverlayActiveTab = 'general';
     }
   }
-  discipleOverlay = createOverlay({ className: 'disciple-overlay' });
+  discipleOverlay = createOverlay({ className: 'disciple-overlay', boxClass: 'parchment-box' });
+  discipleOverlay.box.classList.add('parchment-box');
   const { box } = discipleOverlay;
 
   const closeBtn = document.createElement('button');
@@ -2676,7 +2677,8 @@ function openCamp(onCloseCallback = null) {
   setCampOverlayOpen(true);
   setGamePaused(true);
   hidePlayerAttackBar(playerAttackFill);
-  setCampOverlay(createOverlay({ className: 'camp-overlay' }));
+  setCampOverlay(createOverlay({ className: 'camp-overlay', boxClass: 'parchment-box' }));
+  campOverlay.box.classList.add('parchment-box');
   campOverlay.onClose(() => {
     setCampOverlayOpen(false);
     setGamePaused(false);

--- a/style.css
+++ b/style.css
@@ -534,6 +534,12 @@ body.darkenshift-mode .tabsContainer button.active {
     max-width: 600px;
 }
 
+.parchment-box {
+  background: url('img/parchment.png') center/cover no-repeat;
+  color: #000;
+  border: 1px solid #7d8b50;
+}
+
 .overlay-box button {
     padding: 6px 12px;
     font-size: 1rem;
@@ -3689,9 +3695,6 @@ body.darkenshift-mode .tabsContainer button.active {
 }
 
 .disciple-badge {
-  background: url('img/parchment.png') center/cover no-repeat;
-  color: #000;
-  border: 1px solid #7d8b50;
   border-radius: 6px;
   padding: 2px;
   width: 64px;

--- a/ui/colonyOverlays.js
+++ b/ui/colonyOverlays.js
@@ -17,7 +17,8 @@ export function closeExplorationOverlay() {
 
 export function openExplorationOverlay() {
   if (explorationOverlay) return;
-  explorationOverlay = createOverlay({ className: 'exploration-overlay' });
+  explorationOverlay = createOverlay({ className: 'exploration-overlay', boxClass: 'parchment-box' });
+  explorationOverlay.box.classList.add('parchment-box');
   explorationOverlay.onClose(() => {
     explorationOverlay = null;
   });
@@ -105,7 +106,8 @@ let workOverlay = null;
 let workOverlaySelected = null;
 export function openWorkOverlay() {
   if (workOverlay) return;
-  workOverlay = createOverlay({ className: 'work-overlay' });
+  workOverlay = createOverlay({ className: 'work-overlay', boxClass: 'parchment-box' });
+  workOverlay.box.classList.add('parchment-box');
   workOverlay.onClose(() => {
     workOverlay = null;
     workOverlaySelected = null;
@@ -193,7 +195,8 @@ export function openWorkOverlay() {
 let scheduleOverlay = null;
 export function openScheduleOverlay() {
   if (scheduleOverlay) return;
-  scheduleOverlay = createOverlay({ className: 'schedule-overlay' });
+  scheduleOverlay = createOverlay({ className: 'schedule-overlay', boxClass: 'parchment-box' });
+  scheduleOverlay.box.classList.add('parchment-box');
   let interval;
   scheduleOverlay.onClose(() => {
     if (interval) clearInterval(interval);
@@ -237,7 +240,8 @@ export function openScheduleOverlay() {
 }
 
 export function openPlaceholderOverlay(title) {
-  const ov = createOverlay({});
+  const ov = createOverlay({ boxClass: 'parchment-box' });
+  ov.box.classList.add('parchment-box');
   const { box } = ov;
   const closeBtn = document.createElement('button');
   closeBtn.className = 'close-btn';
@@ -252,7 +256,8 @@ export function openPlaceholderOverlay(title) {
 let resourceOverlay = null;
 export function openResourceOverlay() {
   if (resourceOverlay) return;
-  resourceOverlay = createOverlay({ className: 'resource-overlay' });
+  resourceOverlay = createOverlay({ className: 'resource-overlay', boxClass: 'parchment-box' });
+  resourceOverlay.box.classList.add('parchment-box');
   resourceOverlay.onClose(() => {
     resourceOverlay = null;
   });
@@ -300,7 +305,8 @@ export function closeDungeonOverlay() {
 
 export function openDungeonOverlay() {
   if (dungeonOverlay) return;
-  dungeonOverlay = createOverlay({ className: 'dungeon-overlay' });
+  dungeonOverlay = createOverlay({ className: 'dungeon-overlay', boxClass: 'parchment-box' });
+  dungeonOverlay.box.classList.add('parchment-box');
   dungeonOverlay.onClose(() => { dungeonOverlay = null; });
   const { box } = dungeonOverlay;
 

--- a/ui/loadErrorOverlay.js
+++ b/ui/loadErrorOverlay.js
@@ -1,7 +1,8 @@
 import { createOverlay } from './overlay.js';
 
 export function showLoadErrorOverlay(error, onReset) {
-  const overlay = createOverlay({ className: 'load-error-overlay' });
+  const overlay = createOverlay({ className: 'load-error-overlay', boxClass: 'parchment-box' });
+  overlay.box.classList.add('parchment-box');
   const { box } = overlay;
 
   const msg = document.createElement('div');

--- a/ui/overlay.js
+++ b/ui/overlay.js
@@ -1,4 +1,4 @@
-export function createOverlay({ className = '', container = document.body } = {}) {
+export function createOverlay({ className = '', boxClass = '', container = document.body } = {}) {
   const element = document.createElement('div');
   element.classList.add('overlay');
   if (className) {
@@ -7,6 +7,9 @@ export function createOverlay({ className = '', container = document.body } = {}
 
   const box = document.createElement('div');
   box.classList.add('overlay-box');
+  if (boxClass) {
+    boxClass.split(' ').forEach(cls => cls && box.classList.add(cls));
+  }
   element.appendChild(box);
 
   const closeHandlers = new Set();

--- a/ui/restartOverlay.js
+++ b/ui/restartOverlay.js
@@ -36,7 +36,8 @@ export const SPEAKER_QUOTES = [
 export function showRestartScreen(onRestart) {
   if (restartOverlay) return;
 
-  restartOverlay = createOverlay({ className: 'restart-overlay' });
+  restartOverlay = createOverlay({ className: 'restart-overlay', boxClass: 'parchment-box' });
+  restartOverlay.box.classList.add('parchment-box');
   const { box } = restartOverlay;
 
   const canvas = document.createElement('canvas');


### PR DESCRIPTION
## Summary
- add `.parchment-box` CSS helper
- update disciple badges to use new helper
- extend overlay creation API to accept a `boxClass`
- apply parchment styling to all overlays
- document the consistent parchment overlay look

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687c9483a7d48326b23e1d8b5af462a8