### PR TITLE
Add raid summary overlay

### DIFF
--- a/docs/23-raids.md
+++ b/docs/23-raids.md
@@ -21,3 +21,4 @@ Disciples may be called upon to defend the sect from occasional raids.
 * Dealer enemies display a small life bar on their card during raids.
 * Defeating a raid yields **Undead Nectar** in addition to experience.
 * The raid ends when the enemy is defeated or the orb is drained.
+* A summary overlay appears after victory showing damage dealt, damage received and rewards.

--- a/game/combat.js
+++ b/game/combat.js
@@ -7,6 +7,7 @@ import { calculateEnemyBasicDamage } from '../enemySpawning.js';
 import { runAnimation } from '../utils/animation.js';
 import { showRestartScreen } from '../ui/restartOverlay.js';
 import addLog from '../log.js';
+import { raidState } from './raids.js';
 
 export function init() {}
 
@@ -31,6 +32,7 @@ export function attack(deltaTime = 0) {
 
     if (discipleAttackTimers[d.id] >= d.attackSpeed && !enemy.isDefeated()) {
       enemy.takeDamage(d.damage);
+      if (raidState.active) raidState.damageDealt += d.damage;
       discipleAttackTimers[d.id] = 0;
       if (d.attackFill) d.attackFill.style.width = '0%';
     }

--- a/game/raids.js
+++ b/game/raids.js
@@ -7,6 +7,7 @@ import {
   currentEnemy
 } from './state.js';
 import { updateRaidLifeBar, updateDealerLifeDisplay } from './ui.js';
+import { showRaidSummaryOverlay } from '../ui/raidSummaryOverlay.js';
 
 import { spawnDealer } from '../enemySpawning.js';
 import addLog from '../log.js';
@@ -16,7 +17,9 @@ export const raidState = {
   active: false,
   enemy: null,
   attackTimers: {},
-  orbTimer: 0
+  orbTimer: 0,
+  damageDealt: 0,
+  damageReceived: 0
 };
 
 function shootWaterBurst(targetEl) {
@@ -46,8 +49,11 @@ export function startRaid() {
   if (raidState.active) return;
   const stage = Math.max(1, stageData.stage);
   const world = stageData.world;
+  raidState.damageDealt = 0;
+  raidState.damageReceived = 0;
   const onAttack = enemy => {
     const dmg = enemy.damage;
+    raidState.damageReceived += dmg;
     sectSystem.orbs.water.current = Math.max(0, sectSystem.orbs.water.current - dmg);
     if (sectSystem.orbs.water.current === 0) {
       sectState.fruits = Math.floor(sectState.fruits * 0.5);
@@ -61,6 +67,11 @@ export function startRaid() {
     sectState.undeadNectar = (sectState.undeadNectar || 0) + 1;
     addLog('Raiders dropped Undead Nectar!', 'good');
     endRaid();
+    showRaidSummaryOverlay({
+      damageDealt: raidState.damageDealt,
+      damageReceived: raidState.damageReceived,
+      rewards: { undeadNectar: 1 }
+    });
   };
   raidState.enemy = spawnDealer({ stage, world }, 0, onAttack, onDefeat);
   setCurrentEnemy(raidState.enemy);
@@ -95,9 +106,12 @@ export function tickRaid(delta) {
   if (raidState.orbTimer >= ORB_INTERVAL) {
     raidState.orbTimer -= ORB_INTERVAL;
     raidState.enemy.takeDamage(5);
+    raidState.damageDealt += 5;
     const card = document.querySelector('.raidCardContainer .dCardPane');
     shootWaterBurst(card);
-    updateRaidLifeBar(raidState.enemy);
-    if (raidState.enemy.isDefeated()) endRaid();
+    if (raidState.enemy) {
+      updateRaidLifeBar(raidState.enemy);
+      if (raidState.enemy.isDefeated()) endRaid();
+    }
   }
 }

--- a/ui/raidSummaryOverlay.js
+++ b/ui/raidSummaryOverlay.js
@@ -1,0 +1,31 @@
+import { createOverlay } from './overlay.js';
+
+export function showRaidSummaryOverlay({ damageDealt = 0, damageReceived = 0, rewards = {} } = {}) {
+  const overlay = createOverlay({ className: 'raid-summary-overlay', boxClass: 'parchment-box' });
+  overlay.box.classList.add('parchment-box');
+  const { box, close } = overlay;
+
+  const title = document.createElement('h2');
+  title.textContent = 'Raid Defeated';
+  box.appendChild(title);
+
+  const stats = document.createElement('div');
+  stats.className = 'raid-summary-stats';
+  stats.innerHTML = `
+    <p>Damage Dealt: ${Math.round(damageDealt)}</p>
+    <p>Damage Received: ${Math.round(damageReceived)}</p>
+  `;
+  box.appendChild(stats);
+
+  const rewardLines = [];
+  if (rewards.undeadNectar) rewardLines.push(`Undead Nectar +${rewards.undeadNectar}`);
+  if (rewardLines.length > 0) {
+    const rewardSection = document.createElement('div');
+    rewardSection.className = 'raid-summary-rewards';
+    rewardSection.innerHTML = '<p>Rewards:</p><ul>' + rewardLines.map(r => `<li>${r}</li>`).join('') + '</ul>';
+    box.appendChild(rewardSection);
+  }
+
+  overlay.appendButton('Close', close);
+  return overlay;
+}


### PR DESCRIPTION
## Summary
- track raid damage dealt/received
- display overlay summarizing damage and rewards when a raid is defeated
- update raid docs

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688306f9e7d083269a81ebd628b78547