### PR TITLE
feat: add orb light mask

### DIFF
--- a/docs/16-water-orb.md
+++ b/docs/16-water-orb.md
@@ -11,6 +11,7 @@
 - At night the orb glows with a bright blue hue, illuminating nearby terrain using a Pixi.js GlowFilter (radius ~30, outer strength ~2.5, inner strength ~0.5).
 - The glow color is `#7fd9ff` and brightness is boosted 50% at night to help the orb stand out against the dimmed map.
 - Soft light particles swirl around the orb at night, further brightening the surrounding darkness.
+- A radial light mask darkens the map at night while leaving a bright gradient around the orb.
 - The orb now holds up to 20 Water and regenerates at a flat 0.1 Water per second.
 - Orb Revival research grants access to an Orb Management panel showing spells like Water Burst.
 - Word of Haste orb spell speeds up work tasks for one minute at the cost of 15 Water.

--- a/game/orbMask.js
+++ b/game/orbMask.js
@@ -1,0 +1,38 @@
+let overlay = null;
+let map = null;
+
+function update() {
+  if (!overlay || !map) return;
+  const orb = document.querySelector('#sectOrbs .sect-orb.water');
+  if (!orb) return;
+  const mapRect = map.getBoundingClientRect();
+  const orbRect = orb.getBoundingClientRect();
+  const x = orbRect.left + orbRect.width / 2 - mapRect.left;
+  const y = orbRect.top + orbRect.height / 2 - mapRect.top;
+  overlay.style.setProperty('--orb-x', `${x}px`);
+  overlay.style.setProperty('--orb-y', `${y}px`);
+}
+
+export function initOrbMask() {
+  map = document.getElementById('colonyMap');
+  if (!map) return;
+  overlay = document.createElement('div');
+  overlay.id = 'orbLightMask';
+  overlay.style.display = 'none';
+  map.appendChild(overlay);
+  update();
+  window.addEventListener('resize', update);
+  window.addEventListener('orbs-changed', update);
+}
+
+export function showOrbMask() {
+  if (overlay) overlay.style.display = 'block';
+}
+
+export function hideOrbMask() {
+  if (overlay) overlay.style.display = 'none';
+}
+
+export function updateOrbMaskPosition() {
+  update();
+}

--- a/script.js
+++ b/script.js
@@ -119,6 +119,7 @@ import { raidState } from './game/raids.js';
 // developer debug tools
 import { init as initDebug } from "./game/debug.js";
 import { attachOrbGlow, enableOrbGlow, disableOrbGlow, updateOrbGlow } from './game/orbGlow.js';
+import { initOrbMask, showOrbMask, hideOrbMask, updateOrbMaskPosition } from './game/orbMask.js';
 // Shared game state and configuration
 import {
   currentEnemy,
@@ -1319,6 +1320,8 @@ function init() {
   }
   checkBuildingUnlock();
   updateSectDisplay();
+  initOrbMask();
+  window.addEventListener('orbs-changed', updateOrbMaskPosition);
   initVignetteToggles();
   if (window.lucide) lucide.createIcons({ icons: lucide.icons });
   initMetamorphosis();
@@ -1347,8 +1350,11 @@ function init() {
     setNightMode(e.detail.phase === 'Night');
     if (e.detail.phase === 'Night') {
       enableOrbGlow();
+      showOrbMask();
+      updateOrbMaskPosition();
     } else {
       disableOrbGlow();
+      hideOrbMask();
     }
     if (e.detail.action !== 'Work')  {
       sectSystem.disciples.forEach(d => {

--- a/style.css
+++ b/style.css
@@ -3101,6 +3101,20 @@ body.darkenshift-mode .tabsContainer button.active {
     transition: filter 2s linear;
 }
 
+#orbLightMask {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background: radial-gradient(circle at var(--orb-x, 50%) var(--orb-y, 50%), rgba(0,0,0,0) 0%, rgba(0,0,0,0.5) 60%, rgba(0,0,0,0.8) 100%);
+    mix-blend-mode: multiply;
+    z-index: 4;
+    display: none;
+}
+
+.colony-map.night #orbLightMask {
+    display: block;
+}
+
 .disciple-progress {
     position: relative;
     width: 120px;


### PR DESCRIPTION
## Summary
- create `orbMask` module for applying a radial light mask
- style radial mask element in `style.css`
- hook mask into init and night/day transitions
- document orb mask behavior

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688446feeef483269f4a420384e658ec