### PR TITLE
Fix missing constant imports

### DIFF
--- a/game/raids.js
+++ b/game/raids.js
@@ -6,7 +6,7 @@ import {
   setCurrentEnemy,
   currentEnemy
 } from './state.js';
-import { updateRaidLifeBar } from './ui.js';
+import { updateRaidLifeBar, updateDealerLifeDisplay } from './ui.js';
 
 import { spawnDealer } from '../enemySpawning.js';
 import addLog from '../log.js';

--- a/script.js
+++ b/script.js
@@ -129,6 +129,7 @@ import {
   timeScale,
   setTimeScale,
   FRUIT_MAX_CAP,
+  FRUIT_GROWTH_RATES,
   isDarkenshift,
   setIsDarkenshift,
   lifeCore,


### PR DESCRIPTION
## Summary
- import `FRUIT_GROWTH_RATES` in `script.js`
- import `updateDealerLifeDisplay` in raid logic

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68830388fbdc83269c24e3277908b788