### PR TITLE
Wire research nav to desk unlock

### DIFF
--- a/docs/12-buildings.md
+++ b/docs/12-buildings.md
@@ -33,6 +33,7 @@ Granary	Softwood: 50 × (1.2^lvl)	+400 food storage capacity	Farming research
 Storage	Softwood & Stone: 30 × (1.3^lvl) each	+100 wood cap, +200 stone cap per level	Granary Lv1
 Celestial Sanctum	Any: 200 × (1.4^lvl)	Unlocks Cultivation Rooms; +4% areaWater, +3% cult speed per level	Research Tree Lv5
 Training Dummy	Softwood: 10	Foundation training station; +2× foundation XP	Start
+Research Desk   Softwood: 15    Unlocks Research navigation; allows disciples to study
 Research Table	Softwood: 30 × (lvl^1.3)	Convert 4% global Water → Insight per level	Chanting research
 Library	Wood: 200 × (lvl^1.1); Stone: 100 × (lvl^1.1)	Unlock learning/spell teaching; +4% teaching rate per level	Research Table Lv1
 Jadefire Pavilion	Softwood & Stone: 20 × (1.1^lvl) each	Enables Transmutation; +3% spell potency per level	Transmutation research

--- a/docs/15-research.md
+++ b/docs/15-research.md
@@ -2,6 +2,8 @@
 
 This section outlines the major research branches and their unlock progression.
 
+Build a Research Desk to unlock the Research screen and begin accumulating Research Points.
+
 
 ---
 

--- a/script.js
+++ b/script.js
@@ -44,7 +44,7 @@ import { initMetamorphosis, refreshMetamorphosis } from './metamorphosis.js';
 import { intelligenceXpMultiplier } from './attributes.js';
 import { createOverlay } from './ui/overlay.js';
 import { showLoadErrorOverlay } from './ui/loadErrorOverlay.js';
-import { openExplorationOverlay, closeExplorationOverlay, openWorkOverlay, openScheduleOverlay, openPlaceholderOverlay, openResourceOverlay, openBuildOverlay, closeDungeonOverlay, locationListContainer, explorationListContainer } from "./ui/colonyOverlays.js";
+import { openExplorationOverlay, closeExplorationOverlay, openWorkOverlay, openScheduleOverlay, openPlaceholderOverlay, openResourceOverlay, openBuildOverlay, openResearchOverlay, closeDungeonOverlay, locationListContainer, explorationListContainer } from "./ui/colonyOverlays.js";
 import { createDiscipleBadge } from "./game/badges.js";
 import { calculateKillXp } from './utils/xp.js';
 import { initTooltip } from './game/tooltip.js';
@@ -479,7 +479,12 @@ function initTabs() {
   if (sectNavChantBtn) sectNavChantBtn.addEventListener("click", () => { setActiveNavBtn(sectNavChantBtn); openPlaceholderOverlay("Chanting"); });
   if (sectNavMapBtn) sectNavMapBtn.addEventListener("click", () => { setActiveNavBtn(sectNavMapBtn); openExplorationOverlay(); });
   if (sectNavInfluenceBtn) sectNavInfluenceBtn.addEventListener("click", () => { setActiveNavBtn(sectNavInfluenceBtn); openPlaceholderOverlay("Influence"); });
-  if (sectNavResearchBtn) sectNavResearchBtn.addEventListener("click", () => { setActiveNavBtn(sectNavResearchBtn); openPlaceholderOverlay("Research"); });
+  if (sectNavResearchBtn)
+    sectNavResearchBtn.addEventListener("click", () => {
+      setActiveNavBtn(sectNavResearchBtn);
+      if (systems.researchUnlocked) openResearchOverlay();
+      else openPlaceholderOverlay("Research");
+    });
   if (sectNavCultivationBtn)
     sectNavCultivationBtn.addEventListener("click", () => {
       setActiveNavBtn(sectNavCultivationBtn);
@@ -644,6 +649,9 @@ function updateSectDisplay() {
   checkBuildingUnlock();
   if (sectNavBuildBtn) {
     sectNavBuildBtn.style.display = systems.buildingUnlocked ? '' : 'none';
+  }
+  if (sectNavResearchBtn) {
+    sectNavResearchBtn.style.display = systems.researchUnlocked ? '' : 'none';
   }
   if (!sectTabUnlocked || !playerSectPanel) return;
   const total = sectSystem.disciples.length;

--- a/ui/colonyOverlays.js
+++ b/ui/colonyOverlays.js
@@ -159,6 +159,7 @@ export function openWorkOverlay() {
     right.innerHTML = '';
     const tasks = ['Gather Fruit', 'Gather Softwood'];
     if (systems.buildingUnlocked) tasks.push('Building');
+    if (systems.researchUnlocked) tasks.push('Research');
     tasks.forEach(t => {
       const btn = document.createElement('button');
       btn.textContent = t;
@@ -383,4 +384,50 @@ export function openDungeonOverlay() {
     entry.appendChild(btn);
     worldsContainer.appendChild(entry);
   });
+}
+
+let researchOverlay = null;
+export function openResearchOverlay() {
+  if (researchOverlay) return;
+  researchOverlay = createOverlay({ className: 'research-overlay', boxClass: 'parchment-box' });
+  researchOverlay.box.classList.add('parchment-box');
+  let interval;
+  researchOverlay.onClose(() => {
+    if (interval) clearInterval(interval);
+    researchOverlay = null;
+  });
+  const { box } = researchOverlay;
+
+  const header = document.createElement('div');
+  header.className = 'panel-heading';
+  header.textContent = 'Research';
+  box.appendChild(header);
+
+  const pointsEl = document.createElement('div');
+  box.appendChild(pointsEl);
+
+  const progress = document.createElement('div');
+  progress.className = 'research-progress';
+  const fill = document.createElement('div');
+  fill.className = 'research-progress-fill';
+  progress.appendChild(fill);
+  box.appendChild(progress);
+
+  const info = document.createElement('div');
+  info.className = 'research-progress-info';
+  box.appendChild(info);
+
+  function render() {
+    pointsEl.textContent = `Research Points: ${sectState.researchPoints}`;
+    const prog = sectState.researchProgress % 500;
+    const pct = (prog / 500) * 100;
+    fill.style.width = `${pct}%`;
+    const researchers = sectSystem.disciples.filter(d => sectState.discipleTasks[d.id] === 'Research').length;
+    const rate = researchers * 4;
+    const time = rate > 0 ? (500 - prog) / rate : Infinity;
+    info.textContent = `Next point: ${rate > 0 ? time.toFixed(1) : '∞'}s`;
+  }
+
+  render();
+  interval = setInterval(render, 1000);
 }


### PR DESCRIPTION
## Summary
- unlock Research navigation button upon constructing a Research Desk
- show Research task in work overlay when research unlocked
- implement Research overlay with progress display
- document Research Desk and Research screen access

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6882d86c6a9c8326a0b3b353025a40ae