### PR TITLE
Add night mode orb glow

### DIFF
--- a/docs/16-water-orb.md
+++ b/docs/16-water-orb.md
@@ -8,6 +8,6 @@
 - Disciples can direct % of personal Water to orb.
 - The orb is now larger and displays its regeneration rate centered within.
 - The orb fill displays the current Water against its maximum capacity.
-- At night the orb glows with a bright blue hue, illuminating nearby terrain.
+- At night the orb glows with a bright blue hue, illuminating nearby terrain using a Pixi.js GlowFilter (radius ~30, outer strength ~2.5, inner strength ~0.5).
 - The orb now holds up to 20 Water and regenerates at a flat 0.1 Water per second.
 - Orb Revival research grants access to an Orb Management panel showing spells like Water Burst.

--- a/game/orbGlow.js
+++ b/game/orbGlow.js
@@ -1,0 +1,50 @@
+import * as PIXI from '../pixi.min.js';
+
+let orbSprite = null;
+let glowFilter = null;
+let app = null;
+let enabled = false;
+let time = 0;
+
+export function attachOrbGlow(element) {
+  if (!element || orbSprite) return;
+  const { clientWidth: w, clientHeight: h } = element;
+  if (!w || !h) return;
+  app = new PIXI.Application({ width: w, height: h, transparent: true });
+  const canvas = app.view;
+  canvas.style.position = 'absolute';
+  canvas.style.left = '0';
+  canvas.style.top = '0';
+  canvas.style.pointerEvents = 'none';
+  element.appendChild(canvas);
+  orbSprite = new PIXI.Graphics();
+  orbSprite.beginFill(0xffffff, 0);
+  orbSprite.drawCircle(w / 2, h / 2, Math.min(w, h) / 2);
+  orbSprite.endFill();
+  app.stage.addChild(orbSprite);
+  glowFilter = new PIXI.filters.GlowFilter({
+    distance: 30,
+    outerStrength: 2.5,
+    innerStrength: 0.5,
+    color: 0xffffff
+  });
+  orbSprite.filters = [];
+}
+
+export function enableOrbGlow() {
+  if (!orbSprite) return;
+  orbSprite.filters = [glowFilter];
+  enabled = true;
+}
+
+export function disableOrbGlow() {
+  if (!orbSprite) return;
+  orbSprite.filters = [];
+  enabled = false;
+}
+
+export function updateOrbGlow(delta) {
+  if (!glowFilter || !enabled) return;
+  time += delta / 1000;
+  glowFilter.distance = 30 + Math.sin(time) * 5;
+}

--- a/game/state.js
+++ b/game/state.js
@@ -6,6 +6,11 @@ export function setIsDarkenshift(val) {
   isDarkenshift = val;
 }
 
+export let nightMode = false;
+export function setNightMode(val) {
+  nightMode = val;
+}
+
 export const lifeCore = { real: false };
 
 export const WORLD_PROGRESS_TARGET = 1820;

--- a/script.js
+++ b/script.js
@@ -118,6 +118,7 @@ import {
 import { raidState } from './game/raids.js';
 // developer debug tools
 import { init as initDebug } from "./game/debug.js";
+import { attachOrbGlow, enableOrbGlow, disableOrbGlow, updateOrbGlow } from './game/orbGlow.js';
 // Shared game state and configuration
 import {
   currentEnemy,
@@ -148,7 +149,8 @@ import {
   setSpeakerOverlay,
   worldProgressTimer,
   setWorldProgressTimer,
-  worldProgressRateTracker
+  worldProgressRateTracker,
+  setNightMode
 } from "./game/state.js";
 import {
   BASE_STATS,
@@ -733,6 +735,7 @@ function updateSectDisplay() {
         rateEl.className = 'orb-regen';
         rateEl.textContent = `${sectSystem.gains.water.toFixed(2)}/s`;
         orb.appendChild(rateEl);
+        attachOrbGlow(orb);
       }
       orbs.appendChild(orb);
     });
@@ -1317,6 +1320,12 @@ function init() {
   });
   document.addEventListener('schedule-phase', e => {
     updateMapBrightness(e.detail.phase);
+    setNightMode(e.detail.phase === 'Night');
+    if (e.detail.phase === 'Night') {
+      enableOrbGlow();
+    } else {
+      disableOrbGlow();
+    }
     if (e.detail.action !== 'Work')  {
       sectSystem.disciples.forEach(d => {
         sectState.discipleProgress[d.id] = 0;
@@ -2415,6 +2424,7 @@ function gameLoop(currentTime) {
   // refresh sect resource UI every tick for real-time updates
   if (typeof updateSectDisplay === 'function') updateSectDisplay();
   updateTaskProgressDisplay();
+  updateOrbGlow(deltaTime);
   requestAnimationFrame(gameLoop);
 }
 


### PR DESCRIPTION
## Summary
- add `nightMode` to game state
- implement orb glow filter via Pixi.js
- toggle glow on schedule phase change
- document glow filter details

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6883b161003c8326b2d3413da7ff3a7b