### PR TITLE
Add new orb research and spells

### DIFF
--- a/docs/12-buildings.md
+++ b/docs/12-buildings.md
@@ -38,6 +38,7 @@ Research Table	Softwood: 30 × (lvl^1.3)	Convert 4% global Water → Insight per
 Library	Wood: 200 × (lvl^1.1); Stone: 100 × (lvl^1.1)	Unlock learning/spell teaching; +4% teaching rate per level	Research Table Lv1
 Jadefire Pavilion	Softwood & Stone: 20 × (1.1^lvl) each	Enables Transmutation; +3% spell potency per level	Transmutation research
 Chanting Halls	Wood: 300 × (1.15^lvl)	–4% chant cooldown per level; +1 chanter per 3 levels	Library Lv2
+Orb Spell Strength  Softwood: 100 × (1.3^lvl)  +20% orb spell damage per level   Research: Orb Spell Strength
 
 
 Ornaments / Cultivation Enhancers

--- a/docs/15-research.md
+++ b/docs/15-research.md
@@ -78,3 +78,15 @@ Orb Revival
 
 Unlocks the Orb Management screen, providing details on abilities like Water Burst.
 
+Word of Haste
+
+Costs 2 points. Grants an orb spell that spends 15 Water to boost sect work speed for 1 minute. Shares a 1 minute cooldown.
+
+Orb Spell Strength
+
+Costs 3 points. Unlocks the Orb Spell Strength building. Each level increases orb damage spells by 20%.
+
+Orb Reverberation
+
+Costs 4 points. Unlocks a continuous orb spell that boosts disciple attack speed by 30% while draining 1 Water per second.
+

--- a/docs/16-water-orb.md
+++ b/docs/16-water-orb.md
@@ -11,3 +11,6 @@
 - At night the orb glows with a bright blue hue, illuminating nearby terrain using a Pixi.js GlowFilter (radius ~30, outer strength ~2.5, inner strength ~0.5).
 - The orb now holds up to 20 Water and regenerates at a flat 0.1 Water per second.
 - Orb Revival research grants access to an Orb Management panel showing spells like Water Burst.
+- Word of Haste orb spell speeds up work tasks for one minute at the cost of 15 Water.
+- Orb Spell Strength buildings raise Water Burst damage by 20% per level.
+- Orb Reverberation grants a toggled effect that increases disciple attack speed by 30% while draining 1 Water each second.

--- a/game/buildings.js
+++ b/game/buildings.js
@@ -13,7 +13,14 @@ export const BUILDINGS = {
     costFunc: lvl => 20 * Math.pow(2, lvl)
   },
   researchDesk: { name: 'Research Desk', cost: 15, time: 300, max: 1, requires: 'bohio' },
-  chantingHall: { name: 'Chanting Hall', cost: 50, time: 600, max: 1, requires: 'researchDesk' }
+  chantingHall: { name: 'Chanting Hall', cost: 50, time: 600, max: 1, requires: 'researchDesk' },
+  orbSpellStrength: {
+    name: 'Orb Spell Strength',
+    time: 300,
+    costFunc: lvl => Math.round(100 * Math.pow(1.3, lvl)),
+    max: 10,
+    requires: 'researchDesk'
+  }
 };
 
 export function getHousingName(level) {
@@ -49,6 +56,7 @@ export function startBuilding(key) {
   if (sectState.currentBuild) return;
   if (b.requires && sectState.buildings[b.requires] < b.max) return;
   if (key === 'chantingHall' && !systems.chantingHallUnlocked) return;
+  if (key === 'orbSpellStrength' && !systems.spellStrengthUnlocked) return;
   sectState.softwood -= cost;
   sectState.currentBuild = key;
   sectState.buildProgress = 0;
@@ -72,6 +80,7 @@ export function tickBuilding(dt) {
     }
   });
   if (speed === 0) return;
