### PR TITLE
fix: display water row

### DIFF
--- a/script.js
+++ b/script.js
@@ -970,7 +970,7 @@ function buildDiscipleGeneralView(d) {
   const waterRate = document.createElement('span');
   waterRate.textContent = ` (+${calculateWaterRegen(waterLvl).toFixed(2)}/s)`;
   waterRow.appendChild(waterRate);
-  vit.appendChild(hungerRow);
+  vit.appendChild(waterRow);
   body.appendChild(vit);
 
   const task = document.createElement('div');


### PR DESCRIPTION
## Summary
- fix disciple overlay not displaying water stat

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6884179dc550832696fa9be307b9b10f