### PR TITLE
Add sect raid system

### DIFF
--- a/docs/23-raids.md
+++ b/docs/23-raids.md
@@ -1,0 +1,10 @@
+# 23 – Raids
+
+Disciples may be called upon to defend the sect from occasional raids.
+
+* Raids begin automatically during the Night phase.
+* Raiders attack the Water orb, reducing its stored energy.
+* Disciples assigned to **Defend** fight the raiders using their combat stats.
+* If the orb is depleted the sect loses a small amount of fruit and softwood.
+* The Water orb periodically lashes out at the raiders.
+* The raid ends when the enemy is defeated or the orb is drained.

--- a/docs/README.md
+++ b/docs/README.md
@@ -66,3 +66,5 @@ Table of Contents
 20. [Skills](20-skills.md)
 
 21. [Metamorphosis UI Expansion](21-metamorphosis-ui.md)
+22. [Affinities](22-affinities.md)
+23. [Raids](23-raids.md)

--- a/game/constants.js
+++ b/game/constants.js
@@ -49,7 +49,8 @@ export const TASK_ICONS = {
   Resting: '🛌',
   Training: '🥋',
   Eat: '🍽️',
-  Sleep: '💤'
+  Sleep: '💤',
+  Defend: '🛡️'
 };
 
 export const TASK_GROUPS = {
@@ -61,7 +62,8 @@ export const TASK_GROUPS = {
   'Chant': 'Chanting',
   'Exploration': 'Exploration',
   Idle: 'Idle',
-  Resting: 'Idle'
+  Resting: 'Idle',
+  Defend: 'Combat'
 };
 
 export const ATTRIBUTE_FOR_GROUP = {
@@ -72,7 +74,8 @@ export const ATTRIBUTE_FOR_GROUP = {
   Researching: 'intelligence',
   Chanting: 'intelligence',
   Exploration: 'dexterity',
-  Idle: null
+  Idle: null,
+  Combat: 'strength'
 };
 
 export const LOCATION_DEFS = [

--- a/game/raids.js
+++ b/game/raids.js
@@ -1,0 +1,59 @@
+/* global updateSectDisplay */
+import { sectSystem } from './sect.js';
+import { sectState } from './state.js';
+import { spawnDealer } from '../enemySpawning.js';
+import addLog from '../log.js';
+
+export const raidState = {
+  active: false,
+  enemy: null,
+  attackTimers: {},
+  orbTimer: 0
+};
+
+const ORB_INTERVAL = 5000; // ms
+
+export function startRaid() {
+  if (raidState.active) return;
+  const stage = Math.max(1, sectSystem.seasonDay + 1);
+  const onAttack = enemy => {
+    const dmg = enemy.damage;
+    sectSystem.orbs.water.current = Math.max(0, sectSystem.orbs.water.current - dmg);
+    if (sectSystem.orbs.water.current === 0) {
+      sectState.fruits = Math.max(0, sectState.fruits - 20);
+      sectState.softwood = Math.max(0, sectState.softwood - 10);
+      addLog('Raiders plunder your supplies!', 'damage');
+      endRaid();
+    }
+    if (typeof updateSectDisplay === 'function') updateSectDisplay();
+  };
+  raidState.enemy = spawnDealer({ stage, world: 1 }, 0, onAttack, endRaid);
+  raidState.active = true;
+  raidState.attackTimers = {};
+  raidState.orbTimer = 0;
+  addLog('Raiders have attacked!', 'info');
+  document.dispatchEvent(new CustomEvent('raid-start', { detail: raidState.enemy }));
+  if (typeof updateSectDisplay === 'function') updateSectDisplay();
+}
+
+export function endRaid() {
+  if (!raidState.active) return;
+  raidState.active = false;
+  raidState.enemy = null;
+  raidState.attackTimers = {};
+  raidState.orbTimer = 0;
+  addLog('The raid has ended.', 'info');
+  document.dispatchEvent(new CustomEvent('raid-end'));
+  if (typeof updateSectDisplay === 'function') updateSectDisplay();
+}
+
+export function tickRaid(delta) {
+  if (!raidState.active || !raidState.enemy) return;
+  raidState.enemy.tick(delta);
+  raidState.orbTimer += delta;
+  if (raidState.orbTimer >= ORB_INTERVAL) {
+    raidState.orbTimer -= ORB_INTERVAL;
+    raidState.enemy.takeDamage(5);
+    if (raidState.enemy.isDefeated()) endRaid();
+  }
+}

--- a/game/sect.js
+++ b/game/sect.js
@@ -27,6 +27,7 @@ import {
   HUNT_CYCLE_SECONDS,
   EXPLORATION_CYCLE_SECONDS
 } from './constants.js';
+import { startRaid, tickRaid, raidState, endRaid } from './raids.js';
 
 export { addDiscoveredLocation } from "./ui.js";
 export const discoveredLocations = [];
@@ -1190,6 +1191,7 @@ export function tickSectSystem(delta) {
     document.dispatchEvent(
       new CustomEvent('schedule-phase', { detail: getCurrentSchedule() })
     );
+    if (getCurrentSchedule().phase === 'Night') startRaid();
   }
   sectSystem.seasonTimer += dt;
   if (sectSystem.seasonTimer >= DAY_LENGTH_SECONDS) {
@@ -1199,6 +1201,7 @@ export function tickSectSystem(delta) {
     document.dispatchEvent(
       new CustomEvent('schedule-phase', { detail: getCurrentSchedule() })
     );
+    if (getCurrentSchedule().phase === 'Night') startRaid();
     sectSystem.seasonDay += 1;
     document.dispatchEvent(new CustomEvent('day-passed', {
       detail: { day: sectSystem.seasonDay, season: sectSystem.seasonIndex }
@@ -1309,6 +1312,7 @@ export function tickSectSystem(delta) {
   }
   tickActiveConstructs(dt);
   tickMetamorphosis(dt);
+  tickRaid(delta);
   ins.current = Math.min(ins.max, Math.max(0, ins.current));
   if (hasUI) {
     updateCooldownOverlays();
@@ -1516,6 +1520,17 @@ export function tickSect(delta) {
     } else if (task === 'Exploration') {
       progress = (progress + dt) % EXPLORATION_CYCLE_SECONDS;
       sectState.discipleProgress[d.id] = progress;
+    } else if (task === 'Defend') {
+      if (raidState.active && raidState.enemy) {
+        if (!raidState.attackTimers[d.id]) raidState.attackTimers[d.id] = 0;
+        raidState.attackTimers[d.id] += delta;
+        const atkTime = d.attackSpeed;
+        if (raidState.attackTimers[d.id] >= atkTime) {
+          raidState.enemy.takeDamage(d.damage);
+          raidState.attackTimers[d.id] = 0;
+          if (raidState.enemy.isDefeated()) endRaid();
+        }
+      }
     }
 
     if (xpRate > 0 && group) {


### PR DESCRIPTION
## Summary
- support Defend task icons and groups
- trigger raids during the Night phase
- implement raid logic with new module
- allow disciples to Defend and fight raiders
- document raids

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688275011f948326b0de8d347ac1272c