### PR TITLE
Add tooltip for metamorphosis stats

### DIFF
--- a/docs/21-metamorphosis-ui.md
+++ b/docs/21-metamorphosis-ui.md
@@ -21,7 +21,7 @@ Egg → Tail → Limbs → Body → Crown. Hovering near a threshold causes the 
 
 ## Optional Modifiers Panel
 
-The game displays a stats panel on the right side of the metamorphosis screen. This panel lists the season, room and weather multipliers that affect the growth formula and shows the resulting XP per second.
+The game displays a stats panel on the right side of the metamorphosis screen. This panel lists the season, room and weather multipliers that affect the growth formula and shows the resulting XP per second. **Hover over any stat** to view a tooltip detailing how that value is calculated.
 
 ## Formula
 

--- a/metamorphosis.js
+++ b/metamorphosis.js
@@ -225,14 +225,22 @@ function updateStats() {
   let rate = 0.4;
   Object.values(stats).forEach(v => { rate *= v; });
   statsContainer.innerHTML = `
-    <div class="meta-stat">XP/sec: ${rate.toFixed(2)}</div>
-    <div class="meta-stat">Method ×${stats.method}</div>
-    <div class="meta-stat">Building ×${stats.building}</div>
-    <div class="meta-stat">Room ×${stats.room}</div>
-    <div class="meta-stat">Path Match ×${stats.pathMatch}</div>
-    <div class="meta-stat">Stability ×${stats.stability}</div>
-    <div class="meta-stat">Cultivation ${stats.cultivation}</div>
-    <div class="meta-stat">Season ×${stats.season}</div>
+    <div class="meta-stat" data-tip="XP/sec = 0.4 × method × building × room × path match × stability × cultivation × season">XP/sec: ${rate.toFixed(2)}</div>
+    <div class="meta-stat" data-tip="Multiplier from assigned cultivation method">Method ×${stats.method}</div>
+    <div class="meta-stat" data-tip="Multiplier from cultivation building effects">Building ×${stats.building}</div>
+    <div class="meta-stat" data-tip="Room bonuses like humidity and ornaments">Room ×${stats.room}</div>
+    <div class="meta-stat" data-tip="Bonus when method matches disciple's Path">Path Match ×${stats.pathMatch}</div>
+    <div class="meta-stat" data-tip="Penalty or boost based on current Stability">Stability ×${stats.stability}</div>
+    <div class="meta-stat" data-tip="Potential squared (discipline talent)">Cultivation ${stats.cultivation}</div>
+    <div class="meta-stat" data-tip="Seasonal multiplier from weather">Season ×${stats.season}</div>
   `;
+  statsContainer.querySelectorAll('.meta-stat').forEach(el => {
+    const tip = el.dataset.tip;
+    if (!tip) return;
+    el.addEventListener('mouseenter', e => {
+      window.showTooltip(tip, e.pageX + 10, e.pageY + 10);
+    });
+    el.addEventListener('mouseleave', window.hideTooltip);
+  });
 }
 


### PR DESCRIPTION
## Summary
- show how each metamorphosis stat is calculated via tooltip
- document the tooltip usage in metamorphosis UI docs

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687d1cc2dc108326b3dd1400935e2dff