### PR TITLE
Fix metamorphosis ring clipping

### DIFF
--- a/style.css
+++ b/style.css
@@ -2087,10 +2087,12 @@ body.darkenshift-mode .tabsContainer button.active {
     background: rgba(252, 236, 194, 0.5);
     padding: 4px 8px;
     border-radius: 6px;
+    margin-bottom: 8px;
 }
 .metamorphosis-progress {
-    width: 200px;
-    height: 200px;
+    width: 240px;
+    height: 240px;
+    overflow: visible;
 }
 #metamorphosisRing {
     filter: drop-shadow(0 0 8px rgba(188,164,255,0.7));


### PR DESCRIPTION
## Summary
- widen `.metamorphosis-progress` so scaled SVGs aren't clipped
- add space below the stage label

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687d046514308326b2d1d539f0e39c67