### PR TITLE
feat: style disciple badges

### DIFF
--- a/game/badges.js
+++ b/game/badges.js
@@ -4,21 +4,24 @@ import { DISCIPLE_MAX_HEALTH } from './constants.js';
 
 export function createDiscipleBadge(d) {
   const badge = document.createElement('div');
-  badge.className = 'disciple-badge parchment-box';
+  badge.className = 'disciple-badge';
+
+  const content = document.createElement('div');
+  content.className = 'disciple-content parchment-box';
 
   const name = document.createElement('div');
   name.className = 'disciple-name';
   name.textContent = d.name || `Disciple ${d.id}`;
-  badge.appendChild(name);
+  content.appendChild(name);
 
   const mood = document.createElement('span');
   mood.className = 'mood-icon';
   mood.textContent = d.mood || '🙂';
-  badge.appendChild(mood);
+  content.appendChild(mood);
 
   const lifeBar = makeBar(d.health, DISCIPLE_MAX_HEALTH, '#a33');
   lifeBar.classList.add('life-bar');
-  badge.appendChild(lifeBar);
+  content.appendChild(lifeBar);
 
   const wrapper = document.createElement('div');
   wrapper.dataset.discipleId = d.id;
@@ -31,7 +34,9 @@ export function createDiscipleBadge(d) {
   const curTask = d.incapacitated ? 'Resting' : sectState.discipleTasks[d.id] || 'Idle';
   label.textContent = curTask;
   wrapper.appendChild(label);
-  badge.appendChild(wrapper);
+  content.appendChild(wrapper);
+
+  badge.appendChild(content);
 
   
   return badge;

--- a/style.css
+++ b/style.css
@@ -3731,15 +3731,27 @@ body.darkenshift-mode .tabsContainer button.active {
 }
 
 .disciple-badge {
-  border-radius: 6px;
-  padding: 2px;
-  width: 72px;
-  font-size: 0.55rem;
+  background-image: url('img/bamboo.png');
+  background-size: 100% 100%;
+  background-repeat: no-repeat;
+  border-radius: 12px;
+  padding: 8px;
+  position: relative;
+  z-index: 1;
   display: flex;
   flex-direction: column;
   align-items: center;
-  position: relative;
-  z-index: 1;
+  gap: 2px;
+}
+
+.disciple-badge .disciple-content {
+  background-color: rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  padding: 4px;
+  width: 72px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
   gap: 2px;
 }
 


### PR DESCRIPTION
## Summary
- bamboo background added for disciples
- wrap badge content in `.disciple-content` container

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687d360dd0a483268f16866461d454ad