### PR TITLE
Update fonts and metamorphosis visuals

### DIFF
--- a/docs/21-metamorphosis-ui.md
+++ b/docs/21-metamorphosis-ui.md
@@ -41,3 +41,9 @@ metamorphosis XP/sec = 0.4
 ## Taino‑styled Glyph
 
 Integrate a Taino‑inspired frog glyph around the icon for ambient feedback.
+
+## Styling
+
+- The metamorphosis panel now uses a parchment texture background at 30% opacity.
+- Progress rings feature a lilac to teal gradient with a subtle glow.
+- Progress numbers appear on semi-transparent parchment panels.

--- a/index.html
+++ b/index.html
@@ -4,6 +4,8 @@
   <link rel="stylesheet" href="style.css">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Creepster&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Patrick+Hand&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Quicksand&display=swap" rel="stylesheet">
   <script src="https://unpkg.com/lucide@latest"></script>
   <title>Page Title</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/metamorphosis.js
+++ b/metamorphosis.js
@@ -37,6 +37,12 @@ const bodyPath = `M200 150
           <div id="metamorphosisStageLabel" class="metamorphosis-stage"></div>
       <div class="progress-wrapper metamorphosis-progress">
         <svg class="progress-ring" width="${RING_RADIUS * 2 + 20}" height="${RING_RADIUS * 2 + 20}">
+          <defs>
+            <linearGradient id="metaRingGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+              <stop offset="0%" stop-color="#c8a2ff" />
+              <stop offset="100%" stop-color="#50e3c2" />
+            </linearGradient>
+          </defs>
           <circle class="progress-ring-bg" cx="${RING_RADIUS + 10}" cy="${RING_RADIUS + 10}" r="${RING_RADIUS}" />
           <circle id="metamorphosisRing" class="progress-ring-fill" cx="${RING_RADIUS + 10}" cy="${RING_RADIUS + 10}" r="${RING_RADIUS}" />
         </svg>

--- a/style.css
+++ b/style.css
@@ -1,6 +1,6 @@
 * {
     overflow-x: hidden;
-    font-family: 'Inter', sans-serif;
+    font-family: 'Patrick Hand', 'Quicksand', sans-serif;
     padding: 0;
     margin: 0;
     box-sizing: border-box;
@@ -20,9 +20,9 @@ body {
     background-position: center;
     background-repeat: no-repeat;
     background-attachment: fixed;
-    font-family: 'Inter', sans-serif;
+    font-family: 'Patrick Hand', 'Quicksand', sans-serif;
     padding: 5px;
-    color: #fff;
+    color: var(--body-color);
     min-height: 100vh;
     overflow-y: auto;
     line-height: 1.4;
@@ -41,6 +41,17 @@ body {
     --verdantia-jade: #52795c;
     --verdantia-parchment: #fefae0;
     --zone-size: 26%;
+    --title-color: #fcecc2;
+    --body-color: #ddd3a0;
+    --highlight-number: #bca4ff;
+}
+
+h1, h2, h3 {
+    color: var(--title-color);
+}
+
+.highlight-number {
+    color: var(--highlight-number);
 }
 
 body.darkenshift-mode {
@@ -1393,7 +1404,7 @@ body.darkenshift-mode .tabsContainer button.active {
     width: 100%;
     line-height: 1em;
     font-size: 0.6em;
-    color: white;
+    color: var(--highlight-number);
     pointer-events: none; /* clicks pass through */
     text-align: center;
     white-space: nowrap;
@@ -1684,6 +1695,10 @@ body.darkenshift-mode .tabsContainer button.active {
 .world-progress-text {
     font-size: 12px;
     margin-left: 4px;
+}
+
+.progress-text {
+    color: var(--highlight-number);
 }
 
 /* Stage traversal progress bar */
@@ -1992,6 +2007,17 @@ body.darkenshift-mode .tabsContainer button.active {
     border-radius: 8px;
     padding: 8px;
     box-shadow: 0 0 10px var(--core-glow);
+    position: relative;
+}
+.player-metamorphosis-panel::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: url('img/parchment.png');
+    background-size: cover;
+    opacity: 0.3;
+    pointer-events: none;
+    border-radius: inherit;
 }
 
 .metamorphosis-side-panel {
@@ -2061,9 +2087,20 @@ body.darkenshift-mode .tabsContainer button.active {
     gap: 6px;
     flex: 1;
 }
+.metamorphosis-room .progress-area,
+.metamorphosis-room .assigned-disciple,
+.metamorphosis-room .metamorphosis-stage {
+    background: rgba(252, 236, 194, 0.5);
+    padding: 4px 8px;
+    border-radius: 6px;
+}
 .metamorphosis-progress {
     width: 200px;
     height: 200px;
+}
+#metamorphosisRing {
+    filter: drop-shadow(0 0 8px rgba(188,164,255,0.7));
+    stroke: url(#metaRingGradient);
 }
 .metamorphosis-figure {
     width: 100%;
@@ -2140,7 +2177,7 @@ body.darkenshift-mode .tabsContainer button.active {
 
 .core-activity-text {
     font-size: 0.9rem;
-    font-family: 'Inter', sans-serif;
+    font-family: 'Patrick Hand', 'Quicksand', sans-serif;
     height: auto;
     text-align: center;
     margin-top: 4px;
@@ -2165,7 +2202,7 @@ body.darkenshift-mode .tabsContainer button.active {
 .stamina-text {
     text-align: center;
     font-size: 0.8rem;
-    font-family: 'Inter', sans-serif;
+    font-family: 'Patrick Hand', 'Quicksand', sans-serif;
     margin-bottom: 4px;
 }
 


### PR DESCRIPTION
## Summary
- load Patrick Hand and Quicksand fonts
- use softer color scheme for titles and body text
- style XP numbers and metamorphosis ring with gradient glow
- overlay parchment texture on metamorphosis panel
- document UI styling changes

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687c95a61e2c83269de845cbcd67dd9c