### PR TITLE
Fix debug buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,11 @@ This is not a standard Wuxia knockoff — **Taino and Caribbean mysticism** blen
 
 ## Dev Tools
 
-Run the game with the `?dev` query parameter to enable a debug panel.
-It offers helpers like spawning bosses, toggling fast mode, and skipping
-directly to the next night. A new button lets you toggle the sect map's
-zone overlays on or off for layout testing. You can also grant yourself
+The game includes a built-in debug panel with helpers like spawning
+bosses, toggling fast mode, and skipping directly to the next night.
+The panel loads its logic the first time you click any debug button, so
+no special query parameter is required. A button also lets you toggle
+sect map zone overlays for layout testing, and you can grant yourself
 extra fruit by entering an amount and clicking **Give**.
 
 ### Building

--- a/docs/module-structure.md
+++ b/docs/module-structure.md
@@ -9,7 +9,8 @@ The project organizes game logic under the `game/` directory.
 - **game/combat.js** – centralizes all combat logic including damage
   resolution and disciple hit animations.
 - **game/debug.js** – wiring for optional debug controls.
-- **debugTools.js** – development helpers loaded when `?dev` is present.
+- **debugTools.js** – development helpers lazily loaded when a debug
+  button is clicked.
 - **game/zones.js** – toggles visibility of sect map zone elements.
 - **game/constants.js** – collection of shared gameplay constants used across systems.
 - **game/tooltip.js** – simple helpers for showing and hiding the UI tooltip.

--- a/index.html
+++ b/index.html
@@ -205,15 +205,18 @@
     </div>
     <div id="tooltip"></div>
     <script type="module" src="script.js"></script>
-    <script>window.devTools = new Proxy({}, { get: () => () => {} });</script>
     <script type="module">
-      const isDev = (typeof process !== 'undefined' && process.env && process.env.NODE_ENV === 'development') ||
-                    new URLSearchParams(window.location.search).has('dev');
-      if (isDev) {
-        import('./debugTools.js').then(m => {
-          window.devTools = m.devTools;
-        });
-      }
+      window.devTools = new Proxy(
+        {},
+        {
+          get: (_, prop) => (...args) => {
+            import('./debugTools.js').then(m => {
+              window.devTools = m.devTools;
+              window.devTools[prop]?.(...args);
+            });
+          }
+        }
+      );
     </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- lazy load debug tools automatically when a debug button is clicked
- update README dev tool instructions
- document new lazy load behaviour in module overview

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68841be2ef488326ae7d852b79e6ea03