### PR TITLE
Fix metamorph tab layout on mobile

### DIFF
--- a/metamorphosis.js
+++ b/metamorphosis.js
@@ -226,13 +226,13 @@ function updateStats() {
   Object.values(stats).forEach(v => { rate *= v; });
   statsContainer.innerHTML = `
     <div class="meta-stat" data-tip="XP/sec = 0.4 × method × building × room × path match × stability × cultivation × season">XP/sec: ${rate.toFixed(2)}</div>
-    <div class="meta-stat" data-tip="Multiplier from assigned cultivation method">Method ×${stats.method}</div>
-    <div class="meta-stat" data-tip="Multiplier from cultivation building effects">Building ×${stats.building}</div>
-    <div class="meta-stat" data-tip="Room bonuses like humidity and ornaments">Room ×${stats.room}</div>
-    <div class="meta-stat" data-tip="Bonus when method matches disciple's Path">Path Match ×${stats.pathMatch}</div>
-    <div class="meta-stat" data-tip="Penalty or boost based on current Stability">Stability ×${stats.stability}</div>
-    <div class="meta-stat" data-tip="Potential squared (discipline talent)">Cultivation ${stats.cultivation}</div>
-    <div class="meta-stat" data-tip="Seasonal multiplier from weather">Season ×${stats.season}</div>
+    <div class="meta-stat" data-tip="Multiplier from assigned cultivation method">Method ×${stats.method.toFixed(2)}</div>
+    <div class="meta-stat" data-tip="Multiplier from cultivation building effects">Building ×${stats.building.toFixed(2)}</div>
+    <div class="meta-stat" data-tip="Room bonuses like humidity and ornaments">Room ×${stats.room.toFixed(2)}</div>
+    <div class="meta-stat" data-tip="Bonus when method matches disciple's Path">Path Match ×${stats.pathMatch.toFixed(2)}</div>
+    <div class="meta-stat" data-tip="Penalty or boost based on current Stability">Stability ×${stats.stability.toFixed(2)}</div>
+    <div class="meta-stat" data-tip="Potential squared (discipline talent)">Cultivation ${stats.cultivation.toFixed(2)}</div>
+    <div class="meta-stat" data-tip="Seasonal multiplier from weather">Season ×${stats.season.toFixed(2)}</div>
   `;
   statsContainer.querySelectorAll('.meta-stat').forEach(el => {
     const tip = el.dataset.tip;

--- a/style.css
+++ b/style.css
@@ -2052,14 +2052,14 @@ body.darkenshift-mode .tabsContainer button.active {
     flex-direction: column;
     gap: 8px;
     font-size: 0.8rem;
-    min-width: 160px;
+    min-width: 120px;
 }
 .metamorphosis-stats-panel {
     display: flex;
     flex-direction: column;
     gap: 6px;
     font-size: 0.8rem;
-    min-width: 160px;
+    min-width: 120px;
 }
 .metamorphosis-stats-panel .meta-stat {
     background: rgba(252, 236, 194, 0.5);
@@ -2069,6 +2069,10 @@ body.darkenshift-mode .tabsContainer button.active {
 .metamorphosis-side-panel .sect-disciple-list {
     flex-direction: column;
     overflow-x: visible;
+}
+.metamorphosis-side-panel .disciple-badge .disciple-content,
+.metamorphosis-side-panel .disciple-badge .disciple-progress {
+    width: 60px;
 }
 .construct-side-panel {
     display: flex;


### PR DESCRIPTION
## Summary
- shrink disciple and stats panels so the progress ring is visible
- format metamorphosis stat numbers to two decimals

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688009ffc9b48326bed3e063c7326291