### PR TITLE
feat: add metamorphosis stats panel

### DIFF
--- a/docs/21-metamorphosis-ui.md
+++ b/docs/21-metamorphosis-ui.md
@@ -21,7 +21,7 @@ Egg → Tail → Limbs → Body → Crown. Hovering near a threshold causes the 
 
 ## Optional Modifiers Panel
 
-A side panel can show season, room and weather modifiers that affect the growth formula.
+The game displays a stats panel on the right side of the metamorphosis screen. This panel lists the season, room and weather multipliers that affect the growth formula and shows the resulting XP per second.
 
 ## Formula
 

--- a/index.html
+++ b/index.html
@@ -198,6 +198,9 @@
       <div class="metamorphosis-main">
         <div id="metamorphosisTabContent"></div>
       </div>
+      <div class="metamorphosis-stats-panel sidePanel">
+        <div id="metamorphosisStats"></div>
+      </div>
     </div>
     <div class="lexiconTab player-lexicon-panel" style="display:none;">
       <div id="tagGuide" class="tags-guide"></div>

--- a/metamorphosis.js
+++ b/metamorphosis.js
@@ -15,6 +15,7 @@ let ringFill;
 let ringWrapper;
 let listContainer;
 let breakthroughBtn;
+let statsContainer;
 let selectedDiscipleId = null;
 const RING_RADIUS = 80;
 const RING_CIRCUMFERENCE = 2 * Math.PI * RING_RADIUS;
@@ -23,6 +24,7 @@ const STAGE_NAMES = ['Egg', 'Tadpole', 'Young Coquí', 'Elder Frog', 'Divine Coq
 export function initMetamorphosis() {
   container = document.getElementById('metamorphosisTabContent');
   listContainer = document.getElementById('metamorphosisDiscipleList');
+  statsContainer = document.getElementById('metamorphosisStats');
   if (!container) return;
 const bodyPath = `M200 150
                m -25 0
@@ -169,6 +171,8 @@ function renderMetamorphosis() {
 
   const label = container.querySelector('#assignedDisciple');
   if (label && d) label.textContent = d.name || `Disciple ${d.id}`;
+
+  updateStats();
 }
 
 export function refreshMetamorphosis() {
@@ -193,6 +197,7 @@ export function tickMetamorphosis(dt) {
     }
   });
   renderMetamorphosis();
+  updateStats();
 }
 
 function getMethodMultiplier() { return 1; }
@@ -204,4 +209,30 @@ function getCultivationSpeed(d) {
   return d.potential * d.potential;
 }
 function getSeasonMultiplier() { return 1; }
+
+function updateStats() {
+  if (!statsContainer || !selectedDiscipleId) return;
+  const d = sectSystem.disciples.find(x => x.id === selectedDiscipleId);
+  const stats = {
+    method: getMethodMultiplier(d),
+    building: getBuildingMultiplier(d),
+    room: getRoomMultiplier(d),
+    pathMatch: getPathMatchMultiplier(d),
+    stability: getStabilityFactor(d),
+    cultivation: getCultivationSpeed(d),
+    season: getSeasonMultiplier()
+  };
+  let rate = 0.4;
+  Object.values(stats).forEach(v => { rate *= v; });
+  statsContainer.innerHTML = `
+    <div class="meta-stat">XP/sec: ${rate.toFixed(2)}</div>
+    <div class="meta-stat">Method ×${stats.method}</div>
+    <div class="meta-stat">Building ×${stats.building}</div>
+    <div class="meta-stat">Room ×${stats.room}</div>
+    <div class="meta-stat">Path Match ×${stats.pathMatch}</div>
+    <div class="meta-stat">Stability ×${stats.stability}</div>
+    <div class="meta-stat">Cultivation ${stats.cultivation}</div>
+    <div class="meta-stat">Season ×${stats.season}</div>
+  `;
+}
 

--- a/style.css
+++ b/style.css
@@ -2018,6 +2018,18 @@ body.darkenshift-mode .tabsContainer button.active {
     font-size: 0.8rem;
     min-width: 160px;
 }
+.metamorphosis-stats-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    font-size: 0.8rem;
+    min-width: 160px;
+}
+.metamorphosis-stats-panel .meta-stat {
+    background: rgba(252, 236, 194, 0.5);
+    padding: 4px 6px;
+    border-radius: 6px;
+}
 .metamorphosis-side-panel .sect-disciple-list {
     flex-direction: column;
     overflow-x: visible;


### PR DESCRIPTION
## Summary
- show a new metamorphosis stats panel to the right of the frog UI
- update styles for the new stats panel
- display XP/sec and multipliers in the metamorphosis state
- document the new stats panel in the metamorphosis UI guide

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687d0cf93e108326b7027dc1caf929a2