### PR TITLE
Fix construct toggle null error

### DIFF
--- a/game/sect.js
+++ b/game/sect.js
@@ -519,13 +519,17 @@ export function initSect() {
   `;
   panel = container.querySelector('#modalConstructorPanel');
   const toggleBtn = container.querySelector('#constructToggle');
-  toggleBtn.addEventListener('click', togglePanel);
-  toggleBtn.addEventListener('mouseenter', e => {
-    window.showTooltip('Toggle constructor panel', e.pageX + 10, e.pageY + 10);
-  });
-  toggleBtn.addEventListener('mouseleave', window.hideTooltip);
-  panel.querySelector('#closeConstructBtn').addEventListener('click', togglePanel);
-  panel.querySelector('#performConstruct').addEventListener('click', performConstruct);
+  if (toggleBtn) {
+    toggleBtn.addEventListener('click', togglePanel);
+    toggleBtn.addEventListener('mouseenter', e => {
+      window.showTooltip('Toggle constructor panel', e.pageX + 10, e.pageY + 10);
+    });
+    toggleBtn.addEventListener('mouseleave', window.hideTooltip);
+  }
+  const closeBtn = panel?.querySelector('#closeConstructBtn');
+  if (closeBtn) closeBtn.addEventListener('click', togglePanel);
+  const performBtn = panel?.querySelector('#performConstruct');
+  if (performBtn) performBtn.addEventListener('click', performConstruct);
   renderResourcesUI();
   renderPot();
   renderOrbs();


### PR DESCRIPTION
## Summary
- add null checks before adding event listeners for construct UI buttons

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68800c680e7c83268ae11a00098cf82b