### PR TITLE
Enable skill XP gain

### DIFF
--- a/docs/09-skill-proficiency.md
+++ b/docs/09-skill-proficiency.md
@@ -28,3 +28,8 @@
 Each disciple rolls two random skill affinities when created. These grant either
 1.5× or 3× XP for the chosen skills. Attributes other than Intelligence do not
 affect proficiency gain.
+
+### In-game Implementation
+Proficiency XP is applied every tick while a disciple performs a task. The base
+rates above are multiplied by the disciple's Intelligence modifier and any
+affinity bonuses.

--- a/game/sect.js
+++ b/game/sect.js
@@ -14,7 +14,14 @@ import {
   TASK_GROUPS,
   ATTRIBUTE_FOR_GROUP
 } from './constants.js';
-import { getTaskSkillProgress } from '../utils/skills.js';
+import { intelligenceXpMultiplier } from '../attributes.js';
+import { addSkillXp, ensureDiscipleSkills, getTaskSkillProgress } from '../utils/skills.js';
+import {
+  FRUIT_XP_PER_CYCLE,
+  LOG_XP_PER_CYCLE,
+  RESEARCH_XP_PER_CYCLE,
+  CHANT_XP_PER_CYCLE
+} from './constants.js';
 
 export { addDiscoveredLocation } from "./ui.js";
 export const discoveredLocations = [];
@@ -1435,6 +1442,44 @@ export function getDailyResourceDelta() {
 
 
 // placeholder colony functions
-export function tickSect() {}
+
+export function tickSect(delta) {
+  const dt = delta / 1000;
+  sectSystem.disciples.forEach(d => {
+    if (d.incapacitated) return;
+    const task = sectState.discipleTasks[d.id];
+    if (!task || task === 'Idle' || task === 'Resting') return;
+    ensureDiscipleSkills(d.id);
+    const group = TASK_GROUPS[task];
+    let xpRate = 0;
+
+    if (task === 'Gather Fruit' || task === 'Gather Softwood') {
+      const spot = GATHER_SPOTS[task];
+      const travel = Math.max(
+        MIN_TRAVEL_SECONDS,
+        spot.travel * TRAVEL_SECONDS_PER_UNIT
+      );
+      const cycleSeconds = travel * 2 + GATHER_WORK_SECONDS;
+      const rate =
+        (task === 'Gather Fruit' ? FRUIT_XP_PER_CYCLE : LOG_XP_PER_CYCLE) /
+        cycleSeconds;
+      xpRate = rate;
+    } else if (task === 'Research') {
+      sectState.researchProgress += 4 * dt;
+      while (sectState.researchProgress >= 500) {
+        sectState.researchProgress -= 500;
+        sectState.researchPoints += 1;
+      }
+      xpRate = RESEARCH_XP_PER_CYCLE / 125;
+    } else if (task === 'Chant') {
+      xpRate = CHANT_XP_PER_CYCLE / 5;
+    }
+
+    if (xpRate > 0 && group) {
+      addSkillXp(d, group, xpRate * dt * intelligenceXpMultiplier());
+    }
+  });
+
+}
 
 export function renderColonyResources() {}

--- a/script.js
+++ b/script.js
@@ -3069,6 +3069,7 @@ function gameLoop(currentTime) {
 
   tickSectSystem(deltaTime);
   tickSect(deltaTime);
+  tickBuilding(deltaTime / 1000);
   const dtSeconds = deltaTime / 1000;
   sectSystem.gains.water =
     dtSeconds > 0


### PR DESCRIPTION
## Summary
- award proficiency XP per tick for disciples
- document skill XP gains
- hook up building tick in the game loop

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687cf17e42248326b0b766364b855732