### PR TITLE
Add orb light particle effects

### DIFF
--- a/docs/16-water-orb.md
+++ b/docs/16-water-orb.md
@@ -10,6 +10,7 @@
 - The orb fill displays the current Water against its maximum capacity.
 - At night the orb glows with a bright blue hue, illuminating nearby terrain using a Pixi.js GlowFilter (radius ~30, outer strength ~2.5, inner strength ~0.5).
 - The glow color is `#7fd9ff` and brightness is boosted 50% at night to help the orb stand out against the dimmed map.
+- Soft light particles swirl around the orb at night, further brightening the surrounding darkness.
 - The orb now holds up to 20 Water and regenerates at a flat 0.1 Water per second.
 - Orb Revival research grants access to an Orb Management panel showing spells like Water Burst.
 - Word of Haste orb spell speeds up work tasks for one minute at the cost of 15 Water.

--- a/game/orbGlow.js
+++ b/game/orbGlow.js
@@ -5,6 +5,24 @@ let glowFilter = null;
 let app = null;
 let enabled = false;
 let time = 0;
+let orbRadius = 0;
+let particleContainer = null;
+const particles = [];
+
+function resetParticle(p) {
+  if (!p || !orbRadius) return;
+  p.life = 0.5 + Math.random() * 1.5;
+  p.maxLife = p.life;
+  const angle = Math.random() * Math.PI * 2;
+  const speed = 20 + Math.random() * 30;
+  p.vx = Math.cos(angle) * speed;
+  p.vy = Math.sin(angle) * speed;
+  p.sprite.x = orbRadius;
+  p.sprite.y = orbRadius;
+  p.sprite.alpha = 1;
+  const scale = 0.5 + Math.random() * 0.5;
+  p.sprite.scale.set(scale);
+}
 
 export function attachOrbGlow(element) {
   if (!element || orbSprite) return;
@@ -22,6 +40,20 @@ export function attachOrbGlow(element) {
   orbSprite.drawCircle(w / 2, h / 2, Math.min(w, h) / 2);
   orbSprite.endFill();
   app.stage.addChild(orbSprite);
+  orbRadius = Math.min(w, h) / 2;
+  particleContainer = new PIXI.Container();
+  particleContainer.visible = false;
+  app.stage.addChild(particleContainer);
+  for (let i = 0; i < 20; i++) {
+    const g = new PIXI.Graphics();
+    g.beginFill(0x7fd9ff);
+    g.drawCircle(0, 0, 2);
+    g.endFill();
+    g.blendMode = PIXI.BLEND_MODES.ADD;
+    particleContainer.addChild(g);
+    particles.push({ sprite: g, vx: 0, vy: 0, life: 0, maxLife: 0 });
+    resetParticle(particles[i]);
+  }
   glowFilter = new PIXI.filters.GlowFilter({
     distance: 30,
     outerStrength: 2.5,
@@ -34,12 +66,15 @@ export function attachOrbGlow(element) {
 export function enableOrbGlow() {
   if (!orbSprite) return;
   orbSprite.filters = [glowFilter];
+  if (particleContainer) particleContainer.visible = true;
   enabled = true;
+  particles.forEach(resetParticle);
 }
 
 export function disableOrbGlow() {
   if (!orbSprite) return;
   orbSprite.filters = [];
+  if (particleContainer) particleContainer.visible = false;
   enabled = false;
 }
 
@@ -47,4 +82,11 @@ export function updateOrbGlow(delta) {
   if (!glowFilter || !enabled) return;
   time += delta / 1000;
   glowFilter.distance = 30 + Math.sin(time) * 5;
+  particles.forEach(p => {
+    p.life -= delta / 1000;
+    p.sprite.x += p.vx * (delta / 1000);
+    p.sprite.y += p.vy * (delta / 1000);
+    p.sprite.alpha = Math.max(0, p.life / p.maxLife);
+    if (p.life <= 0) resetParticle(p);
+  });
 }


### PR DESCRIPTION
## Summary
- add particle system to orb glow visuals
- document nighttime particles for Water Orb

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68841870d88c83269a2924ff7e96b6c8