### PR TITLE
Fix night visuals

### DIFF
--- a/docs/16-water-orb.md
+++ b/docs/16-water-orb.md
@@ -8,5 +8,5 @@
 - Disciples can direct % of personal Water to orb.
 - The orb is now larger and displays its regeneration rate centered within.
 - The orb fill displays the current Water against its maximum capacity.
-- At night the orb glows brightly, illuminating nearby terrain.
+- At night the orb glows with a bright blue hue, illuminating nearby terrain.
 - The orb now holds up to 20 Water and regenerates at a flat 0.1 Water per second.

--- a/script.js
+++ b/script.js
@@ -756,14 +756,26 @@ function updateSectDisplay() {
 function applyNightFilters(brightness) {
   const inv = brightness < 1 ? 1 / brightness : 1;
   document.querySelectorAll('#sectOrbs .sect-orb.water').forEach(o => {
+    if (!o.dataset.baseFilter) o.dataset.baseFilter = o.style.filter || '';
     if (brightness < 1) {
-      o.style.filter = `brightness(${1.5 * inv})`;
+      o.style.filter = `${o.dataset.baseFilter} brightness(${inv}) saturate(1.2)`;
     } else {
-      o.style.filter = '';
+      o.style.filter = o.dataset.baseFilter;
     }
   });
   document.querySelectorAll('.raidCardContainer .dCardPane').forEach(c => {
     c.style.filter = brightness < 1 ? `brightness(${inv})` : '';
+  });
+  document.querySelectorAll('.raidCardContainer .dCard__icon').forEach(icon => {
+    if (!icon.dataset.baseFilter) icon.dataset.baseFilter = icon.style.filter || '';
+    if (!icon.dataset.baseStroke) icon.dataset.baseStroke = icon.style.stroke || '';
+    if (brightness < 1) {
+      icon.style.filter = `${icon.dataset.baseFilter} drop-shadow(0 0 6px red)`;
+      icon.style.stroke = 'red';
+    } else {
+      icon.style.filter = icon.dataset.baseFilter;
+      icon.style.stroke = icon.dataset.baseStroke;
+    }
   });
 }
 

--- a/style.css
+++ b/style.css
@@ -3169,8 +3169,8 @@ body.darkenshift-mode .tabsContainer button.active {
 }
 .sect-orb.water .orb-fill { background: rgba(127,217,255,0.6); }
 .colony-map.night .sect-orb.water {
-    box-shadow: 0 0 20px rgba(127,217,255,0.8), 0 0 60px rgba(127,217,255,0.6);
-    filter: brightness(1.5);
+    box-shadow: 0 0 30px rgba(80,180,255,0.9), 0 0 80px rgba(80,180,255,0.7);
+    filter: brightness(1.2) saturate(1.2);
 }
 .sect-basket {
     position: absolute;


### PR DESCRIPTION
## Summary
- ensure orb glows blue and dealer icons glow red at night
- document orb's nighttime blue glow

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688309ab213c8326b70023296aab03b3