### PR TITLE
fix: refresh resource UI on each frame

### DIFF
--- a/script.js
+++ b/script.js
@@ -2314,6 +2314,8 @@ function gameLoop(currentTime) {
     sectSystem.gains.fruits = 0;
     sectSystem.gains.softwood = 0;
   }
+  // refresh sect resource UI every tick for real-time updates
+  if (typeof updateSectDisplay === 'function') updateSectDisplay();
   updateTaskProgressDisplay();
   requestAnimationFrame(gameLoop);
 }

--- a/test/resource-gathering.test.js
+++ b/test/resource-gathering.test.js
@@ -55,7 +55,7 @@ describe('resource gathering', () => {
     const group = TASK_GROUPS[task];
     const attr = ATTRIBUTE_FOR_GROUP[group];
     const lvl = getTaskSkillProgress(0).level;
-    cconst gatherRate = spot.baseYield * (1 + 0.05 * d[attr] + 0.02 * lvl);
+    const gatherRate = spot.baseYield * (1 + 0.05 * d[attr] + 0.02 * lvl);
 
     let called = false;
     globalThis.updateSectDisplay = () => { called = true; };


### PR DESCRIPTION
## Summary
- refresh sect resource display every frame to keep resources in sync with internal values
- fix typo in resource gathering test

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6882e1285a9c8326bf611ec96e62052b