### PR TITLE
Fix softwood display bug

### DIFF
--- a/docs/00-wireframes.md
+++ b/docs/00-wireframes.md
@@ -53,6 +53,7 @@ Left panel (Resource / Items)
 
 Shows stackable resources (fruit, wood, stone, etc.).
 Selecting the Resources nav opens an overlay showing daily gains and losses.
+Softwood production appears once a disciple is assigned to gather it.
 
 
 Right panel (Navigation)

--- a/game/sect.js
+++ b/game/sect.js
@@ -1419,11 +1419,22 @@ export function getDailyResourceDelta() {
   const fruitGain = FRUIT_GROWTH_RATES[sectSystem.seasonIndex] || 0;
   const fruitLoss = DAILY_FRUIT_CONSUMPTION * sectSystem.disciples.length;
   const waterPerDay = sectSystem.gains.water * DAY_LENGTH_SECONDS;
+  let softwoodGain = 0;
+  sectSystem.disciples.forEach(d => {
+    if (sectState.discipleTasks[d.id] === 'Gather Softwood') {
+      softwoodGain += getDiscipleDailyOutput(d);
+    }
+  });
   return [
     {
       name: 'Fruit',
       gain: fruitGain,
       loss: fruitLoss
+    },
+    {
+      name: 'Softwood',
+      gain: softwoodGain,
+      loss: 0
     },
     {
       name: 'Water',


### PR DESCRIPTION
## Summary
- calculate Softwood gain when disciples gather it
- clarify in docs that softwood appears in the resources overlay

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687cf0e0c28483268ddf402372334341