### PR TITLE
Add unit test for water orb regen

### DIFF
--- a/test/water-orb.test.js
+++ b/test/water-orb.test.js
@@ -1,0 +1,35 @@
+/* global describe, it, before, after */
+import { expect } from 'chai';
+
+let sectModule;
+let sectSystem;
+let tickSectSystem;
+
+// Setup DOM stubs to satisfy module imports
+before(async () => {
+  globalThis.document = {
+    getElementById: () => null,
+    getElementsByClassName: () => [null],
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    querySelector: () => null,
+  };
+  globalThis.window = { dispatchEvent() {} };
+  sectModule = await import('../game/sect.js');
+  ({ sectSystem, tickSectSystem } = sectModule);
+});
+
+after(() => {
+  delete globalThis.document;
+  delete globalThis.window;
+});
+
+describe('water orb regeneration', () => {
+  it('regenerates over time', () => {
+    sectSystem.resources.water.current = 0;
+    for (let i = 0; i < 10; i++) {
+      tickSectSystem(1000);
+    }
+    expect(sectSystem.resources.water.current).to.be.closeTo(1, 1e-6);
+  });
+});


### PR DESCRIPTION
## Summary
- add test to ensure water orb regenerates over time

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6882d9bc417483268fc51981c3fb00fc