### PR TITLE
feat: bamboo border for badges

### DIFF
--- a/docs/00-wireframes.md
+++ b/docs/00-wireframes.md
@@ -86,7 +86,8 @@ Footer
 “Gate” button to open the full map/exploration/tasks overlay.
 * Exploration and sect disciple lists now use a unified badge styled purely via CSS.
   Each badge displays a parchment background inside a bamboo border along with the
-  disciple's name, mood, HP bar and current task.
+  disciple's name, mood, HP bar and current task. The bamboo frame is drawn using
+  the CSS `border-image` property so the texture tiles cleanly around the badge.
 * All overlays now use the same parchment-style box for a consistent look.
 
 #dicsiple overlay card on pressing disciple

--- a/style.css
+++ b/style.css
@@ -3676,15 +3676,23 @@ body.darkenshift-mode .tabsContainer button.active {
 
 .disciple-badge {
   border-radius: 6px;
-  padding: 2px;
+  border: 12px solid transparent;
+  border-image: url('img/bamboo.png') 12 round;
+  padding: 6px;
+  box-sizing: border-box;
   width: 72px;
   font-size: 0.55rem;
-  display: flex;
+  display: inline-flex;
   flex-direction: column;
   align-items: center;
   position: relative;
   z-index: 1;
   gap: 2px;
+  transition: box-shadow 0.2s;
+}
+
+.disciple-badge:hover {
+  box-shadow: 0 0 6px var(--verdantia-highlight);
 }
 .disciple-badge .mood-icon {
   position: absolute;


### PR DESCRIPTION
## Summary
- style disciple badges with bamboo border-image
- document the badge border effect in wireframes
- adjust border width and sizing so the frame fits correctly

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687d21d915188326a00fc4bba494dda7