### PR TITLE
Add affinity icons and overlay tweaks

### DIFF
--- a/docs/00-wireframes.md
+++ b/docs/00-wireframes.md
@@ -144,6 +144,8 @@ Here’s the updated **Disciple Overlay UI wireframe** with the added `Cultivati
 └────────────────────────────────────────────────────┘
 ```
 
+Heart and thumbs-up icons denote loved and liked skills respectively.
+
 ---
 
 ### 🔮 **Constructs Tab**

--- a/docs/09-skill-proficiency.md
+++ b/docs/09-skill-proficiency.md
@@ -33,3 +33,5 @@ Attributes other than Intelligence do not affect proficiency gain.
 Proficiency XP is applied every tick while a disciple performs a task. The base
 rates above are multiplied by the disciple's Intelligence modifier and any
 affinity bonuses.
+Loved skills display a heart icon in the Proficiency tab, while liked skills
+show a thumbs-up icon.

--- a/docs/22-affinities.md
+++ b/docs/22-affinities.md
@@ -3,6 +3,9 @@ Affinities increase starting skill levels and proficiency gain.
 When a disciple is created it gains "liked" affinity toward 0‑3 skills.
 A disciple also gains "loved" affinity for 0‑3 random skills, overriding "liked".
 
+In the disciple overlay's **Proficiency** tab, loved skills show a heart icon
+while liked skills show a thumbs-up icon.
+
 ### Liked
 - Increases proficiency gain by **40%**.
 - Grants bonus starting skill levels. See [recruitment](02‑recruitment.md).

--- a/script.js
+++ b/script.js
@@ -1277,8 +1277,17 @@ function buildDiscipleProficiencyView(d) {
     const isGather = name === 'Gathering' || name === 'Logging';
     const mult = 1 + (isGather ? 0.05 : 0.02) * prog.level;
     const effect = effects[name];
-    head.textContent = `${name} Lv ${prog.level}` +
+    const label = document.createElement('span');
+    label.textContent = `${name} Lv ${prog.level}` +
       (effect ? ` (×${mult.toFixed(2)} ${effect})` : '');
+    const affinity = d.affinities?.[name];
+    if (affinity === 'liked' || affinity === 'loved') {
+      const icon = document.createElement('i');
+      icon.dataset.lucide = affinity === 'loved' ? 'heart' : 'thumbs-up';
+      icon.className = `affinity-icon ${affinity}`;
+      head.appendChild(icon);
+    }
+    head.appendChild(label);
     const bar = document.createElement('div');
     bar.className = 'disciple-skill-progress';
     const fill = document.createElement('div');

--- a/style.css
+++ b/style.css
@@ -590,10 +590,10 @@ body.darkenshift-mode .tabsContainer button.active {
 
 /* Disciple overlay positioning and style */
 .disciple-overlay.overlay {
-    background: none;
+    background: var(--verdantia-parchment);
     backdrop-filter: none;
-    justify-content: flex-end;
-    align-items: flex-start;
+    justify-content: flex-start;
+    align-items: flex-end;
     pointer-events: none;
 }
 .disciple-overlay .overlay-box {
@@ -3602,6 +3602,14 @@ body.darkenshift-mode .tabsContainer button.active {
 .skill-group > div:first-child {
     cursor: pointer;
 }
+.affinity-icon {
+    width: 1em;
+    height: 1em;
+    vertical-align: middle;
+    margin-right: 2px;
+}
+.affinity-icon.liked { color: #d97e00; }
+.affinity-icon.loved { color: #c0392b; }
 .verdantia-bg::before {
   content: "";
   position: absolute;


### PR DESCRIPTION
## Summary
- show heart/thumbs-up icons for loved and liked skills
- move disciple overlay to bottom left and use parchment background
- document affinity icons in docs

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687e4d4cb124832695ac310e6e252e35