### PR TITLE
Add undead nectar resource to UI

### DIFF
--- a/docs/23-raids.md
+++ b/docs/23-raids.md
@@ -22,6 +22,7 @@ Disciples may be called upon to defend the sect from occasional raids.
 * The Water orb periodically lashes out with a **Water Burst** every 10&nbsp;s, dealing 5 damage.
   The burst now appears as a blue projectile traveling from the orb to the dealer card.
 * Dealer enemies display a small life bar on their card during raids.
-* Defeating a raid yields **Undead Nectar** in addition to experience.
+* Defeating a raid yields **Undead Nectar** in addition to experience. The nectar
+  is added to your resources side panel for later use.
 * The raid ends when the enemy is defeated or the orb is drained.
 * A summary overlay appears after victory showing damage dealt, damage received and rewards.

--- a/game/raids.js
+++ b/game/raids.js
@@ -87,6 +87,11 @@ export function startRaid() {
   };
   const onDefeat = () => {
     sectState.undeadNectar = (sectState.undeadNectar || 0) + 1;
+    if (sectSystem.resources.undeadNectar) {
+      const res = sectSystem.resources.undeadNectar;
+      res.current = Math.min(res.max, res.current + 1);
+      res.unlocked = true;
+    }
     addLog('Raiders dropped Undead Nectar!', 'good');
     endRaid();
     showRaidSummaryOverlay({

--- a/game/sect.js
+++ b/game/sect.js
@@ -93,7 +93,8 @@ export const sectSystem = {
     fireEssence: { current: 0, max: 10, regen: 0, unlocked: false },
     earthEssence: { current: 0, max: 10, regen: 0, unlocked: false },
     summerEssence: { current: 0, max: 10, regen: 0, unlocked: false },
-    waterEssence: { current: 0, max: 10, regen: 0, unlocked: false }
+    waterEssence: { current: 0, max: 10, regen: 0, unlocked: false },
+    undeadNectar: { current: 0, max: 10, regen: 0, unlocked: false }
   },
   gains: {
     water: 0,
@@ -267,7 +268,8 @@ const resourceIcons = {
   fireEssence: 'flame',
   earthEssence: 'mountain',
   summerEssence: 'sun',
-  waterEssence: 'droplet'
+  waterEssence: 'droplet',
+  undeadNectar: 'test-tube'
 };
 
 

--- a/script.js
+++ b/script.js
@@ -2302,6 +2302,11 @@ Object.assign(playerStats, state.playerStats || {});
   if (state.sectState) {
     Object.assign(sectState, state.sectState);
     sectState.researchProgress = 0; // progress is not persisted
+    if (sectSystem.resources && sectSystem.resources.undeadNectar) {
+      const res = sectSystem.resources.undeadNectar;
+      res.current = sectState.undeadNectar || 0;
+      res.unlocked = res.current > 0;
+    }
   }
 
   // synchronize disciple global levels with saved skill data

--- a/style.css
+++ b/style.css
@@ -2755,6 +2755,7 @@ body.darkenshift-mode .tabsContainer button.active {
 .resource-fill.water { background: #7fd9ff; }
 .resource-fill.thought { background: #c785ff; }
 .resource-fill.structure { background: #a97b5d; }
+.resource-fill.undeadNectar { background: #ff7fd9; }
 }
 
 .resource-text {


### PR DESCRIPTION
## Summary
- display Undead Nectar from raids in resource panel
- map icon for the new resource
- color bar styling for nectar
- persist nectar count on load
- document nectar appearing in the resource sidebar

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6883993a24908326a82390ec49d63339