### PR TITLE
Add blob raid behavior

### DIFF
--- a/docs/23-raids.md
+++ b/docs/23-raids.md
@@ -5,7 +5,7 @@
 
 Night raids escalate the longer your sect survives. Each evening hostile frogs or spirits attack from the edge of the sect map and attempt to reach the Water Orb.
 
-- **Enemy scaling** – raid size and enemy stats grow with the current stage and world. Early attacks feature a single dealer while later nights spawn full groups and elite units.
+- **Enemy scaling** – raid size and enemy stats grow with the current stage and world. Early attacks feature sluggish "SlowBlob" spirits that spawn every few seconds and crawl toward the orb.
 - **Orb damage** – the Water Orb pulses damage in a small radius, harming nearby attackers. Buildings can boost this effect.
 - **Resource theft** – if any enemy touches the orb they steal a portion of stored resources (fruit, timber and ore) before escaping.
 - **Rewards** – defeating a raid grants small loot drops and experience for participating disciples.
@@ -19,9 +19,8 @@ Disciples may be called upon to defend the sect from occasional raids.
 * Fighters absorb damage with their personal Water first. When empty they lose HP.
 * Raiders randomly target a fighter when multiple disciples are on guard.
 * If the orb is depleted the sect loses **half** of its stored fruit and softwood.
-* The Water orb periodically lashes out with a **Water Burst** every 10&nbsp;s, dealing 5 damage.
-  The burst now appears as a blue projectile traveling from the orb to the dealer card and the orb pulses when firing.
-* Dealer enemies display a small life bar on their card during raids.
+* The Water orb lashes out every second, striking the closest blob for 5 damage.
+* Blobs show a small health meter as they crawl across the map.
 * Defeating a raid yields **Undead Nectar** in addition to experience. The nectar
   is added to your resources side panel for later use.
 * The raid ends when the enemy is defeated or the orb is drained.

