### PR TITLE
Fix devTools reference error

### DIFF
--- a/index.html
+++ b/index.html
@@ -204,6 +204,7 @@
     </div>
     <div id="tooltip"></div>
     <script type="module" src="script.js"></script>
+    <script>window.devTools = new Proxy({}, { get: () => () => {} });</script>
     <script type="module">
       const isDev = (typeof process !== 'undefined' && process.env && process.env.NODE_ENV === 'development') ||
                     new URLSearchParams(window.location.search).has('dev');


### PR DESCRIPTION
## Summary
- guard devTools usage when not in development

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68830840c1d483269768bd370feb40c9