### PR TITLE
Fix raid UI

### DIFF
--- a/docs/23-raids.md
+++ b/docs/23-raids.md
@@ -15,6 +15,8 @@ Disciples may be called upon to defend the sect from occasional raids.
 * Raids begin automatically during the Night phase.
 * Raiders attack the Water orb, reducing its stored energy.
 * Disciples assigned to **Defend** fight the raiders using their combat stats.
-* If the orb is depleted the sect loses a small amount of fruit and softwood.
-* The Water orb periodically lashes out at the raiders.
+* If the orb is depleted the sect loses **half** of its stored fruit and softwood.
+* The Water orb periodically lashes out with a **Water Burst** every 10&nbsp;s, dealing 5 damage.
+* Dealer enemies display a small life bar on their card during raids.
+* Defeating a raid yields **Undead Nectar** in addition to experience.
 * The raid ends when the enemy is defeated or the orb is drained.

--- a/game/raids.js
+++ b/game/raids.js
@@ -1,6 +1,12 @@
 /* global updateSectDisplay */
 import { sectSystem } from './sect.js';
-import { sectState } from './state.js';
+import {
+  sectState,
+  stageData,
+  setCurrentEnemy,
+  currentEnemy
+} from './state.js';
+import { updateRaidLifeBar } from './ui.js';
 import { spawnDealer } from '../enemySpawning.js';
 import addLog from '../log.js';
 
@@ -11,23 +17,52 @@ export const raidState = {
   orbTimer: 0
 };
 