--- a/game/blobRaids.js
+++ b/game/blobRaids.js
@@ -1,0 +1,182 @@
+import { sectSystem } from './sect.js';
+import { sectState } from './state.js';
+import { runAnimation } from '../utils/animation.js';
+
+const SPAWN_INTERVAL = 5000; // ms
+const BLOB_SPEED = 10; // px per second
+const ORB_ATTACK_INTERVAL = 1000; // ms
+const DISCIPLE_ATTACK_INTERVAL = 10000; // ms
+const DISCIPLE_RANGE = 50; // px
+const DISCIPLE_DAMAGE = 3;
+
+export const blobs = [];
+let spawnTimer = 0;
+let orbAttackTimer = 0;
+
+function getMap() {
+  return document.getElementById('colonyMap');
+}
+
+function getOrb() {
+  return document.querySelector('#sectOrbs .sect-orb.water');
+}
+
+function createBlob() {
+  const map = getMap();
+  const orb = getOrb();
+  if (!map || !orb) return null;
+  const mapRect = map.getBoundingClientRect();
+  const orbRect = orb.getBoundingClientRect();
+  const size = 16;
+  const blob = document.createElement('div');
+  blob.className = 'slow-blob';
+  blob.style.width = `${size}px`;
+  blob.style.height = `${size}px`;
+  blob.style.position = 'absolute';
+  blob.style.borderRadius = '50%';
+  blob.style.background = 'purple';
+  let x = 0;
+  let y = 0;
+  const edge = Math.floor(Math.random() * 4);
+  if (edge === 0) {
+    x = Math.random() * mapRect.width;
+    y = 0 - size;
+  } else if (edge === 1) {
+    x = Math.random() * mapRect.width;
+    y = mapRect.height + size;
+  } else if (edge === 2) {
+    x = 0 - size;
+    y = Math.random() * mapRect.height;
+  } else {
+    x = mapRect.width + size;
+    y = Math.random() * mapRect.height;
+  }
+  blob.style.left = `${x}px`;
+  blob.style.top = `${y}px`;
+  map.appendChild(blob);
+  return {
+    el: blob,
+    x,
+    y,
+    hp: 20,
+    nextAttack: performance.now() + 1000,
+    size,
+    update(dt) {
+      const ox = orbRect.left + orbRect.width / 2 - mapRect.left;
+      const oy = orbRect.top + orbRect.height / 2 - mapRect.top;
+      const dx = ox - this.x;
+      const dy = oy - this.y;
+      const dist = Math.hypot(dx, dy);
+      if (dist > 1) {
+        const move = Math.min((BLOB_SPEED * dt) / 1000, dist);
+        this.x += (dx / dist) * move;
+        this.y += (dy / dist) * move;
+        this.el.style.left = `${this.x}px`;
+        this.el.style.top = `${this.y}px`;
+      }
+      if (dist <= this.size && performance.now() >= this.nextAttack) {
+        sectSystem.orbs.water.current = Math.max(
+          0,
+          sectSystem.orbs.water.current - 5
+        );
+        runAnimation(orb, 'orb-hit');
+        this.nextAttack = performance.now() + 1000;
+      }
+    },
+    takeDamage(dmg) {
+      this.hp = Math.max(0, this.hp - dmg);
+      if (this.hp === 0) {
+        this.el.remove();
+        const idx = blobs.indexOf(this);
+        if (idx >= 0) blobs.splice(idx, 1);
+      }
+    }
+  };
+}
+
+function orbAttack() {
+  const orb = getOrb();
+  const map = getMap();
+  if (!orb || blobs.length === 0 || !map) return;
+  const mapRect = map.getBoundingClientRect();
+  const orbRect = orb.getBoundingClientRect();
+  const ox = orbRect.left + orbRect.width / 2 - mapRect.left;
+  const oy = orbRect.top + orbRect.height / 2 - mapRect.top;
+  let target = null;
+  blobs.forEach(b => {
+    const dist = Math.hypot(b.x - ox, b.y - oy);
+    if (!target || b.hp < target.hp) {
+      target = { blob: b, dist };
+    }
+  });
+  if (target) {
+    target.blob.takeDamage(5);
+    runAnimation(target.blob.el, 'hit-animate');
+  }
+}
+
+function discipleAttack() {
+  if (!DISCIPLE_ATTACK_INTERVAL) return;
+  const fighters = sectSystem.disciples.filter(d => sectState.discipleTasks[d.id] === 'Fight' && !d.incapacitated);
+  if (fighters.length === 0 || blobs.length === 0) return;
+  const now = performance.now();
+  fighters.forEach(d => {
+    if (!d._attackTimer) d._attackTimer = now + DISCIPLE_ATTACK_INTERVAL;
+    if (now >= d._attackTimer) {
+      const el = document.querySelector(`.sect-disciple:nth-child(${sectSystem.disciples.indexOf(d)+1})`);
+      if (!el) return;
+      const rect = el.getBoundingClientRect();
+      const map = getMap();
+      const mapRect = map.getBoundingClientRect();
+      const px = rect.left + rect.width / 2 - mapRect.left;
+      const py = rect.top + rect.height / 2 - mapRect.top;
+      let target = null;
+      blobs.forEach(b => {
+        const dist = Math.hypot(b.x - px, b.y - py);
+        if (dist <= DISCIPLE_RANGE && (!target || b.hp < target.hp)) {
+          target = b;
+        }
+      });
+      if (target) {
+        target.takeDamage(DISCIPLE_DAMAGE);
+        d._attackTimer = now + DISCIPLE_ATTACK_INTERVAL;
+      }
+    }
+  });
+}
+
+export function tickBlobRaid(delta) {
+  spawnTimer += delta;
+  if (spawnTimer >= SPAWN_INTERVAL) {
+    spawnTimer -= SPAWN_INTERVAL;
+    const b = createBlob();
+    if (b) blobs.push(b);
+  }
+  orbAttackTimer += delta;
+  if (orbAttackTimer >= ORB_ATTACK_INTERVAL) {
+    orbAttackTimer -= ORB_ATTACK_INTERVAL;
+    orbAttack();
+  }
+  blobs.forEach(b => b.update(delta));
+  discipleAttack();
+}
+
+export function clearBlobs() {
+  blobs.forEach(b => b.el.remove());
+  blobs.length = 0;
+  spawnTimer = 0;
+  orbAttackTimer = 0;
+}
+
+export function damageClosestBlob(dmg) {
+  if (blobs.length === 0) return;
+  let target = blobs[0];
+  blobs.forEach(b => {
+    if (b.hp < target.hp) target = b;
+  });
+  target.takeDamage(dmg);
+}
+
+export function hasBlobs() {
+  return blobs.length > 0;
+}

