### PR TITLE
Refactor damage handler usage

### DIFF
--- a/enemySpawning.js
+++ b/enemySpawning.js
@@ -133,7 +133,7 @@ export function spawnSpeaker(stageData, enemyAttackProgress, onAttack, onDefeat)
   return enemy;
 }
 
-export function spawnEnemy(kind, stageData, enemyAttackProgress, onDefeat) {
+export function spawnEnemy(kind, stageData, enemyAttackProgress, onDamage, onDefeat) {
   let spawner = spawnDealer;
   if (kind === 'boss') {
     spawner = spawnBoss;
@@ -144,8 +144,8 @@ export function spawnEnemy(kind, stageData, enemyAttackProgress, onDefeat) {
   const onAttack = enemy => {
     const dmg = Math.floor(Math.random() * (enemy.maxDamage - enemy.minDamage + 1)) + enemy.minDamage;
     const finalDmg = dmg;
-    if (typeof globalThis.cDealerDamage === 'function') {
-      globalThis.cDealerDamage(finalDmg, enemy.name);
+    if (typeof onDamage === 'function') {
+      onDamage(finalDmg, enemy.name);
     }
   };
 

--- a/script.js
+++ b/script.js
@@ -179,8 +179,6 @@ import {
   getTaskSkillProgress
 } from './utils/skills.js';
 
-// expose combat damage handler for enemy AI
-globalThis.cDealerDamage = cDealerDamage;
 
 
 
@@ -1701,7 +1699,7 @@ export function spawnDealerEvent(powerMult = 1) {
   setInCombat(true);
   removeDealerLifeBar();
   const temp = { ...stageData, stage: Math.round(stageData.stage * powerMult) };
-  setCurrentEnemy(spawnEnemy('dealer', temp, enemyAttackProgress, onDealerDefeat));
+  setCurrentEnemy(spawnEnemy('dealer', temp, enemyAttackProgress, cDealerDamage, onDealerDefeat));
   updateDealerLifeDisplay();
   enemyAttackFill = renderEnemyAttackBar();
   showPlayerAttackBar();
@@ -1714,7 +1712,7 @@ export function spawnBossEvent() {
   const data = worldProgress[stageData.world];
   const bossStage = 10 * (data?.level || 1);
   const temp = { ...stageData, stage: bossStage };
-  setCurrentEnemy(spawnEnemy('boss', temp, enemyAttackProgress, () => onBossDefeat(currentEnemy)));
+  setCurrentEnemy(spawnEnemy('boss', temp, enemyAttackProgress, cDealerDamage, () => onBossDefeat(currentEnemy)));
   updateDealerLifeDisplay();
   enemyAttackFill = renderEnemyAttackBar();
   showPlayerAttackBar();
@@ -1729,9 +1727,9 @@ export function respawnDealerStage() {
   removeDealerLifeBar();
   if (speakerEncounterPending) {
     speakerEncounterPending = false;
-    setCurrentEnemy(spawnEnemy('speaker', stageData, enemyAttackProgress, onSpeakerDefeat));
+    setCurrentEnemy(spawnEnemy('speaker', stageData, enemyAttackProgress, cDealerDamage, onSpeakerDefeat));
   } else {
-    setCurrentEnemy(spawnEnemy('dealer', stageData, enemyAttackProgress, onDealerDefeat));
+    setCurrentEnemy(spawnEnemy('dealer', stageData, enemyAttackProgress, cDealerDamage, onDealerDefeat));
   }
   updateDealerLifeDisplay();
   enemyAttackFill = renderEnemyAttackBar();

--- a/test/resource-gathering.test.js
+++ b/test/resource-gathering.test.js
@@ -55,7 +55,7 @@ describe('resource gathering', () => {
     const group = TASK_GROUPS[task];
     const attr = ATTRIBUTE_FOR_GROUP[group];
     const lvl = getTaskSkillProgress(0).level;
-    cconst gatherRate = spot.baseYield * (1 + 0.05 * d[attr] + 0.02 * lvl);
+    const gatherRate = spot.baseYield * (1 + 0.05 * d[attr] + 0.02 * lvl);
 
     let called = false;
     globalThis.updateSectDisplay = () => { called = true; };


### PR DESCRIPTION
## Summary
- remove global damage handler injection
- let `spawnEnemy` accept a damage callback
- pass `cDealerDamage` to `spawnEnemy` call sites
- fix lint issue in test

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6882e16142c483269ab4b8e51b4e12c0