### PR TITLE
Add raid xp progress display

### DIFF
--- a/docs/23-raids.md
+++ b/docs/23-raids.md
@@ -26,5 +26,6 @@ Disciples may be called upon to defend the sect from occasional raids.
   is added to your resources side panel for later use.
 * The raid ends when the enemy is defeated or the orb is drained.
 * A summary overlay appears after victory showing damage dealt, damage received,
-  rewards and how much combat XP each participating disciple earned. Level ups
-  are noted next to the fighter's name.
+  rewards and how much combat XP each participating disciple earned. Each
+  fighter now displays a small progress bar indicating their level and progress
+  toward the next. Level ups are noted next to the fighter's name.

--- a/game/raids.js
+++ b/game/raids.js
@@ -114,11 +114,13 @@ export function startRaid() {
       const endXp = sectState.discipleSkills[id].Combat || 0;
       const gained = endXp - info.xp;
       const startLvl = info.level;
-      const endLvl = getTaskSkillProgress(endXp).level;
+      const endProg = getTaskSkillProgress(endXp);
       return {
         name: info.name,
         xp: gained,
-        leveled: endLvl > startLvl
+        leveled: endProg.level > startLvl,
+        level: endProg.level,
+        progress: endProg.progress
       };
     });
     raidState.xpStart = {};

--- a/script.js
+++ b/script.js
@@ -897,11 +897,30 @@ function buildDiscipleCombatStatsView(d) {
   const body = document.createElement('div');
   const atkPerSec = (1000 / d.attackSpeed).toFixed(2);
   const defense = Math.round(d.defense ?? 0);
-  body.innerHTML =
-    `Level ${d.combatLevel}<br>` +
+
+  const levelRow = document.createElement('div');
+  levelRow.textContent = `Level ${d.combatLevel}`;
+  body.appendChild(levelRow);
+
+  const bar = document.createElement('div');
+  bar.className = 'disciple-progress';
+  const fill = document.createElement('div');
+  fill.className = 'disciple-progress-fill';
+  const pct = Math.min(1, d.combatXp / d.xpForNextLevel());
+  fill.style.width = `${Math.floor(pct * 100)}%`;
+  const label = document.createElement('div');
+  label.className = 'disciple-progress-label';
+  label.textContent = `${Math.floor(d.combatXp)}/${d.xpForNextLevel()}`;
+  bar.append(fill, label);
+  body.appendChild(bar);
+
+  const stats = document.createElement('div');
+  stats.innerHTML =
     `Damage ${Math.round(d.damage)}<br>` +
     `Attack/s ${atkPerSec}<br>` +
     `Defense ${defense}`;
+  body.appendChild(stats);
+
   return body;
 }
 

--- a/style.css
+++ b/style.css
@@ -3961,3 +3961,18 @@ body.darkenshift-mode .tabsContainer button.active {
   font-size: 0.55rem;
 }
 
+/* Raid summary overlay */
+.raid-summary-fighters ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+.raid-summary-fighters li {
+  margin-bottom: 4px;
+}
+.raid-summary-fighters .disciple-progress {
+  width: 100px;
+  height: 8px;
+  margin-top: 2px;
+}
+

--- a/test/combat-xp.test.js
+++ b/test/combat-xp.test.js
@@ -1,0 +1,62 @@
+/* global describe, it, before, after, beforeEach */
+import { expect } from 'chai';
+import Disciple from '../disciple.js';
+import { initializeDisciple } from '../utils/discipleInit.js';
+import { sectState } from '../game/state.js';
+
+let sectModule;
+let raidModule;
+let sectSystem;
+let tickSect;
+let startRaid;
+let tickRaid;
+let raidState;
+
+function setupDom() {
+  globalThis.document = {
+    getElementById: () => null,
+    getElementsByClassName: () => [{ textContent: '', style: {}, appendChild() {} }],
+    createElement: () => ({ appendChild() {}, style: {}, addEventListener() {}, remove() {} }),
+    querySelector: () => null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    body: { appendChild() {} },
+    dispatchEvent: () => {}
+  };
+  globalThis.window = { dispatchEvent() {} };
+}
+
+describe('combat xp gain', () => {
+  before(async () => {
+    setupDom();
+    sectModule = await import(`../game/sect.js?test=${Date.now()}`);
+    raidModule = await import(`../game/raids.js?test=${Date.now()}`);
+    ({ sectSystem, tickSect } = sectModule);
+    ({ startRaid, tickRaid, raidState } = raidModule);
+  });
+
+  after(() => {});
+
+  beforeEach(() => {
+    sectSystem.disciples.length = 0;
+    Object.keys(sectState.discipleTasks).forEach(k => delete sectState.discipleTasks[k]);
+    Object.keys(sectState.discipleSkills).forEach(k => delete sectState.discipleSkills[k]);
+  });
+
+  it('awards combat xp to fighters during a raid', () => {
+    const d = new Disciple({ id: 1 });
+    initializeDisciple(d);
+    sectSystem.disciples.push(d);
+    sectState.discipleTasks[d.id] = 'Fight';
+
+    const startXp = sectState.discipleSkills[d.id]?.Combat || 0;
+    startRaid();
+    for (let i = 0; i < 10; i++) {
+      tickSect(1000);
+      tickRaid(1000);
+    }
+    raidState.active = false;
+    const endXp = sectState.discipleSkills[d.id].Combat || 0;
+    expect(endXp - startXp).to.be.greaterThan(0);
+  });
+});

--- a/ui/raidSummaryOverlay.js
+++ b/ui/raidSummaryOverlay.js
@@ -25,11 +25,25 @@ export function showRaidSummaryOverlay({
   if (fighters.length > 0) {
     const fighterSection = document.createElement('div');
     fighterSection.className = 'raid-summary-fighters';
-    const lines = fighters.map(f => {
-      const xp = Math.round(f.xp);
-      return `<li>${f.name}: +${xp} XP${f.leveled ? ' (Level Up!)' : ''}</li>`;
-    }).join('');
-    fighterSection.innerHTML = '<p>Participants:</p><ul>' + lines + '</ul>';
+    const list = document.createElement('ul');
+    fighters.forEach(f => {
+      const li = document.createElement('li');
+      li.textContent = `${f.name}: +${Math.round(f.xp)} XP` +
+        (f.leveled ? ' (Level Up!)' : '');
+      const bar = document.createElement('div');
+      bar.className = 'disciple-progress';
+      const fill = document.createElement('div');
+      fill.className = 'disciple-progress-fill';
+      fill.style.width = `${Math.floor(f.progress * 100)}%`;
+      const label = document.createElement('div');
+      label.className = 'disciple-progress-label';
+      label.textContent = `LV ${f.level}`;
+      bar.append(fill, label);
+      li.appendChild(bar);
+      list.appendChild(li);
+    });
+    fighterSection.innerHTML = '<p>Participants:</p>';
+    fighterSection.appendChild(list);
     box.appendChild(fighterSection);
   }
 


### PR DESCRIPTION
## Summary
- show fighter combat XP gain with progress bars in raid summary
- expose level and progress stats when raid ends
- show XP progress in disciple stats view
- style raid summary fighter rows
- test combat XP accumulation during raids

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6883b73405f48326958689c283bdb176