### PR TITLE
Add Orb Revival research and management UI

### DIFF
--- a/docs/15-research.md
+++ b/docs/15-research.md
@@ -74,3 +74,7 @@ Enables discovery of Gold during Coal Transmute operations.
 
 Unlocks the Golden Mausoleum building for advanced cultivation legacy effects.
 
+Orb Revival
+
+Unlocks the Orb Management screen, providing details on abilities like Water Burst.
+

--- a/docs/16-water-orb.md
+++ b/docs/16-water-orb.md
@@ -10,3 +10,4 @@
 - The orb fill displays the current Water against its maximum capacity.
 - At night the orb glows with a bright blue hue, illuminating nearby terrain.
 - The orb now holds up to 20 Water and regenerates at a flat 0.1 Water per second.
+- Orb Revival research grants access to an Orb Management panel showing spells like Water Burst.

--- a/game/state.js
+++ b/game/state.js
@@ -77,7 +77,8 @@ export const systems = {
   buildingUnlocked: false,
   researchUnlocked: false,
   chantingHallUnlocked: false,
-  explorationUnlocked: false
+  explorationUnlocked: false,
+  orbManagementUnlocked: false
 };
 
 // Fruit gathering and growth configuration
@@ -104,6 +105,7 @@ export const sectState = {
   buildings: { bohio: 0, researchDesk: 0, chantingHall: 0 },
   researchPoints: 0,
   researchProgress: 0,
+  completedResearch: [],
   currentBuild: null,
   buildProgress: 0
 };

--- a/index.html
+++ b/index.html
@@ -94,6 +94,7 @@
             <button id="sectNavMapBtn" title="Map"><i data-lucide="map"></i><span>Map</span></button>
             <button id="sectNavInfluenceBtn" title="Influence"><i data-lucide="users"></i><span>Influence</span></button>
             <button id="sectNavResearchBtn" title="Research"><i data-lucide="flask-conical"></i><span>Research</span></button>
+            <button id="sectNavOrbBtn" title="Orbs"><i data-lucide="droplet"></i><span>Orbs</span></button>
             <button id="sectNavCultivationBtn" title="Cultivation"><i data-lucide="sprout"></i><span>Cultivate</span></button>
           </div>
           <div class="raidCardContainer"></div>

--- a/script.js
+++ b/script.js
@@ -44,7 +44,7 @@ import { initMetamorphosis, refreshMetamorphosis } from './metamorphosis.js';
 import { intelligenceXpMultiplier } from './attributes.js';
 import { createOverlay } from './ui/overlay.js';
 import { showLoadErrorOverlay } from './ui/loadErrorOverlay.js';
-import { openExplorationOverlay, closeExplorationOverlay, openWorkOverlay, openScheduleOverlay, openPlaceholderOverlay, openResourceOverlay, openBuildOverlay, openResearchOverlay, closeDungeonOverlay, locationListContainer, explorationListContainer } from "./ui/colonyOverlays.js";
+import { openExplorationOverlay, closeExplorationOverlay, openWorkOverlay, openScheduleOverlay, openPlaceholderOverlay, openResourceOverlay, openBuildOverlay, openResearchOverlay, openOrbOverlay, closeDungeonOverlay, locationListContainer, explorationListContainer } from "./ui/colonyOverlays.js";
 import { createDiscipleBadge } from "./game/badges.js";
 import { calculateKillXp } from './utils/xp.js';
 import { initTooltip } from './game/tooltip.js';
@@ -341,6 +341,7 @@ let sectNavChantBtn;
 let sectNavMapBtn;
 let sectNavInfluenceBtn;
 let sectNavResearchBtn;
+let sectNavOrbBtn;
 let sectNavCultivationBtn;
 let sectNavScheduleBtn;
 
@@ -436,6 +437,7 @@ function initTabs() {
   sectNavMapBtn = document.getElementById("sectNavMapBtn");
   sectNavInfluenceBtn = document.getElementById("sectNavInfluenceBtn");
   sectNavResearchBtn = document.getElementById("sectNavResearchBtn");
+  sectNavOrbBtn = document.getElementById("sectNavOrbBtn");
   sectNavCultivationBtn = document.getElementById("sectNavCultivationBtn");
   sectNavScheduleBtn = document.getElementById("sectNavScheduleBtn");
   statsOverviewSubTabButton = document.querySelector('.statsOverviewSubTabButton');
@@ -461,7 +463,7 @@ function initTabs() {
       }
       openExplorationOverlay();
     });
