### PR TITLE
Implement fight task for raids

### DIFF
--- a/docs/23-raids.md
+++ b/docs/23-raids.md
@@ -15,7 +15,9 @@ Disciples may be called upon to defend the sect from occasional raids.
 * Raids begin automatically during the Night phase.
 * A red alert briefly appears on screen when a raid starts.
 * Raiders attack the Water orb, reducing its stored energy.
-* Disciples assigned to **Defend** fight the raiders using their combat stats.
+* Disciples assigned to **Fight** take position before the Water Orb, striking back each attack.
+* Fighters absorb damage with their personal Water first. When empty they lose HP.
+* Raiders randomly target a fighter when multiple disciples are on guard.
 * If the orb is depleted the sect loses **half** of its stored fruit and softwood.
 * The Water orb periodically lashes out with a **Water Burst** every 10&nbsp;s, dealing 5 damage.
   The burst now appears as a blue projectile traveling from the orb to the dealer card.

--- a/game/constants.js
+++ b/game/constants.js
@@ -23,6 +23,7 @@ export const LOG_XP_PER_CYCLE = 1; // 0.0047 XP/s × 215s ≈ 1
 export const BUILD_XP_RATE = 1; // per second
 export const RESEARCH_XP_PER_CYCLE = 1; // 0.008 XP/s × ~125s ≈ 1
 export const CHANT_XP_PER_CYCLE = 1.665; // 0.333 XP/s × 5s
+export const COMBAT_XP_RATE = 0.1; // per second
 export const EXPLORATION_CYCLE_SECONDS = 150;
 export const STAMINA_DRAIN_PER_EXPLORATION = 1;
 export const DISCIPLE_MAX_HEALTH = 10;
@@ -50,7 +51,7 @@ export const TASK_ICONS = {
   Training: '🥋',
   Eat: '🍽️',
   Sleep: '💤',
-  Defend: '🛡️'
+  Fight: '⚔️'
 };
 
 export const TASK_GROUPS = {
@@ -63,7 +64,7 @@ export const TASK_GROUPS = {
   'Exploration': 'Exploration',
   Idle: 'Idle',
   Resting: 'Idle',
-  Defend: 'Combat'
+  Fight: 'Combat'
 };
 
 export const ATTRIBUTE_FOR_GROUP = {

--- a/game/raids.js
+++ b/game/raids.js
@@ -55,7 +55,24 @@ export function startRaid() {
   raidState.damageDealt = 0;
   raidState.damageReceived = 0;
   const onAttack = enemy => {
-    const dmg = enemy.damage;
+    let dmg = enemy.damage;
+    const fighters = sectSystem.disciples.filter(
+      d => sectState.discipleTasks[d.id] === 'Fight' && !d.incapacitated
+    );
+    if (fighters.length > 0) {
+      const target = fighters[Math.floor(Math.random() * fighters.length)];
+      raidState.damageReceived += dmg;
+      const before = target.water;
+      const blocked = Math.min(before, dmg);
+      target.water -= blocked;
+      dmg -= blocked;
+      if (dmg > 0) {
+        target.currentHp = Math.max(0, target.currentHp - dmg);
+        if (target.currentHp === 0) target.incapacitated = true;
+      }
+      if (typeof updateSectDisplay === 'function') updateSectDisplay();
+      return;
+    }
     raidState.damageReceived += dmg;
     sectSystem.orbs.water.current = Math.max(0, sectSystem.orbs.water.current - dmg);
     const orbEl = document.querySelector('#sectOrbs .sect-orb.water');

--- a/game/sect.js
+++ b/game/sect.js
@@ -22,6 +22,7 @@ import {
   LOG_XP_PER_CYCLE,
   RESEARCH_XP_PER_CYCLE,
   CHANT_XP_PER_CYCLE,
+  COMBAT_XP_RATE,
   HUNT_CYCLE_SECONDS,
   EXPLORATION_CYCLE_SECONDS
 } from './constants.js';
@@ -1471,7 +1472,7 @@ export function tickSect(delta) {
       sectState.discipleProgress[d.id] = progress;
     } else if (task === 'Exploration') {
       progress = (progress + dt) % EXPLORATION_CYCLE_SECONDS;
-    } else if (task === 'Defend') {
+    } else if (task === 'Fight') {
       if (raidState.active && raidState.enemy) {
         if (!raidState.attackTimers[d.id]) raidState.attackTimers[d.id] = 0;
         raidState.attackTimers[d.id] += delta;
@@ -1483,6 +1484,7 @@ export function tickSect(delta) {
           if (raidState.enemy.isDefeated()) endRaid();
         }
       }
+      xpRate = COMBAT_XP_RATE;
     }
     sectState.discipleProgress[d.id] = progress;
 

--- a/script.js
+++ b/script.js
@@ -115,6 +115,7 @@ import {
   deselectDisciple,
   clearActiveDisciples
 } from "./game/disciples.js";
+import { raidState } from './game/raids.js';
 // developer debug tools
 import { init as initDebug } from "./game/debug.js";
 // Shared game state and configuration
@@ -846,9 +847,16 @@ function startDiscipleMovement() {
         } else {
           const task = sectState.discipleTasks[d.id];
           taskName = task || 'Idle';
-          if (task === 'Gather Fruit' || task === 'Gather Softwood')
+          if (task === 'Gather Fruit' || task === 'Gather Softwood') {
             updateDiscipleGather(d.id, el);
-          else moveDisciple(el);
+          } else if (raidState.active && task === 'Fight') {
+            const orb = document.querySelector('#sectOrbs .water');
+            if (orb) {
+              const bx = orb.offsetLeft + orb.offsetWidth / 2 - 10;
+              const by = orb.offsetTop - 20;
+              el.style.transform = `translate(${bx}px, ${by}px)`;
+            }
+          } else moveDisciple(el);
         }
       }
       updateDiscipleVisual(d, el, taskName);

--- a/ui/colonyOverlays.js
+++ b/ui/colonyOverlays.js
@@ -157,7 +157,7 @@ export function openWorkOverlay() {
     });
 
     right.innerHTML = '';
-    const tasks = ['Gather Fruit', 'Gather Softwood'];
+    const tasks = ['Gather Fruit', 'Gather Softwood', 'Fight'];
     if (systems.buildingUnlocked) tasks.push('Building');
     if (systems.researchUnlocked) tasks.push('Research');
     tasks.forEach(t => {


### PR DESCRIPTION
## Summary
- add "Fight" as the single combat task
- fighters attack raiders and earn combat XP
- remove the old Defend task

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688371e105888326824296243f637ab4