+  if (sectSystem.wordOfHasteTimer > 0) speed *= 1.5;
   const b = BUILDINGS[sectState.currentBuild];
   sectState.buildProgress += (dt * speed) / b.time;
   if (sectState.buildProgress >= 1) {

--- a/game/combat.js
+++ b/game/combat.js
@@ -4,6 +4,7 @@ import { renderDealerLifeBarFill, removeBloodSplat, updateBloodSplat } from '../
 import { formatNumber } from '../utils/numberFormat.js';
 import { activeDisciples } from './disciples.js';
 import { calculateEnemyBasicDamage } from '../enemySpawning.js';
+import { sectSystem } from './sect.js';
 import { runAnimation } from '../utils/animation.js';
 import { showRestartScreen } from '../ui/restartOverlay.js';
 import addLog from '../log.js';
@@ -25,12 +26,13 @@ export function attack(deltaTime = 0) {
     if (!discipleAttackTimers[d.id]) discipleAttackTimers[d.id] = 0;
     discipleAttackTimers[d.id] += deltaTime;
 
+    const atkTime = d.attackSpeed / sectSystem.attackSpeedMult;
     if (d.attackFill) {
-      const pratio = Math.min(1, discipleAttackTimers[d.id] / d.attackSpeed);
+      const pratio = Math.min(1, discipleAttackTimers[d.id] / atkTime);
       d.attackFill.style.width = `${pratio * 100}%`;
     }
 
-    if (discipleAttackTimers[d.id] >= d.attackSpeed && !enemy.isDefeated()) {
+    if (discipleAttackTimers[d.id] >= atkTime && !enemy.isDefeated()) {
       enemy.takeDamage(d.damage);
       if (raidState.active) raidState.damageDealt += d.damage;
       discipleAttackTimers[d.id] = 0;

--- a/game/orbSpells.js
+++ b/game/orbSpells.js
@@ -1,0 +1,45 @@
+import { sectSystem } from './sect.js';
+import { sectState } from './state.js';
+import addLog from '../log.js';
+
+export function orbDamageMultiplier() {
+  return 1 + 0.2 * (sectState.buildings.orbSpellStrength || 0);
+}
+
+export function castWordOfHaste() {
+  if (sectSystem.wordOfHasteCd > 0) return;
+  if (sectSystem.orbs.water.current < 15) return;
+  sectSystem.orbs.water.current -= 15;
+  sectSystem.wordOfHasteTimer = 60;
+  sectSystem.wordOfHasteCd = 60;
+  addLog('Word of Haste activated!', 'info');
+}
+
+export function toggleReverberation() {
+  if (sectSystem.orbReverbActive) {
+    sectSystem.orbReverbActive = false;
+    sectSystem.attackSpeedMult = 1;
+    return;
+  }
+  if (sectSystem.orbs.water.current <= 0) return;
+  sectSystem.orbReverbActive = true;
+  sectSystem.attackSpeedMult = 1.3;
+  addLog('Orb Reverberation active', 'info');
+}
+
+export function tickOrbSpells(dt) {
+  if (sectSystem.wordOfHasteTimer > 0) {
+    sectSystem.wordOfHasteTimer = Math.max(0, sectSystem.wordOfHasteTimer - dt);
+  }
+  if (sectSystem.wordOfHasteCd > 0) {
+    sectSystem.wordOfHasteCd = Math.max(0, sectSystem.wordOfHasteCd - dt);
+  }
+  if (sectSystem.orbReverbActive) {
+    const orb = sectSystem.orbs.water;
+    orb.current = Math.max(0, orb.current - dt);
+    if (orb.current === 0) {
+      sectSystem.orbReverbActive = false;
+      sectSystem.attackSpeedMult = 1;
+    }
+  }
+}

--- a/game/raids.js
+++ b/game/raids.js
@@ -8,6 +8,7 @@ import {
 } from './state.js';
 import { updateRaidLifeBar, updateDealerLifeDisplay } from './ui.js';
 import { showRaidSummaryOverlay } from '../ui/raidSummaryOverlay.js';
+import { orbDamageMultiplier } from './orbSpells.js';
 
 import { spawnDealer } from '../enemySpawning.js';
 import addLog from '../log.js';
@@ -162,8 +163,9 @@ export function tickRaid(delta) {
   raidState.orbTimer += delta;
   if (raidState.orbTimer >= ORB_INTERVAL) {
     raidState.orbTimer -= ORB_INTERVAL;
-    raidState.enemy.takeDamage(5);
-    raidState.damageDealt += 5;
+    const dmg = 5 * orbDamageMultiplier();
+    raidState.enemy.takeDamage(dmg);
+    raidState.damageDealt += dmg;
     const card = document.querySelector('.raidCardContainer .dCardPane');
     shootWaterBurst(card);
     if (raidState.enemy) {

--- a/game/sect.js
+++ b/game/sect.js
@@ -28,6 +28,7 @@ import {
 } from './constants.js';
 import { startRaid, tickRaid, raidState, endRaid } from './raids.js';
 import { updateRaidLifeBar } from './ui.js';
+import { tickOrbSpells } from './orbSpells.js';
 
 export { addDiscoveredLocation } from "./ui.js";
 export const discoveredLocations = [];
@@ -128,6 +129,10 @@ export const sectSystem = {
   mnemonicTimer: 0,
   mnemonicBeats: 0,
   mnemonicPotency: 1,
+  wordOfHasteTimer: 0,
+  wordOfHasteCd: 0,
+  orbReverbActive: false,
+  attackSpeedMult: 1,
   murmurChain: 0,
   scheduleIndex: 0,
   scheduleTimer: 0
@@ -1310,6 +1315,7 @@ export function tickSectSystem(delta) {
     }
   }
   tickActiveConstructs(dt);
+  tickOrbSpells(dt);
   tickMetamorphosis(dt);
   tickRaid(delta);
   ins.current = Math.min(ins.max, Math.max(0, ins.current));
@@ -1478,7 +1484,7 @@ export function tickSect(delta) {
       if (raidState.active && raidState.enemy) {
         if (!raidState.attackTimers[d.id]) raidState.attackTimers[d.id] = 0;
         raidState.attackTimers[d.id] += delta;
-        const atkTime = d.attackSpeed;
+        const atkTime = d.attackSpeed / sectSystem.attackSpeedMult;
         if (raidState.attackTimers[d.id] >= atkTime) {
           raidState.enemy.takeDamage(d.damage);
           updateRaidLifeBar(raidState.enemy);

--- a/game/state.js
+++ b/game/state.js
@@ -83,7 +83,8 @@ export const systems = {
   researchUnlocked: false,
   chantingHallUnlocked: false,
   explorationUnlocked: false,
-  orbManagementUnlocked: false
+  orbManagementUnlocked: false,
+  spellStrengthUnlocked: false
 };
 
 // Fruit gathering and growth configuration
@@ -107,7 +108,7 @@ export const sectState = {
   discipleRest: {},
   maxDisciples: 3,
   housingBonus: 0,
-  buildings: { bohio: 0, researchDesk: 0, chantingHall: 0 },
+  buildings: { bohio: 0, researchDesk: 0, chantingHall: 0, orbSpellStrength: 0 },
   researchPoints: 0,
   researchProgress: 0,
   completedResearch: [],

--- a/ui/colonyOverlays.js
+++ b/ui/colonyOverlays.js
@@ -8,6 +8,7 @@ import { sectSystem, SECT_SCHEDULE, getCurrentSchedule, renderConstructCards, ge
 import { systems, sectState, worldProgress } from '../game/state.js';
 import { createSectDiscipleCard, renderExplorationTab, startExploration, startWorldCombat, discipleGatherPhase } from '../script.js';
 import { BUILDINGS, startBuilding } from '../game/buildings.js';
+import { castWordOfHaste, toggleReverberation, orbDamageMultiplier } from '../game/orbSpells.js';
 
 let explorationOverlay = null;
 let explorationOverlayActiveTab = 'explore';
@@ -296,8 +297,36 @@ export function openOrbOverlay() {
 
   const burst = document.createElement('li');
   burst.className = 'orb-spell';
-  burst.innerHTML = '<b>Water Burst</b> - Automatically hits raiders every 10s for 5 damage.';
+  burst.innerHTML = `<b>Water Burst</b> - Automatically hits raiders every 10s for ${5 * orbDamageMultiplier()} damage.`;
   list.appendChild(burst);
+
+  function render() {
+    list.querySelectorAll('.dynamic-spell').forEach(el => el.remove());
+    if (sectState.completedResearch.includes('wordOfHaste')) {
+      const li = document.createElement('li');
+      li.className = 'orb-spell dynamic-spell';
+      const btn = document.createElement('button');
+      btn.textContent = 'Cast Word of Haste';
+      btn.disabled = sectSystem.wordOfHasteCd > 0 || sectSystem.orbs.water.current < 15;
+      btn.addEventListener('click', () => { castWordOfHaste(); render(); });
+      li.appendChild(btn);
+      li.appendChild(document.createTextNode(' - Boost work speed for 1m'));
+      list.appendChild(li);
+    }
+    if (sectState.completedResearch.includes('orbReverb')) {
+      const li = document.createElement('li');
+      li.className = 'orb-spell dynamic-spell';
+      const btn = document.createElement('button');
+      btn.textContent = sectSystem.orbReverbActive ? 'Stop Reverberation' : 'Start Reverberation';
+      btn.disabled = !sectSystem.orbReverbActive && sectSystem.orbs.water.current < 1;
+      btn.addEventListener('click', () => { toggleReverberation(); render(); });
+      li.appendChild(btn);
+      li.appendChild(document.createTextNode(' - +30% attack speed, drains 1 Water/s'));
+      list.appendChild(li);
+    }
+  }
+
+  render();
 }
 
 let buildOverlay = null;
@@ -324,6 +353,7 @@ export function openBuildOverlay() {
     list.innerHTML = '';
     Object.entries(BUILDINGS).forEach(([key, def]) => {
       if (def.requires && !(sectState.buildings[def.requires] > 0)) return;
+      if (key === 'orbSpellStrength' && !systems.spellStrengthUnlocked) return;
       const built = sectState.buildings[key] || 0;
       const row = document.createElement('div');
       row.className = 'build-entry';
@@ -457,6 +487,29 @@ export function openResearchOverlay() {
       unlock() {
         if (!systems.orbManagementUnlocked) systems.orbManagementUnlocked = true;
       }
+    },
+    {
+      key: 'wordOfHaste',
+      label: 'Word of Haste',
+      cost: 2,
+      desc: 'Orb spell granting 1m work speed boost (15 Water)',
+      unlock() {}
+    },
+    {
+      key: 'orbSpellStrength',
+      label: 'Orb Spell Strength',
+      cost: 3,
+      desc: 'Unlocks building to raise orb damage by 20%/level',
+      unlock() {
+        systems.spellStrengthUnlocked = true;
+      }
+    },
+    {
+      key: 'orbReverb',
+      label: 'Orb Reverberation',
+      cost: 4,
+      desc: 'Continuous spell: +30% attack speed, drains 1 Water/s',
+      unlock() {}
     }
   ];
 


### PR DESCRIPTION
## Summary
- introduce orb spell research and mechanics
- boost orb burst damage via new Orb Spell Strength building
- add Word of Haste and Orb Reverberation abilities
- document new research options and orb mechanics

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6883b69f0ff48326bbf0c5b2e7880aaf