-const ORB_INTERVAL = 5000; // ms
+function shootWaterBurst(targetEl) {
+  const orb = document.querySelector('#sectOrbs .sect-orb.water');
+  const map = document.getElementById('colonyMap');
+  if (!orb || !map || !targetEl) return;
+  const orbRect = orb.getBoundingClientRect();
+  const targetRect = targetEl.getBoundingClientRect();
+  const mapRect = map.getBoundingClientRect();
+  const proj = document.createElement('div');
+  const dx = targetRect.left + targetRect.width / 2 - (orbRect.left + orbRect.width / 2);
+  const dy = targetRect.top + targetRect.height / 2 - (orbRect.top + orbRect.height / 2);
+  const dist = Math.hypot(dx, dy);
+  proj.className = 'water-burst';
+  proj.style.left = `${orbRect.left - mapRect.left + orbRect.width / 2}px`;
+  proj.style.top = `${orbRect.top - mapRect.top + orbRect.height / 2}px`;
+  proj.style.setProperty('--dx', `${dx}px`);
+  proj.style.setProperty('--dy', `${dy}px`);
+  proj.style.setProperty('--duration', `${Math.max(300, dist)}ms`);
+  map.appendChild(proj);
+  proj.addEventListener('animationend', () => proj.remove(), { once: true });
+}
+
+const ORB_INTERVAL = 10000; // ms
 
 export function startRaid() {
   if (raidState.active) return;
-  const stage = Math.max(1, sectSystem.seasonDay + 1);
+  const stage = Math.max(1, stageData.stage);
+  const world = stageData.world;
   const onAttack = enemy => {
     const dmg = enemy.damage;
     sectSystem.orbs.water.current = Math.max(0, sectSystem.orbs.water.current - dmg);
     if (sectSystem.orbs.water.current === 0) {
-      sectState.fruits = Math.max(0, sectState.fruits - 20);
-      sectState.softwood = Math.max(0, sectState.softwood - 10);
+      sectState.fruits = Math.floor(sectState.fruits * 0.5);
+      sectState.softwood = Math.floor(sectState.softwood * 0.5);
       addLog('Raiders plunder your supplies!', 'damage');
       endRaid();
     }
     if (typeof updateSectDisplay === 'function') updateSectDisplay();
   };
-  raidState.enemy = spawnDealer({ stage, world: 1 }, 0, onAttack, endRaid);
+  const onDefeat = () => {
+    sectState.undeadNectar = (sectState.undeadNectar || 0) + 1;
+    addLog('Raiders dropped Undead Nectar!', 'good');
+    endRaid();
+  };
+  raidState.enemy = spawnDealer({ stage, world }, 0, onAttack, onDefeat);
+  setCurrentEnemy(raidState.enemy);
+  updateRaidLifeBar(raidState.enemy);
   raidState.active = true;
   raidState.attackTimers = {};
   raidState.orbTimer = 0;
@@ -39,6 +74,7 @@ export function startRaid() {
 export function endRaid() {
   if (!raidState.active) return;
   raidState.active = false;
+  setCurrentEnemy(null);
   raidState.enemy = null;
   raidState.attackTimers = {};
   raidState.orbTimer = 0;
@@ -49,11 +85,14 @@ export function endRaid() {
 
 export function tickRaid(delta) {
   if (!raidState.active || !raidState.enemy) return;
-  raidState.enemy.tick(delta);
+  if (raidState.enemy !== currentEnemy) raidState.enemy.tick(delta);
   raidState.orbTimer += delta;
   if (raidState.orbTimer >= ORB_INTERVAL) {
     raidState.orbTimer -= ORB_INTERVAL;
     raidState.enemy.takeDamage(5);
+    const card = document.querySelector('.raidCardContainer .dCardPane');
+    shootWaterBurst(card);
+    updateRaidLifeBar(raidState.enemy);
     if (raidState.enemy.isDefeated()) endRaid();
   }
 }

--- a/game/sect.js
+++ b/game/sect.js
@@ -26,6 +26,7 @@ import {
   EXPLORATION_CYCLE_SECONDS
 } from './constants.js';
 import { startRaid, tickRaid, raidState, endRaid } from './raids.js';
+import { updateRaidLifeBar } from './ui.js';
 
 export { addDiscoveredLocation } from "./ui.js";
 export const discoveredLocations = [];
@@ -1464,6 +1465,7 @@ export function tickSect(delta) {
         const atkTime = d.attackSpeed;
         if (raidState.attackTimers[d.id] >= atkTime) {
           raidState.enemy.takeDamage(d.damage);
+          updateRaidLifeBar(raidState.enemy);
           raidState.attackTimers[d.id] = 0;
           if (raidState.enemy.isDefeated()) endRaid();
         }

--- a/game/state.js
+++ b/game/state.js
@@ -87,6 +87,7 @@ export const FRUIT_GROWTH_RATES = [60, 40, 30, 20, 0];
 export const sectState = {
   fruits: 0,
   softwood: 0,
+  undeadNectar: 0,
   availableFruits: FRUIT_MAX_CAP,
   animals: { Chicken: 3, Boar: 1, Deer: 0 },
   discipleTasks: {},

--- a/game/ui.js
+++ b/game/ui.js
@@ -70,6 +70,12 @@ export function updateDealerLifeDisplay(currentEnemy) {
   renderDealerLifeBarFill(currentEnemy);
 }
 
+export function updateRaidLifeBar(enemy) {
+  if (!enemy || !enemy.raidLifeFill) return;
+  const ratio = Math.max(0, Math.min(1, enemy.currentHp / enemy.maxHp));
+  enemy.raidLifeFill.style.width = `${ratio * 100}%`;
+}
+
 export function updateDiscipleStatsDisplay(d) {
   if (!d.statsElement) return;
   d.statsElement.innerHTML = '';

--- a/index.html
+++ b/index.html
@@ -96,6 +96,7 @@
             <button id="sectNavResearchBtn" title="Research"><i data-lucide="flask-conical"></i><span>Research</span></button>
             <button id="sectNavCultivationBtn" title="Cultivation"><i data-lucide="sprout"></i><span>Cultivate</span></button>
           </div>
+          <div class="raidCardContainer"></div>
         </div>
       </div>
     </div>

--- a/script.js
+++ b/script.js
@@ -278,6 +278,7 @@ const dom = {
   killsDisplay: document.getElementById("kills"),
   worldProgressPerSecDisplay: document.getElementById("worldProgressPerSecDisplay"),
   dCardContainer: document.getElementsByClassName("dCardContainer")[0],
+  raidCardContainer: document.querySelector('.raidCardContainer'),
   dealerContainer: document.querySelector('.dealerContainer'),
   combatResources: document.getElementById('combatResources'),
 };
@@ -1255,6 +1256,21 @@ function init() {
     }
     updateSectDisplay();
   });
+  document.addEventListener('raid-start', e => {
+    setInCombat(true);
+    removeDealerLifeBar();
+    setCurrentEnemy(e.detail);
+    renderDealerCard(dom.raidCardContainer);
+    enemyAttackFill = renderEnemyAttackBar();
+    showPlayerAttackBar();
+  });
+  document.addEventListener('raid-end', () => {
+    setInCombat(false);
+    setCurrentEnemy(null);
+    hidePlayerAttackBar(enemyAttackFill);
+    removeDealerLifeBar();
+    if (dom.raidCardContainer) dom.raidCardContainer.innerHTML = '';
+  });
   updatePlayerStats(stats);
   // Game starts in sect view; exploration initiates combat
   renderWorldsMenu();
@@ -1424,22 +1440,30 @@ function renderDealerCardBase(enemy) {
     : `<i data-lucide="skull" class="dCard__icon" style="stroke:${color}; filter: drop-shadow(0 0 ${blur}px ${color});"></i>`;
   const { minDamage, maxDamage } = calculateEnemyBasicDamage(enemy.stage, enemy.world);
   pane.innerHTML = `\n    ${iconHtml}\n    <span class="dCard__text">\n    ${enemy.name}<br>\n    Damage: ${formatNumber(Math.floor(minDamage))} - ${formatNumber(Math.floor(maxDamage))}\n    </span>\n    `;
+  const lifeBar = document.createElement('div');
+  lifeBar.className = 'raid-life-bar';
+  const lifeFill = document.createElement('div');
+  lifeFill.className = 'raid-life-fill';
+  lifeFill.style.width = `${(enemy.currentHp / enemy.maxHp) * 100}%`;
+  lifeBar.appendChild(lifeFill);
+  pane.appendChild(lifeBar);
   abilityPane.innerHTML = renderAbilityIcons(enemy.abilities, false);
   wrapper.append(pane, abilityPane);
   if (enemy.isSpeaker) {
     const canvas = pane.querySelector('canvas.speaker-icon');
     if (canvas) drawSpeakerIcon(canvas);
   }
+  enemy.raidLifeFill = lifeFill;
   return wrapper;
 }
 
-function renderDealerCard() {
-  if (!currentEnemy) return;
+function renderDealerCard(container = dom.dCardContainer) {
+  if (!currentEnemy || !container) return;
   const card = currentEnemy instanceof Boss
     ? renderBossCard(currentEnemy)
     : renderDealerCardBase(currentEnemy);
-  dom.dCardContainer.innerHTML = '';
-  dom.dCardContainer.appendChild(card);
+  container.innerHTML = '';
+  container.appendChild(card);
   lucide.createIcons({ icons: lucide.icons });
 }
 

--- a/style.css
+++ b/style.css
@@ -507,6 +507,55 @@ body.darkenshift-mode .tabsContainer button.active {
     box-shadow: 0 0 10px rgba(0,0,0,0.6);
 }
 
+.raidCardContainer {
+    position: absolute;
+    bottom: 4px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 100%;
+    display: flex;
+    justify-content: center;
+    pointer-events: none;
+    z-index: 5;
+}
+.raidCardContainer .card-wrapper {
+    pointer-events: auto;
+}
+
+.raid-life-bar {
+    position: absolute;
+    left: 4px;
+    right: 4px;
+    bottom: 2px;
+    height: 4px;
+    background: #333;
+    border: 1px solid #e74c3c;
+    border-radius: 4px;
+    overflow: hidden;
+}
+
+.raid-life-fill {
+    height: 100%;
+    width: 100%;
+    background: #e74c3c;
+    transition: width 0.3s;
+}
+
+.water-burst {
+    position: absolute;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: #7fd9ff;
+    pointer-events: none;
+    animation: burstMove var(--duration) linear forwards;
+}
+
+@keyframes burstMove {
+    from { transform: translate(0,0); opacity: 1; }
+    to { transform: translate(var(--dx), var(--dy)); opacity: 0; }
+}
+
 /* Generic overlay background */
 .overlay {
     position: fixed;


### PR DESCRIPTION
## Summary
- show raid enemy card in sect map
- add small life bar and water burst attacks
- drain half of stored supplies if the orb is depleted
- drop Undead Nectar on raid victory

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6882d9cdbac083269903693c0c575c92