### PR TITLE
Add devtool to skip directly to next night

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,9 @@ This is not a standard Wuxia knockoff — **Taino and Caribbean mysticism** blen
 - The `Disciple` class lives in `disciple.js` while `game/disciples.js` tracks
   which disciples are currently participating in combat.
 
+## Dev Tools
+
+Run the game with the `?dev` query parameter to enable a debug panel.
+It offers helpers like spawning bosses, toggling fast mode, and skipping
+directly to the next night.
+

--- a/debugTools.js
+++ b/debugTools.js
@@ -1,5 +1,5 @@
 import { Boss } from './boss.js';
-import { unlockConstruct } from './game/sect.js';
+import { unlockConstruct, skipToNextNight } from './game/sect.js';
 import {
   spawnBossEvent,
   spawnDealerEvent,
@@ -41,6 +41,7 @@ export const devTools = {
   },
   logEnemy: () => console.log(currentEnemy),
   advanceStage: () => nextStage(),
+  nextNight: () => skipToNextNight(),
   setStageWorld: () => {
     const stage = parseInt(document.getElementById('debugStage').value);
     const world = parseInt(document.getElementById('debugWorld').value);

--- a/docs/module-structure.md
+++ b/docs/module-structure.md
@@ -9,6 +9,7 @@ The project organizes game logic under the `game/` directory.
 - **game/combat.js** – centralizes all combat logic including damage
   resolution and disciple hit animations.
 - **game/debug.js** – wiring for optional debug controls.
+- **debugTools.js** – development helpers loaded when `?dev` is present.
 - **game/constants.js** – collection of shared gameplay constants used across systems.
 - **game/tooltip.js** – simple helpers for showing and hiding the UI tooltip.
 - **game/sect.js** – implements the sect management system including constructs and colony helpers.

--- a/game/sect.js
+++ b/game/sect.js
@@ -58,6 +58,10 @@ export const SECT_SCHEDULE = [
   { phase: 'Night', duration: 60, action: 'Work' }
 ];
 
+const NIGHT_INDEX = SECT_SCHEDULE.findIndex(p => p.phase === 'Night');
+const NIGHT_START_SECONDS = SECT_SCHEDULE.slice(0, NIGHT_INDEX)
+  .reduce((sum, p) => sum + p.duration, 0);
+
 export const DAILY_WORK_SECONDS = SECT_SCHEDULE.filter(p => p.action === 'Work')
   .reduce((sum, p) => sum + p.duration, 0);
 
@@ -1489,3 +1493,27 @@ export function tickSect(delta) {
 }
 
 export function renderColonyResources() {}
+
+export function skipToNextNight() {
+  const nightIndex = NIGHT_INDEX;
+  const nightStart = NIGHT_START_SECONDS;
+  if (sectSystem.scheduleIndex >= nightIndex) {
+    sectSystem.seasonDay += 1;
+    document.dispatchEvent(
+      new CustomEvent('day-passed', {
+        detail: { day: sectSystem.seasonDay, season: sectSystem.seasonIndex }
+      })
+    );
+    if (sectSystem.seasonDay >= SEASON_LENGTH_DAYS) {
+      sectSystem.seasonDay = 0;
+      sectSystem.seasonIndex = (sectSystem.seasonIndex + 1) % seasons.length;
+    }
+  }
+  sectSystem.seasonTimer = nightStart;
+  sectSystem.scheduleIndex = nightIndex;
+  sectSystem.scheduleTimer = 0;
+  document.dispatchEvent(
+    new CustomEvent('schedule-phase', { detail: getCurrentSchedule() })
+  );
+  startRaid();
+}

--- a/index.html
+++ b/index.html
@@ -32,6 +32,7 @@
       <button onclick="devTools.killEnemy()">Kill Enemy</button>
       <button onclick="devTools.killBoss()">Kill Boss</button>
       <button onclick="devTools.advanceStage()">Next Stage</button>
+      <button onclick="devTools.nextNight()">Next Night</button>
       <br>
       <button onclick="devTools.logEnemy()">Log Enemy</button>
       <br>


### PR DESCRIPTION
## Summary
- add constants to compute night start
- implement `skipToNextNight` in `game/sect.js`
- expose new debug helper in `debugTools.js`
- add button for it in `index.html`
- document dev tools in README and module overview

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68830659625c8326b28b697a49dc10a9