--- a/game/raids.js
+++ b/game/raids.js
@@ -2,19 +2,19 @@
 import { sectSystem } from './sect.js';
 import {
   sectState,
-  stageData,
-  setCurrentEnemy,
-  currentEnemy
+  setCurrentEnemy
 } from './state.js';
-import { updateRaidLifeBar, updateDealerLifeDisplay } from './ui.js';
-import { showRaidSummaryOverlay } from '../ui/raidSummaryOverlay.js';
-import { orbDamageMultiplier } from './orbSpells.js';
+import { updateDealerLifeDisplay } from './ui.js';
 
-import { spawnDealer } from '../enemySpawning.js';
 import addLog from '../log.js';
 import { showRaidAlert } from './alerts.js';
-import { runAnimation } from '../utils/animation.js';
 import { ensureDiscipleSkills, getTaskSkillProgress } from '../utils/skills.js';
+import {
+  tickBlobRaid,
+  clearBlobs,
+  damageClosestBlob,
+  hasBlobs
+} from './blobRaids.js';
 
 export const raidState = {
   active: false,
@@ -26,35 +26,10 @@ export const raidState = {
   xpStart: {}
 };
 
-function shootWaterBurst(targetEl) {
-  const orb = document.querySelector('#sectOrbs .sect-orb.water');
-  const map = document.getElementById('colonyMap');
-  if (!orb || !map || !targetEl) return;
-  const orbRect = orb.getBoundingClientRect();
-  const targetRect = targetEl.getBoundingClientRect();
-  const mapRect = map.getBoundingClientRect();
-  const proj = document.createElement('div');
-  const dx = targetRect.left + targetRect.width / 2 - (orbRect.left + orbRect.width / 2);
-  const dy = targetRect.top + targetRect.height / 2 - (orbRect.top + orbRect.height / 2);
-  const dist = Math.hypot(dx, dy);
-  proj.className = 'water-burst';
-  proj.style.left = `${orbRect.left - mapRect.left + orbRect.width / 2}px`;
-  proj.style.top = `${orbRect.top - mapRect.top + orbRect.height / 2}px`;
-  proj.style.setProperty('--dx', `${dx}px`);
-  proj.style.setProperty('--dy', `${dy}px`);
-  proj.style.setProperty('--duration', `${Math.max(300, dist)}ms`);
-  map.appendChild(proj);
-  proj.addEventListener('animationend', () => proj.remove(), { once: true });
-  runAnimation(targetEl, 'hit-animate');
-  runAnimation(orb, 'orb-burst');
-}
-
-const ORB_INTERVAL = 10000; // ms
+// blob raids handle their own visuals and timing
 
 export function startRaid() {
   if (raidState.active) return;
-  const stage = Math.max(1, stageData.stage);
-  const world = stageData.world;
   raidState.damageDealt = 0;
   raidState.damageReceived = 0;
   raidState.xpStart = {};
@@ -70,78 +45,30 @@ export function startRaid() {
       };
     }
   });
