### PR TITLE
Fix orb glow visibility at night

### DIFF
--- a/docs/16-water-orb.md
+++ b/docs/16-water-orb.md
@@ -9,6 +9,7 @@
 - The orb is now larger and displays its regeneration rate centered within.
 - The orb fill displays the current Water against its maximum capacity.
 - At night the orb glows with a bright blue hue, illuminating nearby terrain using a Pixi.js GlowFilter (radius ~30, outer strength ~2.5, inner strength ~0.5).
+- The glow color is `#7fd9ff` and brightness is boosted 50% at night to help the orb stand out against the dimmed map.
 - The orb now holds up to 20 Water and regenerates at a flat 0.1 Water per second.
 - Orb Revival research grants access to an Orb Management panel showing spells like Water Burst.
 - Word of Haste orb spell speeds up work tasks for one minute at the cost of 15 Water.

--- a/game/orbGlow.js
+++ b/game/orbGlow.js
@@ -26,7 +26,7 @@ export function attachOrbGlow(element) {
     distance: 30,
     outerStrength: 2.5,
     innerStrength: 0.5,
-    color: 0xffffff
+    color: 0x7fd9ff
   });
   orbSprite.filters = [];
 }

--- a/script.js
+++ b/script.js
@@ -775,7 +775,7 @@ function applyNightFilters(brightness) {
   document.querySelectorAll('#sectOrbs .sect-orb.water').forEach(o => {
     if (!o.dataset.baseFilter) o.dataset.baseFilter = o.style.filter || '';
     if (brightness < 1) {
-      o.style.filter = `${o.dataset.baseFilter} brightness(${inv}) saturate(1.2)`;
+      o.style.filter = `${o.dataset.baseFilter} brightness(${inv * 1.5}) saturate(1.2)`;
     } else {
       o.style.filter = o.dataset.baseFilter;
     }


### PR DESCRIPTION
## Summary
- adjust water orb glow filter to bright blue
- boost night filter brightness for orb visuals
- document orb glow color and brightness in water orb design

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6883fd4f5df88326a67b582aa9541eff