### PR TITLE
Fix schedule task progress bars

### DIFF
--- a/game/sect.js
+++ b/game/sect.js
@@ -20,7 +20,9 @@ import {
   FRUIT_XP_PER_CYCLE,
   LOG_XP_PER_CYCLE,
   RESEARCH_XP_PER_CYCLE,
-  CHANT_XP_PER_CYCLE
+  CHANT_XP_PER_CYCLE,
+  HUNT_CYCLE_SECONDS,
+  EXPLORATION_CYCLE_SECONDS
 } from './constants.js';
 
 export { addDiscoveredLocation } from "./ui.js";
@@ -1463,6 +1465,7 @@ export function tickSect(delta) {
     ensureDiscipleSkills(d.id);
     const group = TASK_GROUPS[task];
     let xpRate = 0;
+    let progress = sectState.discipleProgress[d.id] || 0;
 
     if (task === 'Gather Fruit' || task === 'Gather Softwood') {
       const spot = GATHER_SPOTS[task];
@@ -1475,6 +1478,8 @@ export function tickSect(delta) {
         (task === 'Gather Fruit' ? FRUIT_XP_PER_CYCLE : LOG_XP_PER_CYCLE) /
         cycleSeconds;
       xpRate = rate;
+      progress = (progress + dt) % cycleSeconds;
+      sectState.discipleProgress[d.id] = progress;
     } else if (task === 'Research') {
       sectState.researchProgress += 4 * dt;
       while (sectState.researchProgress >= 500) {
@@ -1484,6 +1489,12 @@ export function tickSect(delta) {
       xpRate = RESEARCH_XP_PER_CYCLE / 125;
     } else if (task === 'Chant') {
       xpRate = CHANT_XP_PER_CYCLE / 5;
+    } else if (task === 'Hunt') {
+      progress = (progress + dt) % HUNT_CYCLE_SECONDS;
+      sectState.discipleProgress[d.id] = progress;
+    } else if (task === 'Exploration') {
+      progress = (progress + dt) % EXPLORATION_CYCLE_SECONDS;
+      sectState.discipleProgress[d.id] = progress;
     }
 
     if (xpRate > 0 && group) {

--- a/script.js
+++ b/script.js
@@ -1169,6 +1169,7 @@ function renderColonyInfo() {
       const prev = sectState.discipleTasks[d.id];
       sectState.discipleTasks[d.id] = t;
       discipleGatherPhase[d.id] = -1;
+      sectState.discipleProgress[d.id] = 0;
       if (prev === 'Chant' && t !== 'Chant') {
         delete sectState.chantAssignments[d.id];
         if (typeof renderConstructCards === 'function') {
@@ -1988,6 +1989,12 @@ function init() {
   document.addEventListener('schedule-phase', e => {
     updateMapBrightness(e.detail.phase);
     if (e.detail.phase === 'Evening') feedDisciples();
+    if (e.detail.phase !== 'Work') {
+      sectSystem.disciples.forEach(d => {
+        sectState.discipleProgress[d.id] = 0;
+      });
+    }
+    updateTaskProgressDisplay();
   });
   document.addEventListener('disciple-gained', e => {
     if (!sectTabUnlocked && e.detail.count >= 1) {
@@ -3070,6 +3077,7 @@ function gameLoop(currentTime) {
     dtSeconds > 0
       ? (sectSystem.resources.water.current - startWater) / dtSeconds
       : 0;
+  updateTaskProgressDisplay();
   requestAnimationFrame(gameLoop);
 }
 


### PR DESCRIPTION
## Summary
- increment disciple task progress during ticks
- reset progress when changing tasks and when schedule phases change
- refresh task progress each frame and on schedule change

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687d04a077f483269d4776de09eb43ed