-  const onAttack = enemy => {
-    let dmg = enemy.damage;
-    const fighters = sectSystem.disciples.filter(
-      d => sectState.discipleTasks[d.id] === 'Fight' && !d.incapacitated
-    );
-    if (fighters.length > 0) {
-      const target = fighters[Math.floor(Math.random() * fighters.length)];
-      raidState.damageReceived += dmg;
-      const before = target.water;
-      const blocked = Math.min(before, dmg);
-      target.water -= blocked;
-      dmg -= blocked;
-      if (dmg > 0) {
-        target.currentHp = Math.max(0, target.currentHp - dmg);
-        if (target.currentHp === 0) target.incapacitated = true;
-      }
-      if (typeof updateSectDisplay === 'function') updateSectDisplay();
-      return;
+  clearBlobs();
+  raidState.enemy = {
+    maxHp: 20,
+    currentHp: 20,
+    takeDamage(dmg) {
+      damageClosestBlob(dmg);
+    },
+    isDefeated() {
+      return !hasBlobs();
+    },
+    tick(dt) {
+      tickBlobRaid(dt);
     }
-    raidState.damageReceived += dmg;
-    sectSystem.orbs.water.current = Math.max(0, sectSystem.orbs.water.current - dmg);
-    const orbEl = document.querySelector('#sectOrbs .sect-orb.water');
-    if (orbEl) runAnimation(orbEl, 'orb-hit');
-    if (sectSystem.orbs.water.current === 0) {
-      sectState.fruits = Math.floor(sectState.fruits * 0.5);
-      sectState.softwood = Math.floor(sectState.softwood * 0.5);
-      addLog('Raiders plunder your supplies!', 'damage');
-      endRaid();
-    }
-    if (typeof updateSectDisplay === 'function') updateSectDisplay();
   };
-  const onDefeat = () => {
-    sectState.undeadNectar = (sectState.undeadNectar || 0) + 1;
-    if (sectSystem.resources.undeadNectar) {
-      const res = sectSystem.resources.undeadNectar;
-      res.current = Math.min(res.max, res.current + 1);
-      res.unlocked = true;
-    }
-    addLog('Raiders dropped Undead Nectar!', 'good');
-    endRaid();
-    const fighters = Object.entries(raidState.xpStart).map(([id, info]) => {
-      ensureDiscipleSkills(id);
-      const endXp = sectState.discipleSkills[id].Combat || 0;
-      const gained = endXp - info.xp;
-      const startLvl = info.level;
-      const endProg = getTaskSkillProgress(endXp);
-      return {
-        name: info.name,
-        xp: gained,
-        leveled: endProg.level > startLvl,
-        level: endProg.level,
-        progress: endProg.progress
-      };
-    });
-    raidState.xpStart = {};
-    showRaidSummaryOverlay({
-      damageDealt: raidState.damageDealt,
-      damageReceived: raidState.damageReceived,
-      rewards: { undeadNectar: 1 },
-      fighters
-    });
-  };
-  raidState.enemy = spawnDealer({ stage, world }, 0, onAttack, onDefeat);
   setCurrentEnemy(raidState.enemy);
-  updateRaidLifeBar(raidState.enemy);
 
   raidState.active = true;
   raidState.attackTimers = {};
   raidState.orbTimer = 0;
   addLog('Raiders have attacked!', 'info');
   showRaidAlert('Raiders incoming!');
-  document.dispatchEvent(new CustomEvent('raid-start', { detail: raidState.enemy }));
+  document.dispatchEvent(
+    new CustomEvent('raid-start', { detail: { enemy: raidState.enemy, useCard: false } })
+  );
   if (typeof updateSectDisplay === 'function') updateSectDisplay();
 }
 
@@ -153,6 +80,7 @@ export function endRaid() {
   raidState.attackTimers = {};
   raidState.orbTimer = 0;
   raidState.xpStart = {};
+  clearBlobs();
   addLog('The raid has ended.', 'info');
   updateDealerLifeDisplay(null);
   document.dispatchEvent(new CustomEvent('raid-end'));
@@ -161,18 +89,6 @@ export function endRaid() {
 
 export function tickRaid(delta) {
   if (!raidState.active || !raidState.enemy) return;
-  if (raidState.enemy !== currentEnemy) raidState.enemy.tick(delta);
-  raidState.orbTimer += delta;
-  if (raidState.orbTimer >= ORB_INTERVAL) {
-    raidState.orbTimer -= ORB_INTERVAL;
-    const dmg = 5 * orbDamageMultiplier();
-    raidState.enemy.takeDamage(dmg);
-    raidState.damageDealt += dmg;
-    const card = document.querySelector('.raidCardContainer .dCardPane');
-    shootWaterBurst(card);
-    if (raidState.enemy) {
-      updateRaidLifeBar(raidState.enemy);
-      if (raidState.enemy.isDefeated()) endRaid();
-    }
-  }
+  raidState.enemy.tick(delta);
+  if (raidState.enemy.isDefeated()) endRaid();
 }

--- a/game/ui.js
+++ b/game/ui.js
@@ -32,7 +32,7 @@ export function init(elements = {}) {
 
 export const handContainer = document.getElementsByClassName('handContainer')[0];
 export const dealerLifeDisplay =
-  document.getElementsByClassName('dealerLifeDisplay')[0];
+  document.getElementsByClassName('dealerLifeDisplay')[0] || null;
 
 export function showPlayerAttackBar() {
   const bar = document.getElementById('playerAttackBar');
@@ -57,7 +57,7 @@ export function removeDealerLifeBar() {
   if (bar) bar.remove();
   const atk = document.querySelector('.enemyAttackBar');
   if (atk) atk.remove();
-  dealerLifeDisplay.textContent = '';
+  if (dealerLifeDisplay) dealerLifeDisplay.textContent = '';
 }
 
 export function updateDealerLifeDisplay(currentEnemy) {
@@ -65,6 +65,7 @@ export function updateDealerLifeDisplay(currentEnemy) {
     removeDealerLifeBar();
     return;
   }
+  if (!dealerLifeDisplay) return;
   dealerLifeDisplay.textContent = `Life: ${formatNumber(currentEnemy.currentHp)}/${formatNumber(currentEnemy.maxHp)}`;
   renderDealerLifeBar(dealerLifeDisplay, currentEnemy);
   renderDealerLifeBarFill(currentEnemy);

--- a/script.js
+++ b/script.js
@@ -1366,13 +1366,14 @@ function init() {
   document.addEventListener('raid-start', e => {
     setInCombat(true);
     removeDealerLifeBar();
-    setCurrentEnemy(e.detail);
-    renderDealerCard(dom.raidCardContainer);
-
-  
-    
-
-    enemyAttackFill = renderEnemyAttackBar();
+    const detail = e.detail || {};
+    const enemy = detail.enemy ?? detail;
+    const useCard = detail.useCard !== false;
+    setCurrentEnemy(enemy);
+    if (useCard) {
+      renderDealerCard(dom.raidCardContainer);
+      enemyAttackFill = renderEnemyAttackBar();
+    }
     showPlayerAttackBar();
   });
   document.addEventListener('raid-end', () => {

--- a/style.css
+++ b/style.css
@@ -3991,3 +3991,5 @@ body.darkenshift-mode .tabsContainer button.active {
   margin-top: 2px;
 }
 
+
+.slow-blob{position:absolute;background:purple;border-radius:50%;width:16px;height:16px;}


### PR DESCRIPTION
## Summary
- implement basic SlowBlob raid enemies that spawn every 5s
- update raid loop to manage blobs instead of dealer cards
- adjust UI event handler to skip dealer card when unused
- document new raid behavior
- minor styling for blob enemies

## Testing
- `npm run lint`
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68841386d41c8326a9b3f873dcc44873