-  const navButtons = [sectNavWorkBtn, sectNavResourceBtn, sectNavBuildBtn, sectNavScheduleBtn, sectNavChantBtn, sectNavMapBtn, sectNavInfluenceBtn, sectNavResearchBtn, sectNavCultivationBtn];
+  const navButtons = [sectNavWorkBtn, sectNavResourceBtn, sectNavBuildBtn, sectNavScheduleBtn, sectNavChantBtn, sectNavMapBtn, sectNavInfluenceBtn, sectNavResearchBtn, sectNavOrbBtn, sectNavCultivationBtn];
   function setActiveNavBtn(btn) {
     navButtons.forEach(b => b && b.classList.remove("active"));
     if (btn) btn.classList.add("active");
@@ -487,6 +489,12 @@ function initTabs() {
       setActiveNavBtn(sectNavResearchBtn);
       if (systems.researchUnlocked) openResearchOverlay();
       else openPlaceholderOverlay("Research");
+    });
+  if (sectNavOrbBtn)
+    sectNavOrbBtn.addEventListener("click", () => {
+      setActiveNavBtn(sectNavOrbBtn);
+      if (systems.orbManagementUnlocked) openOrbOverlay();
+      else openPlaceholderOverlay("Orbs");
     });
   if (sectNavCultivationBtn)
     sectNavCultivationBtn.addEventListener("click", () => {
@@ -655,6 +663,9 @@ function updateSectDisplay() {
   }
   if (sectNavResearchBtn) {
     sectNavResearchBtn.style.display = systems.researchUnlocked ? '' : 'none';
+  }
+  if (sectNavOrbBtn) {
+    sectNavOrbBtn.style.display = systems.orbManagementUnlocked ? '' : 'none';
   }
   if (!sectTabUnlocked || !playerSectPanel) return;
   const total = sectSystem.disciples.length;

--- a/style.css
+++ b/style.css
@@ -3589,6 +3589,42 @@ body.darkenshift-mode .tabsContainer button.active {
     text-align: center;
 }
 
+.research-list {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    margin-top: 8px;
+}
+
+.research-entry {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    padding: 4px;
+    border: 1px solid #333;
+    border-radius: 4px;
+}
+
+.research-entry button {
+    align-self: flex-start;
+    margin-top: 2px;
+}
+
+.orb-overlay .overlay-box {
+    max-width: 300px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.orb-spell-list {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    font-size: 0.9rem;
+    margin-left: 16px;
+}
+
 /* disciple combat cards reuse generic card styles */
 .disciple-hp {
     margin-top: 2px;

--- a/ui/colonyOverlays.js
+++ b/ui/colonyOverlays.js
@@ -273,6 +273,33 @@ export function openResourceOverlay() {
   interval = setInterval(render, 1000);
 }
 
+let orbOverlay = null;
+export function openOrbOverlay() {
+  if (orbOverlay) return;
+  orbOverlay = createOverlay({ className: 'orb-overlay', boxClass: 'parchment-box' });
+  orbOverlay.box.classList.add('parchment-box');
+  orbOverlay.onClose(() => { orbOverlay = null; });
+  const { box } = orbOverlay;
+
+  const header = document.createElement('div');
+  header.className = 'panel-heading';
+  header.textContent = 'Orb Management';
+  box.appendChild(header);
+
+  const spellHeader = document.createElement('h3');
+  spellHeader.textContent = 'Spells';
+  box.appendChild(spellHeader);
+
+  const list = document.createElement('ul');
+  list.className = 'orb-spell-list';
+  box.appendChild(list);
+
+  const burst = document.createElement('li');
+  burst.className = 'orb-spell';
+  burst.innerHTML = '<b>Water Burst</b> - Automatically hits raiders every 10s for 5 damage.';
+  list.appendChild(burst);
+}
+
 let buildOverlay = null;
 export function openBuildOverlay() {
   if (buildOverlay) return;
@@ -417,6 +444,52 @@ export function openResearchOverlay() {
   info.className = 'research-progress-info';
   box.appendChild(info);
 
+  const researchList = document.createElement('div');
+  researchList.className = 'research-list';
+  box.appendChild(researchList);
+
+  const topics = [
+    {
+      key: 'orbRevival',
+      label: 'Orb Revival',
+      cost: 1,
+      desc: 'Unlocks orb management controls',
+      unlock() {
+        if (!systems.orbManagementUnlocked) systems.orbManagementUnlocked = true;
+      }
+    }
+  ];
+
+  function renderResearch() {
+    researchList.innerHTML = '';
+    topics.forEach(t => {
+      if (sectState.completedResearch.includes(t.key)) return;
+      const row = document.createElement('div');
+      row.className = 'research-entry';
+      const name = document.createElement('div');
+      name.className = 'research-name';
+      name.textContent = t.label;
+      const desc = document.createElement('div');
+      desc.className = 'research-desc';
+      desc.textContent = t.desc;
+      const btn = document.createElement('button');
+      btn.textContent = `Unlock (${t.cost})`;
+      btn.disabled = sectState.researchPoints < t.cost;
+      btn.addEventListener('click', () => {
+        if (sectState.researchPoints < t.cost) return;
+        sectState.researchPoints -= t.cost;
+        sectState.completedResearch.push(t.key);
+        t.unlock();
+        if (typeof window.updateSectDisplay === 'function') window.updateSectDisplay();
+        renderResearch();
+      });
+      row.appendChild(name);
+      row.appendChild(desc);
+      row.appendChild(btn);
+      researchList.appendChild(row);
+    });
+  }
+
   function render() {
     pointsEl.textContent = `Research Points: ${sectState.researchPoints}`;
     const prog = sectState.researchProgress % 500;
@@ -426,6 +499,7 @@ export function openResearchOverlay() {
     const rate = researchers * 4;
     const time = rate > 0 ? (500 - prog) / rate : Infinity;
     info.textContent = `Next point: ${rate > 0 ? time.toFixed(1) : '∞'}s`;
+    renderResearch();
   }
 
   render();


### PR DESCRIPTION
## Summary
- add new `Orb Revival` research topic and unlockable orb management button
- show Orb Revival in research overlay with unlock button
- implement orb management overlay listing the `Water Burst` spell
- update navigation bar to include Orbs button
- document Orb Revival research and update water orb notes

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6883820708a08326bd3f328fa02d1e4f