### PR TITLE
Move theme toggle into stats tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,6 @@
   <body>
     <!--<div id="insanityOrb" class="insanity-orb" title="The mind frays..."></div>-->
     <button id="debugToggle" class="debug-toggle">Debug</button>
-    <button id="themeToggle" class="theme-toggle"><i data-lucide="moon"></i> Darkenshift</button>
     <div id="debugPanel" style="display:none;">
       <label>Cash: <input id="debugCash" type="number" value="10000" style="width: 60px;"></label>
       <button onclick="devTools.giveCash()">Give</button>
@@ -122,6 +121,7 @@
       <div id="star-chart-container"></div>
     </div>
     <div class="playerStatsTab">
+      <button id="themeToggle" class="theme-toggle"><i data-lucide="moon"></i> Darkenshift</button>
       <div class="stats-subtabs">
         <button class="statsOverviewSubTabButton active">Overview</button>
         <button class="statsEconomySubTabButton">Economy</button>

--- a/style.css
+++ b/style.css
@@ -93,10 +93,7 @@ body.darkenshift-mode {
 }
 
 #themeToggle {
-    position: absolute;
-    top: 10px;
-    right: 10px;
-    z-index: 1001;
+    align-self: flex-end;
     background: #222;
     color: #fff;
     border: 1px solid var(--core-accent);


### PR DESCRIPTION
## Summary
- relocate the Darkenshift toggle inside the Stats tab
- remove absolute positioning so the button fits the tab layout

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687d04ef91608326ac5ff186ce558c4d