### PR TITLE
feat: show raid fighter xp

### DIFF
--- a/docs/23-raids.md
+++ b/docs/23-raids.md
@@ -24,4 +24,6 @@ Disciples may be called upon to defend the sect from occasional raids.
 * Dealer enemies display a small life bar on their card during raids.
 * Defeating a raid yields **Undead Nectar** in addition to experience.
 * The raid ends when the enemy is defeated or the orb is drained.
-* A summary overlay appears after victory showing damage dealt, damage received and rewards.
+* A summary overlay appears after victory showing damage dealt, damage received,
+  rewards and how much combat XP each participating disciple earned. Level ups
+  are noted next to the fighter's name.

--- a/game/raids.js
+++ b/game/raids.js
@@ -13,6 +13,7 @@ import { spawnDealer } from '../enemySpawning.js';
 import addLog from '../log.js';
 import { showRaidAlert } from './alerts.js';
 import { runAnimation } from '../utils/animation.js';
+import { ensureDiscipleSkills, getTaskSkillProgress } from '../utils/skills.js';
 
 export const raidState = {
   active: false,
@@ -20,7 +21,8 @@ export const raidState = {
   attackTimers: {},
   orbTimer: 0,
   damageDealt: 0,
-  damageReceived: 0
+  damageReceived: 0,
+  xpStart: {}
 };
 
 function shootWaterBurst(targetEl) {
@@ -54,6 +56,19 @@ export function startRaid() {
   const world = stageData.world;
   raidState.damageDealt = 0;
   raidState.damageReceived = 0;
+  raidState.xpStart = {};
+  sectSystem.disciples.forEach(d => {
+    if (sectState.discipleTasks[d.id] === 'Fight' && !d.incapacitated) {
+      ensureDiscipleSkills(d.id);
+      raidState.xpStart[d.id] = {
+        xp: sectState.discipleSkills[d.id].Combat || 0,
+        level: getTaskSkillProgress(
+          sectState.discipleSkills[d.id].Combat || 0
+        ).level,
+        name: d.name
+      };
+    }
+  });
   const onAttack = enemy => {
     let dmg = enemy.damage;
     const fighters = sectSystem.disciples.filter(
@@ -89,10 +104,24 @@ export function startRaid() {
     sectState.undeadNectar = (sectState.undeadNectar || 0) + 1;
     addLog('Raiders dropped Undead Nectar!', 'good');
     endRaid();
+    const fighters = Object.entries(raidState.xpStart).map(([id, info]) => {
+      ensureDiscipleSkills(id);
+      const endXp = sectState.discipleSkills[id].Combat || 0;
+      const gained = endXp - info.xp;
+      const startLvl = info.level;
+      const endLvl = getTaskSkillProgress(endXp).level;
+      return {
+        name: info.name,
+        xp: gained,
+        leveled: endLvl > startLvl
+      };
+    });
+    raidState.xpStart = {};
     showRaidSummaryOverlay({
       damageDealt: raidState.damageDealt,
       damageReceived: raidState.damageReceived,
-      rewards: { undeadNectar: 1 }
+      rewards: { undeadNectar: 1 },
+      fighters
     });
   };
   raidState.enemy = spawnDealer({ stage, world }, 0, onAttack, onDefeat);
@@ -115,6 +144,7 @@ export function endRaid() {
   raidState.enemy = null;
   raidState.attackTimers = {};
   raidState.orbTimer = 0;
+  raidState.xpStart = {};
   addLog('The raid has ended.', 'info');
   updateDealerLifeDisplay(null);
   document.dispatchEvent(new CustomEvent('raid-end'));

--- a/ui/raidSummaryOverlay.js
+++ b/ui/raidSummaryOverlay.js
@@ -1,6 +1,11 @@
 import { createOverlay } from './overlay.js';
 
-export function showRaidSummaryOverlay({ damageDealt = 0, damageReceived = 0, rewards = {} } = {}) {
+export function showRaidSummaryOverlay({
+  damageDealt = 0,
+  damageReceived = 0,
+  rewards = {},
+  fighters = []
+} = {}) {
   const overlay = createOverlay({ className: 'raid-summary-overlay', boxClass: 'parchment-box' });
   overlay.box.classList.add('parchment-box');
   const { box, close } = overlay;
@@ -16,6 +21,17 @@ export function showRaidSummaryOverlay({ damageDealt = 0, damageReceived = 0, re
     <p>Damage Received: ${Math.round(damageReceived)}</p>
   `;
   box.appendChild(stats);
+
+  if (fighters.length > 0) {
+    const fighterSection = document.createElement('div');
+    fighterSection.className = 'raid-summary-fighters';
+    const lines = fighters.map(f => {
+      const xp = Math.round(f.xp);
+      return `<li>${f.name}: +${xp} XP${f.leveled ? ' (Level Up!)' : ''}</li>`;
+    }).join('');
+    fighterSection.innerHTML = '<p>Participants:</p><ul>' + lines + '</ul>';
+    box.appendChild(fighterSection);
+  }
 
   const rewardLines = [];
   if (rewards.undeadNectar) rewardLines.push(`Undead Nectar +${rewards.undeadNectar}`);


### PR DESCRIPTION
## Summary
- capture starting combat XP when raids begin
- list participating fighters in raid summary overlay
- show XP gained and note level ups
- document new overlay details

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68839924b9e08326974db11324fcdebe