### PR TITLE
Implement sect gathering cycle

### DIFF
--- a/game/sect.js
+++ b/game/sect.js
@@ -1,3 +1,4 @@
+/* global updateSectDisplay */
 import addLog from '../log.js';
 import { refreshMetamorphosis, tickMetamorphosis } from '../metamorphosis.js';
 import { sectState, currentEnemy, FRUIT_GROWTH_RATES } from './state.js';
@@ -1478,7 +1479,20 @@ export function tickSect(delta) {
         (task === 'Gather Fruit' ? FRUIT_XP_PER_CYCLE : LOG_XP_PER_CYCLE) /
         cycleSeconds;
       xpRate = rate;
-      progress = (progress + dt) % cycleSeconds;
+
+      const groupAttr = ATTRIBUTE_FOR_GROUP[TASK_GROUPS[task]];
+      const skillXp = sectState.discipleSkills[d.id]?.[TASK_GROUPS[task]] || 0;
+      const lvl = getTaskSkillProgress(skillXp).level;
+      const yieldMult = 1 + 0.05 * (d[groupAttr] || 0) + 0.02 * lvl;
+      const gatherAmt = spot.baseYield * yieldMult * GATHER_WORK_SECONDS;
+
+      progress += dt;
+      if (progress >= cycleSeconds) {
+        progress -= cycleSeconds;
+        if (task === 'Gather Fruit') sectState.fruits += gatherAmt;
+        else sectState.softwood += gatherAmt;
+        if (typeof updateSectDisplay === 'function') updateSectDisplay();
+      }
       sectState.discipleProgress[d.id] = progress;
     } else if (task === 'Research') {
       sectState.researchProgress += 4 * dt;

--- a/test/resource-gathering.test.js
+++ b/test/resource-gathering.test.js
@@ -1,0 +1,81 @@
+/* global describe, it, beforeEach, afterEach, before, after */
+import { expect } from 'chai';
+import Disciple from '../disciple.js';
+import { initializeDisciple } from '../utils/discipleInit.js';
+import { sectState } from '../game/state.js';
+import {
+  GATHER_SPOTS,
+  GATHER_WORK_SECONDS,
+  MIN_TRAVEL_SECONDS,
+  TRAVEL_SECONDS_PER_UNIT,
+  TASK_GROUPS,
+  ATTRIBUTE_FOR_GROUP
+} from '../game/constants.js';
+import { getTaskSkillProgress } from '../utils/skills.js';
+
+let sectModule;
+let sectSystem;
+let tickSect;
+
+describe('resource gathering', () => {
+  before(async () => {
+    globalThis.document = {
+      getElementsByClassName: () => [null],
+      getElementById: () => null,
+      addEventListener: () => {},
+      removeEventListener: () => {}
+    };
+    sectModule = await import('../game/sect.js');
+    ({ sectSystem, tickSect } = sectModule);
+  });
+  after(() => {
+    delete globalThis.document;
+  });
+  let prevUpdate;
+  beforeEach(() => {
+    prevUpdate = globalThis.updateSectDisplay;
+    globalThis.updateSectDisplay = () => {};
+    sectSystem.disciples.length = 0;
+    Object.keys(sectState.discipleTasks).forEach(k => delete sectState.discipleTasks[k]);
+    Object.keys(sectState.discipleProgress).forEach(k => delete sectState.discipleProgress[k]);
+    Object.keys(sectState.discipleSkills).forEach(k => delete sectState.discipleSkills[k]);
+    sectState.fruits = 0;
+    sectState.softwood = 0;
+  });
+  afterEach(() => {
+    globalThis.updateSectDisplay = prevUpdate;
+  });
+
+  function runGatherTest(task) {
+    const d = new Disciple({ id: 1, attributes: { strength: 1, dexterity: 1, endurance: 1, intelligence: 1, charisma: 1, potential: 1 } });
+    initializeDisciple(d);
+    sectSystem.disciples.push(d);
+    sectState.discipleTasks[d.id] = task;
+
+    const spot = GATHER_SPOTS[task];
+    const travel = Math.max(MIN_TRAVEL_SECONDS, spot.travel * TRAVEL_SECONDS_PER_UNIT);
+    const cycleSeconds = travel * 2 + GATHER_WORK_SECONDS;
+    const group = TASK_GROUPS[task];
+    const attr = ATTRIBUTE_FOR_GROUP[group];
+    const lvl = getTaskSkillProgress(0).level;
+    const gatherAmt = spot.baseYield * (1 + 0.05 * d[attr] + 0.02 * lvl) * GATHER_WORK_SECONDS;
+
+    let called = false;
+    globalThis.updateSectDisplay = () => { called = true; };
+
+    tickSect(cycleSeconds * 1000);
+
+    if (task === 'Gather Fruit') expect(sectState.fruits).to.be.closeTo(gatherAmt, 1e-6);
+    else expect(sectState.softwood).to.be.closeTo(gatherAmt, 1e-6);
+    expect(sectState.discipleProgress[d.id]).to.be.closeTo(0, 1e-6);
+    expect(called).to.be.true;
+  }
+
+  it('collects fruit after a full cycle', () => {
+    runGatherTest('Gather Fruit');
+  });
+
+  it('collects softwood after a full cycle', () => {
+    runGatherTest('Gather Softwood');
+  });
+});


### PR DESCRIPTION
## Summary
- track disciple progress when gathering resources
- deliver resources when a full gathering cycle completes
- refresh UI using `updateSectDisplay`
- add tests for gathering cycles

## Testing
- `npm run lint`
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687d0dab120883268e59fd60d6a53b7b