### PR TITLE
Add zone visibility toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,5 +50,6 @@ This is not a standard Wuxia knockoff — **Taino and Caribbean mysticism** blen
 
 Run the game with the `?dev` query parameter to enable a debug panel.
 It offers helpers like spawning bosses, toggling fast mode, and skipping
-directly to the next night.
+directly to the next night. A new button lets you toggle the sect map's
+zone overlays on or off for layout testing.
 

--- a/debugTools.js
+++ b/debugTools.js
@@ -21,6 +21,7 @@ import {
   setTimeScale
 } from './game/state.js';
 import { activeDisciples } from './game/disciples.js';
+import { toggleZones } from './game/zones.js';
 
 export const devTools = {
   spawnBoss: () => spawnBossEvent(),
@@ -67,6 +68,7 @@ export const devTools = {
     addDiscoveredLocation('Esoteric Dungeon');
     unlockConstruct('Sonic Boom');
   },
+  toggleZones,
   save: saveGame,
   load: loadGame,
   newGame: startNewGame

--- a/docs/module-structure.md
+++ b/docs/module-structure.md
@@ -10,6 +10,7 @@ The project organizes game logic under the `game/` directory.
   resolution and disciple hit animations.
 - **game/debug.js** – wiring for optional debug controls.
 - **debugTools.js** – development helpers loaded when `?dev` is present.
+- **game/zones.js** – toggles visibility of sect map zone elements.
 - **game/constants.js** – collection of shared gameplay constants used across systems.
 - **game/tooltip.js** – simple helpers for showing and hiding the UI tooltip.
 - **game/sect.js** – implements the sect management system including constructs and colony helpers.

--- a/game/zones.js
+++ b/game/zones.js
@@ -1,0 +1,10 @@
+export let zonesVisible = true;
+
+export function toggleZones() {
+  const container = document.getElementById('sectDisciplesContainer');
+  if (!container) return;
+  zonesVisible = !zonesVisible;
+  container.querySelectorAll('.zone, .zone-path').forEach(z => {
+    z.style.display = zonesVisible ? '' : 'none';
+  });
+}

--- a/index.html
+++ b/index.html
@@ -39,6 +39,7 @@
       <button onclick="devTools.save()">Save Game</button>
       <button onclick="devTools.load()">Load Game</button>
       <button onclick="devTools.unlockExploration()">Unlock Exploration</button>
+      <button onclick="devTools.toggleZones()">Toggle Zones</button>
     </div>
 
     <!---tabs container--->


### PR DESCRIPTION
## Summary
- add module for toggling sect map zone elements
- expose toggle in dev tools and hook up a button
- document the new module and dev feature

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6883f1360b5083269f8ad924ea61a27d