### PR TITLE
Fix raid enemy spawn timing

### DIFF
--- a/game/blobRaids.js
+++ b/game/blobRaids.js
@@ -13,6 +13,11 @@ export const blobs = [];
 let spawnTimer = 0;
 let orbAttackTimer = 0;
 
+export function spawnBlob() {
+  const blob = createBlob();
+  if (blob) blobs.push(blob);
+}
+
 function getMap() {
   return document.getElementById('colonyMap');
 }

--- a/game/raids.js
+++ b/game/raids.js
@@ -11,6 +11,7 @@ import { showRaidAlert } from './alerts.js';
 import { ensureDiscipleSkills, getTaskSkillProgress } from '../utils/skills.js';
 import {
   tickBlobRaid,
+  spawnBlob,
   clearBlobs,
   damageClosestBlob,
   hasBlobs
@@ -48,6 +49,7 @@ export function startRaid() {
     }
   });
   clearBlobs();
+  spawnBlob();
   raidState.enemy = {
     maxHp: 20,
     currentHp: 20,


### PR DESCRIPTION
## Summary
- ensure a blob spawns immediately when a raid begins
- export a helper to spawn blobs for raids

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68841bd8f87c83268bbda0336802ab40