### PR TITLE
Implement raid alert overlay

### DIFF
--- a/docs/23-raids.md
+++ b/docs/23-raids.md
@@ -13,6 +13,7 @@ Night raids escalate the longer your sect survives. Each evening hostile frogs o
 Disciples may be called upon to defend the sect from occasional raids.
 
 * Raids begin automatically during the Night phase.
+* A red alert briefly appears on screen when a raid starts.
 * Raiders attack the Water orb, reducing its stored energy.
 * Disciples assigned to **Defend** fight the raiders using their combat stats.
 * If the orb is depleted the sect loses a small amount of fruit and softwood.

--- a/game/alerts.js
+++ b/game/alerts.js
@@ -1,0 +1,13 @@
+export let raidAlertEl = null;
+
+export function showRaidAlert(text = 'Raiders incoming!') {
+  if (raidAlertEl) return;
+  raidAlertEl = document.createElement('div');
+  raidAlertEl.className = 'raid-alert';
+  raidAlertEl.textContent = text;
+  document.body.appendChild(raidAlertEl);
+  setTimeout(() => {
+    raidAlertEl.remove();
+    raidAlertEl = null;
+  }, 3000);
+}

--- a/game/raids.js
+++ b/game/raids.js
@@ -3,6 +3,7 @@ import { sectSystem } from './sect.js';
 import { sectState } from './state.js';
 import { spawnDealer } from '../enemySpawning.js';
 import addLog from '../log.js';
+import { showRaidAlert } from './alerts.js';
 
 export const raidState = {
   active: false,
@@ -32,6 +33,7 @@ export function startRaid() {
   raidState.attackTimers = {};
   raidState.orbTimer = 0;
   addLog('Raiders have attacked!', 'info');
+  showRaidAlert('Raiders incoming!');
   document.dispatchEvent(new CustomEvent('raid-start', { detail: raidState.enemy }));
   if (typeof updateSectDisplay === 'function') updateSectDisplay();
 }

--- a/style.css
+++ b/style.css
@@ -1663,6 +1663,25 @@ body.darkenshift-mode .tabsContainer button.active {
     animation: fogFade 7s ease-in-out;
 }
 
+.raid-alert {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    font-size: 2rem;
+    color: #ff5555;
+    text-shadow: 0 0 6px #ffaaaa;
+    pointer-events: none;
+    animation: raidFade 3s ease-in-out forwards;
+    z-index: 5002;
+}
+
+@keyframes raidFade {
+    from { opacity: 0; }
+    10%, 90% { opacity: 1; }
+    to { opacity: 0; }
+}
+
 /* Floating construct effect */
 .construct-cloud {
     position: absolute;


### PR DESCRIPTION
## Summary
- add simple alert overlay helper
- show overlay when a raid starts
- document the raid alert
- style raid alert overlay

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6882d98d78308326b9c62521954fc9a8