### PR TITLE
Fix resource decimals on sect map

### DIFF
--- a/script.js
+++ b/script.js
@@ -763,8 +763,8 @@ function updateSectDisplay() {
     const upkeep = DAILY_FRUIT_CONSUMPTION * sectSystem.disciples.length;
     sectSummaryDisplay.innerHTML = `
       <span>👥 ${total}/${sectState.maxDisciples} (Idle: ${idle})</span>
-      <span>${sectState.fruits}</span>
-      <span>🪵 ${sectState.softwood}</span>`;
+      <span>${sectState.fruits.toFixed(2)}</span>
+      <span>🪵 ${sectState.softwood.toFixed(2)}</span>`;
     const timer = document.getElementById('resourceTimer');
     if (timer) {
       timer.textContent = `${mm}:${ss}`;


### PR DESCRIPTION
## Summary
- display sect map resources with two decimal places

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687d32eef5d08326a6388d97f4686d7c