### PR TITLE
Fix disciple badge emoji clipping

### DIFF
--- a/style.css
+++ b/style.css
@@ -3733,8 +3733,8 @@ body.darkenshift-mode .tabsContainer button.active {
 }
 .disciple-badge .mood-icon {
   position: absolute;
-  top: -4px;
-  right: -4px;
+  top: 0;
+  right: 0;
   font-size: 0.6rem;
 }
 .disciple-badge.selected {


### PR DESCRIPTION
## Summary
- stop offsetting mood emoji beyond the badge bounds

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687d05da33388326b8e10e8aba7ce49f