### PR TITLE
Add stage-based coquí glow

### DIFF
--- a/docs/13-metamorphosis-stages-&-methods.md
+++ b/docs/13-metamorphosis-stages-&-methods.md
@@ -19,6 +19,10 @@ During the **Training** schedule phase, disciples gain metamorphosis XP automati
 
 ## 🐸 Metamorphosis Stages
 
+As a disciple progresses, their sprite on the sect map gains a brighter aura.
+Early stages feature a subtle glow while higher stages emit pulsing colors to
+reflect growing power.
+
 ### 1. 🥚 Egg Stage
 
 - **Requirement**: 25,000 metamorphosis XP
@@ -53,6 +57,7 @@ When the required XP is reached, progress pauses and a **Breakthrough** button a
 ### 5. 🐸✨ Divine Coquí *(Godhood)*
 
 - Final metamorphosis into mythic form
+- Sprite glows with a shimmering golden aura
 
 
 ### Progress bar and numeric values

--- a/game/disciplesVisuals.js
+++ b/game/disciplesVisuals.js
@@ -1,4 +1,5 @@
 import { TASK_ICONS } from './constants.js';
+import { sectState } from './state.js';
 
 function scheduleNext(el) {
   el.dataset.nextCroak = Date.now() + 10000 + Math.random() * 10000;
@@ -7,10 +8,14 @@ function scheduleNext(el) {
 export function initDiscipleVisual(d, el) {
   scheduleNext(el);
   updateItem(el, 'Idle');
+  const meta = sectState.discipleMetamorphosis[d.id];
+  if (meta) el.dataset.stage = meta.stage + 1;
 }
 
 export function updateDiscipleVisual(d, el, task) {
   updateItem(el, task);
+  const meta = sectState.discipleMetamorphosis[d.id];
+  if (meta) el.dataset.stage = meta.stage + 1;
   const next = parseFloat(el.dataset.nextCroak || '0');
   if (Date.now() >= next) {
     showCroak(el);

--- a/style.css
+++ b/style.css
@@ -3135,6 +3135,41 @@ body.darkenshift-mode .tabsContainer button.active {
 .sect-disciple.incapacitated {
     filter: grayscale(1) drop-shadow(0 0 2px rgba(255,0,0,0.8));
 }
+
+/* metamorphosis stage glow effects */
+.sect-disciple[data-stage="1"] {
+    filter: drop-shadow(0 0 2px rgba(0,0,0,0.8)) drop-shadow(0 0 4px rgba(255,255,255,0.6));
+}
+.sect-disciple[data-stage="2"] {
+    filter: drop-shadow(0 0 2px rgba(0,0,0,0.8)) drop-shadow(0 0 5px rgba(0,255,0,0.7));
+}
+.sect-disciple[data-stage="3"] {
+    filter: drop-shadow(0 0 2px rgba(0,0,0,0.8)) drop-shadow(0 0 6px rgba(0,150,255,0.8));
+}
+.sect-disciple[data-stage="4"] {
+    animation: violetPulse 2s infinite;
+}
+.sect-disciple[data-stage="5"] {
+    animation: goldShimmer 2s infinite;
+}
+
+@keyframes violetPulse {
+    0%, 100% {
+        filter: drop-shadow(0 0 2px rgba(0,0,0,0.8)) drop-shadow(0 0 7px rgba(180,0,255,0.8));
+    }
+    50% {
+        filter: drop-shadow(0 0 2px rgba(0,0,0,0.8)) drop-shadow(0 0 12px rgba(180,0,255,1));
+    }
+}
+
+@keyframes goldShimmer {
+    0%, 100% {
+        filter: drop-shadow(0 0 2px rgba(0,0,0,0.8)) drop-shadow(0 0 8px rgba(255,215,0,0.8));
+    }
+    50% {
+        filter: drop-shadow(0 0 2px rgba(0,0,0,0.8)) drop-shadow(0 0 14px rgba(255,215,0,1));
+    }
+}
 .croak-bubble {
     position: absolute;
     bottom: 12px;


### PR DESCRIPTION
## Summary
- apply metamorphosis stage glow to each disciple sprite
- set sprite `data-stage` from metamorphosis data
- animate higher stages with pulse and shimmer
- document stage glow feature

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687d33792a1c8326942504bb628962e8