### PR TITLE
feat: show buildings overlay

### DIFF
--- a/docs/12-buildings.md
+++ b/docs/12-buildings.md
@@ -2,6 +2,8 @@
 
 This section covers all sect buildings and ornament structures, their costs, effects, and unlock requirements.
 
+Buildings become available once your sect has gathered **20 Softwood**. This unlocks the "Build" button in the sect navigation which opens an overlay listing all constructable buildings.
+
 Housing Buildings
 
 Building	Cost (Softwood)

--- a/style.css
+++ b/style.css
@@ -735,6 +735,42 @@ body.darkenshift-mode .tabsContainer button.active {
     color: #f88;
 }
 
+.build-overlay .overlay-box {
+    max-width: 400px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+.build-list {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+.build-entry {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 4px;
+}
+.build-progress {
+    position: relative;
+    width: 100px;
+    height: 8px;
+    background: #333;
+    border: 1px solid #555;
+    border-radius: 4px;
+    overflow: hidden;
+}
+.build-progress-fill {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: 0;
+    background: var(--core-accent);
+    transition: width 0.3s ease;
+}
+
 .work-disciples .sect-disciple-card.selected {
     background: #fbf6e0;
     color: #000;

--- a/ui/colonyOverlays.js
+++ b/ui/colonyOverlays.js
@@ -7,6 +7,7 @@ import { createOverlay } from './overlay.js';
 import { sectSystem, SECT_SCHEDULE, getCurrentSchedule, renderConstructCards, getDailyResourceDelta, getDiscipleDailyOutput } from '../game/sect.js';
 import { systems, sectState, worldProgress } from '../game/state.js';
 import { createSectDiscipleCard, renderExplorationTab, startExploration, startWorldCombat, discipleGatherPhase } from '../script.js';
+import { BUILDINGS, startBuilding } from '../game/buildings.js';
 
 let explorationOverlay = null;
 let explorationOverlayActiveTab = 'explore';
@@ -271,8 +272,61 @@ export function openResourceOverlay() {
   interval = setInterval(render, 1000);
 }
 
+let buildOverlay = null;
 export function openBuildOverlay() {
-  openPlaceholderOverlay('Build');
+  if (buildOverlay) return;
+  buildOverlay = createOverlay({ className: 'build-overlay', boxClass: 'parchment-box' });
+  buildOverlay.box.classList.add('parchment-box');
+  buildOverlay.onClose(() => {
+    buildOverlay = null;
+    globalThis.updateBuildOverlay = null;
+  });
+  const { box } = buildOverlay;
+
+  const header = document.createElement('div');
+  header.className = 'panel-heading';
+  header.textContent = 'Buildings';
+  box.appendChild(header);
+
+  const list = document.createElement('div');
+  list.className = 'build-list';
+  box.appendChild(list);
+
+  function render() {
+    list.innerHTML = '';
+    Object.entries(BUILDINGS).forEach(([key, def]) => {
+      if (def.requires && !(sectState.buildings[def.requires] > 0)) return;
+      const built = sectState.buildings[key] || 0;
+      const row = document.createElement('div');
+      row.className = 'build-entry';
+      const label = document.createElement('div');
+      label.textContent = `${def.name} (Lv${built}/${def.max})`;
+      row.appendChild(label);
+      if (sectState.currentBuild === key) {
+        const progress = document.createElement('div');
+        progress.className = 'build-progress';
+        const fill = document.createElement('div');
+        fill.className = 'build-progress-fill';
+        fill.style.width = `${Math.floor(sectState.buildProgress * 100)}%`;
+        progress.appendChild(fill);
+        row.appendChild(progress);
+      } else {
+        const cost = def.costFunc ? def.costFunc(built + 1) : def.cost;
+        const btn = document.createElement('button');
+        btn.textContent = `Build (${cost}\u{1FAB5})`;
+        btn.disabled = sectState.softwood < cost || built >= def.max || sectState.currentBuild;
+        btn.addEventListener('click', () => {
+          startBuilding(key);
+          render();
+        });
+        row.appendChild(btn);
+      }
+      list.appendChild(row);
+    });
+  }
+
+  globalThis.updateBuildOverlay = render;
+  render();
 }
 
 let dungeonOverlay = null;


### PR DESCRIPTION
## Summary
- implement Build overlay to show available buildings
- add styles for new overlay
- document unlocking conditions for buildings

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687e45f8352c83269dc74b3b1ceaa335