### PR TITLE
Show disciple skill info in work overlay

### DIFF
--- a/docs/22-affinities.md
+++ b/docs/22-affinities.md
@@ -6,6 +6,10 @@ A disciple also gains "loved" affinity for 0‑3 random skills, overriding "like
 In the disciple overlay's **Proficiency** tab, loved skills show a heart icon
 while liked skills show a thumbs-up icon.
 
+The Work overlay also displays each selected disciple's skill level and
+affinity icon below every task option, making it easier to assign disciples to
+their best roles.
+
 ### Liked
 - Increases proficiency gain by **40%**.
 - Grants bonus starting skill levels. See [recruitment](02‑recruitment.md).

--- a/style.css
+++ b/style.css
@@ -737,6 +737,21 @@ body.darkenshift-mode .tabsContainer button.active {
     color: #ddd;
 }
 
+.work-task-option {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 2px;
+}
+
+.work-task-info {
+    font-size: 0.7rem;
+    color: #ddd;
+    display: flex;
+    align-items: center;
+    gap: 2px;
+}
+
 
 .location-entry {
     cursor: pointer;

--- a/ui/colonyOverlays.js
+++ b/ui/colonyOverlays.js
@@ -8,6 +8,8 @@ import { sectSystem, SECT_SCHEDULE, getCurrentSchedule, renderConstructCards, ge
 import { systems, sectState, worldProgress } from '../game/state.js';
 import { createSectDiscipleCard, renderExplorationTab, startExploration, startWorldCombat, discipleGatherPhase } from '../script.js';
 import { BUILDINGS, startBuilding } from '../game/buildings.js';
+import { TASK_GROUPS } from '../game/constants.js';
+import { getTaskSkillProgress } from '../utils/skills.js';
 
 let explorationOverlay = null;
 let explorationOverlayActiveTab = 'explore';
@@ -160,7 +162,11 @@ export function openWorkOverlay() {
     const tasks = ['Gather Fruit', 'Gather Softwood', 'Fight'];
     if (systems.buildingUnlocked) tasks.push('Building');
     if (systems.researchUnlocked) tasks.push('Research');
+    const selected = sectSystem.disciples.find(d => d.id === workOverlaySelected);
     tasks.forEach(t => {
+      const option = document.createElement('div');
+      option.className = 'work-task-option';
+
       const btn = document.createElement('button');
       btn.textContent = t;
       btn.addEventListener('click', () => {
@@ -176,7 +182,30 @@ export function openWorkOverlay() {
         }
         render();
       });
-      right.appendChild(btn);
+      option.appendChild(btn);
+
+      if (selected) {
+        const group = TASK_GROUPS[t];
+        if (group) {
+          const xp = sectState.discipleSkills[selected.id]?.[group] || 0;
+          const lvl = getTaskSkillProgress(xp).level;
+          const info = document.createElement('div');
+          info.className = 'work-task-info';
+          const affinity = selected.affinities?.[group];
+          if (affinity === 'liked' || affinity === 'loved') {
+            const icon = document.createElement('i');
+            icon.dataset.lucide = affinity === 'loved' ? 'heart' : 'thumbs-up';
+            icon.className = `affinity-icon ${affinity}`;
+            info.appendChild(icon);
+          }
+          const label = document.createElement('span');
+          label.textContent = `Lv ${lvl}`;
+          info.appendChild(label);
+          option.appendChild(info);
+        }
+      }
+
+      right.appendChild(option);
     });
   }
 


### PR DESCRIPTION
## Summary
- display selected disciple's skill level and affinity beneath each task option in the Work overlay
- style new task info lines
- document the new info display in the affinities guide

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6883b357e99c8326bda5954d096739ee