### PR TITLE
Show water orb capacity

### DIFF
--- a/docs/16-water-orb.md
+++ b/docs/16-water-orb.md
@@ -7,5 +7,6 @@
 - Orb distributes Water as global energy; buildings can boost its output.
 - Disciples can direct % of personal Water to orb.
 - The orb is now larger and displays its regeneration rate centered within.
+- The orb fill displays the current Water against its maximum capacity.
 - At night the orb glows brightly, illuminating nearby terrain.
 - The orb now holds up to 20 Water and regenerates at a flat 0.1 Water per second.

--- a/game/sect.js
+++ b/game/sect.js
@@ -993,10 +993,15 @@ export function renderHotbar() {
 
 
 function renderOrbs() {
-  const fill = document.querySelector('#sectOrbs .sect-orb.water .orb-fill');
+  const orb = document.querySelector('#sectOrbs .sect-orb.water');
+  const fill = orb?.querySelector('.orb-fill');
+  const value = orb?.querySelector('.orb-value');
   if (fill) {
     const pct = Math.max(0, Math.min(1, sectSystem.orbs.water.current / sectSystem.orbs.water.max)) * 100;
     fill.style.height = `${pct}%`;
+  }
+  if (value) {
+    value.textContent = `${Math.floor(sectSystem.orbs.water.current)}/${sectSystem.orbs.water.max}`;
   }
   window.dispatchEvent(new CustomEvent('orbs-changed'));
 }

--- a/script.js
+++ b/script.js
@@ -705,6 +705,10 @@ function updateSectDisplay() {
       const fill = document.createElement('div');
       fill.className = 'orb-fill';
       orb.appendChild(fill);
+      const value = document.createElement('div');
+      value.className = 'orb-value';
+      value.textContent = `${Math.floor(sectSystem.orbs.water.current)}/${sectSystem.orbs.water.max}`;
+      orb.appendChild(value);
       orb.style.left = p.left;
       orb.style.top = p.top;
       if (p.cls === 'water') {

--- a/test/resource-gathering.test.js
+++ b/test/resource-gathering.test.js
@@ -55,7 +55,7 @@ describe('resource gathering', () => {
     const group = TASK_GROUPS[task];
     const attr = ATTRIBUTE_FOR_GROUP[group];
     const lvl = getTaskSkillProgress(0).level;
-    cconst gatherRate = spot.baseYield * (1 + 0.05 * d[attr] + 0.02 * lvl);
+    const gatherRate = spot.baseYield * (1 + 0.05 * d[attr] + 0.02 * lvl);
 
     let called = false;
     globalThis.updateSectDisplay = () => { called = true; };


### PR DESCRIPTION
## Summary
- show water orb's current and max value within the orb
- update orb fill rendering to also update text
- document the new visual cue in the Water Orb docs
- fix typo in resource gathering test

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6882e0de4bdc8326a325545d8d0617b8