### PR TITLE
Add water orb attack animations

### DIFF
--- a/docs/23-raids.md
+++ b/docs/23-raids.md
@@ -18,6 +18,7 @@ Disciples may be called upon to defend the sect from occasional raids.
 * Disciples assigned to **Defend** fight the raiders using their combat stats.
 * If the orb is depleted the sect loses **half** of its stored fruit and softwood.
 * The Water orb periodically lashes out with a **Water Burst** every 10&nbsp;s, dealing 5 damage.
+  The burst now appears as a blue projectile traveling from the orb to the dealer card.
 * Dealer enemies display a small life bar on their card during raids.
 * Defeating a raid yields **Undead Nectar** in addition to experience.
 * The raid ends when the enemy is defeated or the orb is drained.

--- a/game/raids.js
+++ b/game/raids.js
@@ -12,6 +12,7 @@ import { showRaidSummaryOverlay } from '../ui/raidSummaryOverlay.js';
 import { spawnDealer } from '../enemySpawning.js';
 import addLog from '../log.js';
 import { showRaidAlert } from './alerts.js';
+import { runAnimation } from '../utils/animation.js';
 
 export const raidState = {
   active: false,
@@ -41,6 +42,8 @@ function shootWaterBurst(targetEl) {
   proj.style.setProperty('--duration', `${Math.max(300, dist)}ms`);
   map.appendChild(proj);
   proj.addEventListener('animationend', () => proj.remove(), { once: true });
+  runAnimation(targetEl, 'hit-animate');
+  runAnimation(orb, 'orb-hit');
 }
 
 const ORB_INTERVAL = 10000; // ms
@@ -55,6 +58,8 @@ export function startRaid() {
     const dmg = enemy.damage;
     raidState.damageReceived += dmg;
     sectSystem.orbs.water.current = Math.max(0, sectSystem.orbs.water.current - dmg);
+    const orbEl = document.querySelector('#sectOrbs .sect-orb.water');
+    if (orbEl) runAnimation(orbEl, 'orb-hit');
     if (sectSystem.orbs.water.current === 0) {
       sectState.fruits = Math.floor(sectState.fruits * 0.5);
       sectState.softwood = Math.floor(sectState.softwood * 0.5);

--- a/style.css
+++ b/style.css
@@ -3167,7 +3167,12 @@ body.darkenshift-mode .tabsContainer button.active {
     border: 1px solid #7fd9ff;
     color: #7fd9ff;
 }
-.sect-orb.water .orb-fill { background: rgba(127,217,255,0.6); }
+.sect-orb.water .orb-fill {
+    background: linear-gradient(to top, rgba(63,149,212,0.8), rgba(127,217,255,0.6));
+}
+.sect-orb.orb-hit {
+    animation: orb-pulse 0.3s ease;
+}
 .colony-map.night .sect-orb.water {
     box-shadow: 0 0 20px rgba(127,217,255,0.8), 0 0 60px rgba(127,217,255,0.6);
     filter: brightness(1.5);


### PR DESCRIPTION
## Summary
- show a projectile when the water orb damages the raiding dealer
- animate the orb pulsing when attacking or taking damage
- shake the dealer card when struck by the orb
- darken water orb fill color
- document the new projectile effect

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68830a2933908326a2c94d8498139d57