### PR TITLE
Improve raid visuals and disciple UI

### DIFF
--- a/docs/00-wireframes.md
+++ b/docs/00-wireframes.md
@@ -85,9 +85,8 @@ Footer
 
 “Gate” button to open the full map/exploration/tasks overlay.
 * Exploration and sect disciple lists now use a unified badge styled purely via CSS.
-  Each badge displays a parchment background inside a bamboo border along with the
-
-  disciple's name, mood, HP bar and current task.
+  Each badge displays a parchment background inside a bamboo border along with the disciple's name,
+  mood, HP bar, Water bar and current task.
 * Disciples on the sect map appear as slightly larger side-facing coquí sprites (about 20% bigger). The bamboo frame is drawn using
   the CSS `border-image` property so the texture tiles cleanly around the badge. Every 10–20 seconds they emit a small croak bubble, and when assigned work they display a task icon such as a pickaxe or scroll.
 

--- a/docs/23-raids.md
+++ b/docs/23-raids.md
@@ -15,12 +15,12 @@ Disciples may be called upon to defend the sect from occasional raids.
 * Raids begin automatically during the Night phase.
 * A red alert briefly appears on screen when a raid starts.
 * Raiders attack the Water orb, reducing its stored energy.
-* Disciples assigned to **Fight** take position before the Water Orb, striking back each attack.
+* Disciples assigned to **Fight** line up south of the Water Orb at night, blocking raiders and striking back each attack.
 * Fighters absorb damage with their personal Water first. When empty they lose HP.
 * Raiders randomly target a fighter when multiple disciples are on guard.
 * If the orb is depleted the sect loses **half** of its stored fruit and softwood.
 * The Water orb periodically lashes out with a **Water Burst** every 10&nbsp;s, dealing 5 damage.
-  The burst now appears as a blue projectile traveling from the orb to the dealer card.
+  The burst now appears as a blue projectile traveling from the orb to the dealer card and the orb pulses when firing.
 * Dealer enemies display a small life bar on their card during raids.
 * Defeating a raid yields **Undead Nectar** in addition to experience.
 * The raid ends when the enemy is defeated or the orb is drained.

--- a/game/badges.js
+++ b/game/badges.js
@@ -1,5 +1,6 @@
 import { makeBar } from './ui.js';
 import { sectState } from './state.js';
+import { calculateMaxWater } from '../utils/water.js';
 import { DISCIPLE_MAX_HEALTH } from './constants.js';
 
 export function createDiscipleBadge(d) {
@@ -22,6 +23,11 @@ export function createDiscipleBadge(d) {
   const lifeBar = makeBar(d.health, DISCIPLE_MAX_HEALTH, '#a33');
   lifeBar.classList.add('life-bar');
   content.appendChild(lifeBar);
+
+  const waterLvl = sectState.discipleSkills[d.id]?.WaterSense || 0;
+  const waterBar = makeBar(d.water, calculateMaxWater(waterLvl), '#7fd9ff');
+  waterBar.classList.add('water-bar');
+  content.appendChild(waterBar);
 
   const wrapper = document.createElement('div');
   wrapper.dataset.discipleId = d.id;

--- a/game/raids.js
+++ b/game/raids.js
@@ -43,7 +43,7 @@ function shootWaterBurst(targetEl) {
   map.appendChild(proj);
   proj.addEventListener('animationend', () => proj.remove(), { once: true });
   runAnimation(targetEl, 'hit-animate');
-  runAnimation(orb, 'orb-hit');
+  runAnimation(orb, 'orb-burst');
 }
 
 const ORB_INTERVAL = 10000; // ms

--- a/script.js
+++ b/script.js
@@ -865,8 +865,17 @@ function startDiscipleMovement() {
           } else if (raidState.active && task === 'Fight') {
             const orb = document.querySelector('#sectOrbs .water');
             if (orb) {
-              const bx = orb.offsetLeft + orb.offsetWidth / 2 - 10;
-              const by = orb.offsetTop - 20;
+              const fighters = sectSystem.disciples.filter(
+                x => sectState.discipleTasks[x.id] === 'Fight' && !x.incapacitated
+              );
+              const idx = fighters.findIndex(x => x.id === d.id);
+              const spacing = 20;
+              const startX =
+                orb.offsetLeft +
+                orb.offsetWidth / 2 -
+                ((fighters.length - 1) * spacing) / 2;
+              const bx = startX + idx * spacing - 10;
+              const by = orb.offsetTop + orb.offsetHeight + 4;
               el.style.transform = `translate(${bx}px, ${by}px)`;
             }
           } else moveDisciple(el);

--- a/style.css
+++ b/style.css
@@ -548,6 +548,7 @@ body.darkenshift-mode .tabsContainer button.active {
     border-radius: 50%;
     background: #7fd9ff;
     pointer-events: none;
+    z-index: 15;
     animation: burstMove var(--duration) linear forwards;
 }
 
@@ -3173,6 +3174,9 @@ body.darkenshift-mode .tabsContainer button.active {
 .sect-orb.orb-hit {
     animation: orb-pulse 0.3s ease;
 }
+.sect-orb.orb-burst {
+    animation: orb-pulse 0.3s ease;
+}
 .colony-map.night .sect-orb.water {
     box-shadow: 0 0 30px rgba(80,180,255,0.9), 0 0 80px rgba(80,180,255,0.7);
     filter: brightness(1.2) saturate(1.2);
@@ -3940,6 +3944,9 @@ body.darkenshift-mode .tabsContainer button.active {
   height: 100%;
   width: 0%;
   background: var(--verdantia-jade);
+}
+.disciple-badge .water-bar .bar-fill {
+  background: #7fd9ff;
 }
 .disciple-badge .disciple-name {
   font-size: 0.55rem;


### PR DESCRIPTION
## Summary
- animate orb attack projectile with z-index fix
- line fighters south of the orb during raids
- show disciple water bar on badges
- document updates for raid behavior and badges

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688398e364e883268d9c4d5f26a5a629