### PR TITLE
Remove background from disciple overlay

### DIFF
--- a/style.css
+++ b/style.css
@@ -590,7 +590,7 @@ body.darkenshift-mode .tabsContainer button.active {
 
 /* Disciple overlay positioning and style */
 .disciple-overlay.overlay {
-    background: var(--verdantia-parchment);
+    background: transparent;
     backdrop-filter: none;
     justify-content: flex-start;
     align-items: flex-end;


### PR DESCRIPTION
## Summary
- update disciple overlay styling so it no longer applies a solid parchment background

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68800f670258832688fa410498066955