### PR TITLE
fix: show disciples during tasks

### DIFF
--- a/script.js
+++ b/script.js
@@ -921,8 +921,8 @@ function updateDiscipleGather(id, el) {
       el.style.opacity = '1';
       el.style.transform = `translate(${px}px, ${py}px)`;
       break;
-    case 1: // gathering (stay outside, hidden)
-      el.style.opacity = '0';
+    case 1: // gathering at spot
+      el.style.opacity = '1';
       el.style.transform = `translate(${px}px, ${py}px)`;
       break;
     case 2: // hauling back


### PR DESCRIPTION
## Summary
- keep disciples visible while gathering

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687d36a4a408832686cfb85b4bfd065b