### PR TITLE
Add generic overlay close button

### DIFF
--- a/script.js
+++ b/script.js
@@ -1788,11 +1788,6 @@ function openDiscipleOverlay(d) {
   discipleOverlay.box.classList.add('parchment-box');
   const { box } = discipleOverlay;
 
-  const closeBtn = document.createElement('button');
-  closeBtn.className = 'close-btn';
-  closeBtn.innerHTML = '&times;';
-  closeBtn.addEventListener('click', discipleOverlay.close);
-  box.appendChild(closeBtn);
 
   const tabs = document.createElement('div');
   tabs.className = 'disciple-tabs';

--- a/style.css
+++ b/style.css
@@ -535,6 +535,7 @@ body.darkenshift-mode .tabsContainer button.active {
 
 /* Box that holds overlay contents */
 .overlay-box {
+    position: relative;
     background: rgba(0, 0, 0, 0.85);
     border-radius: 8px;
     padding: 16px;
@@ -554,6 +555,23 @@ body.darkenshift-mode .tabsContainer button.active {
 .overlay-box button {
     padding: 6px 12px;
     font-size: 1rem;
+}
+
+.overlay .close-btn {
+    position: absolute;
+    top: 4px;
+    right: 4px;
+    width: 16px;
+    height: 16px;
+    background: #c33;
+    color: #fff;
+    border: none;
+    border-radius: 0;
+    padding: 0;
+    font-size: 12px;
+    line-height: 16px;
+    text-align: center;
+    cursor: pointer;
 }
 
 .camp-overlay {
@@ -596,21 +614,6 @@ body.darkenshift-mode .tabsContainer button.active {
     background: var(--verdantia-parchment);
     color: #000;
     border: 1px solid #3a5a3a;
-}
-.disciple-overlay .close-btn {
-    position: absolute;
-    top: 4px;
-    right: 4px;
-    width: 16px;
-    height: 16px;
-    background: #c33;
-    color: #fff;
-    border: none;
-    border-radius: 50%;
-    font-size: 12px;
-    line-height: 14px;
-    text-align: center;
-    cursor: pointer;
 }
 .disciple-stats-general,
 .disciple-stats-combat {
@@ -687,21 +690,6 @@ body.darkenshift-mode .tabsContainer button.active {
     color: #ddd;
 }
 
-.work-overlay .close-btn {
-    position: absolute;
-    top: 4px;
-    right: 4px;
-    width: 16px;
-    height: 16px;
-    background: #c33;
-    color: #fff;
-    border: none;
-    border-radius: 50%;
-    font-size: 12px;
-    line-height: 14px;
-    text-align: center;
-    cursor: pointer;
-}
 
 .location-entry {
     cursor: pointer;

--- a/ui/colonyOverlays.js
+++ b/ui/colonyOverlays.js
@@ -24,11 +24,6 @@ export function openExplorationOverlay() {
   });
   const { box } = explorationOverlay;
 
-  const closeBtn = document.createElement('button');
-  closeBtn.className = 'close-btn';
-  closeBtn.innerHTML = '&times;';
-  closeBtn.addEventListener('click', explorationOverlay.close);
-  box.appendChild(closeBtn);
 
   const map = document.createElement('img');
   map.src = 'img/Map.jpg';
@@ -113,11 +108,6 @@ export function openWorkOverlay() {
     workOverlaySelected = null;
   });
   const { box } = workOverlay;
-  const closeBtn = document.createElement('button');
-  closeBtn.className = 'close-btn';
-  closeBtn.innerHTML = '&times;';
-  closeBtn.addEventListener('click', workOverlay.close);
-  box.appendChild(closeBtn);
 
   const header = document.createElement('div');
   header.className = 'panel-heading';
@@ -203,11 +193,6 @@ export function openScheduleOverlay() {
     scheduleOverlay = null;
   });
   const { box } = scheduleOverlay;
-  const closeBtn = document.createElement('button');
-  closeBtn.className = 'close-btn';
-  closeBtn.innerHTML = '&times;';
-  closeBtn.addEventListener('click', scheduleOverlay.close);
-  box.appendChild(closeBtn);
 
   const header = document.createElement('div');
   header.className = 'panel-heading';
@@ -243,11 +228,6 @@ export function openPlaceholderOverlay(title) {
   const ov = createOverlay({ boxClass: 'parchment-box' });
   ov.box.classList.add('parchment-box');
   const { box } = ov;
-  const closeBtn = document.createElement('button');
-  closeBtn.className = 'close-btn';
-  closeBtn.innerHTML = '&times;';
-  closeBtn.addEventListener('click', ov.close);
-  box.appendChild(closeBtn);
   const msg = document.createElement('div');
   msg.textContent = `${title} coming soon`;
   box.appendChild(msg);
@@ -263,11 +243,6 @@ export function openResourceOverlay() {
   });
   const { box } = resourceOverlay;
 
-  const closeBtn = document.createElement('button');
-  closeBtn.className = 'close-btn';
-  closeBtn.innerHTML = '&times;';
-  closeBtn.addEventListener('click', resourceOverlay.close);
-  box.appendChild(closeBtn);
 
   const header = document.createElement('div');
   header.className = 'panel-heading';
@@ -310,11 +285,6 @@ export function openDungeonOverlay() {
   dungeonOverlay.onClose(() => { dungeonOverlay = null; });
   const { box } = dungeonOverlay;
 
-  const closeBtn = document.createElement('button');
-  closeBtn.className = 'close-btn';
-  closeBtn.innerHTML = '&times;';
-  closeBtn.addEventListener('click', dungeonOverlay.close);
-  box.appendChild(closeBtn);
 
   const partyList = document.createElement('div');
   partyList.className = 'exploration-list casino-section';

--- a/ui/overlay.js
+++ b/ui/overlay.js
@@ -1,4 +1,4 @@
-export function createOverlay({ className = '', boxClass = '', container = document.body } = {}) {
+export function createOverlay({ className = '', boxClass = '', container = document.body, closable = true } = {}) {
   const element = document.createElement('div');
   element.classList.add('overlay');
   if (className) {
@@ -9,6 +9,14 @@ export function createOverlay({ className = '', boxClass = '', container = docum
   box.classList.add('overlay-box');
   if (boxClass) {
     boxClass.split(' ').forEach(cls => cls && box.classList.add(cls));
+  }
+  let closeBtn = null;
+  if (closable) {
+    closeBtn = document.createElement('button');
+    closeBtn.className = 'close-btn';
+    closeBtn.innerHTML = '&times;';
+    closeBtn.addEventListener('click', close);
+    box.appendChild(closeBtn);
   }
   element.appendChild(box);
 


### PR DESCRIPTION
## Summary
- add automatic `close-btn` creation in `createOverlay`
- style `.overlay .close-btn` for all overlays
- remove per-overlay close button markup

## Testing
- `npm test`
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687cf13184d48326898a787552cf8ed9