### PR TITLE
Fix raid spawn timing

### DIFF
--- a/game/blobRaids.js
+++ b/game/blobRaids.js
@@ -13,9 +13,18 @@ export const blobs = [];
 let spawnTimer = 0;
 let orbAttackTimer = 0;
 
+export function canSpawn() {
+  return !!getMap() && !!getOrb();
+}
+
 export function spawnBlob() {
+  if (!canSpawn()) return false;
   const blob = createBlob();
-  if (blob) blobs.push(blob);
+  if (blob) {
+    blobs.push(blob);
+    return true;
+  }
+  return false;
 }
 
 function getMap() {
@@ -151,11 +160,15 @@ function discipleAttack() {
 }
 
 export function tickBlobRaid(delta) {
+  if (!hasBlobs() && canSpawn()) {
+    if (spawnBlob()) {
+      spawnTimer = 0;
+    }
+  }
   spawnTimer += delta;
   if (spawnTimer >= SPAWN_INTERVAL) {
     spawnTimer -= SPAWN_INTERVAL;
-    const b = createBlob();
-    if (b) blobs.push(b);
+    spawnBlob();
   }
   orbAttackTimer += delta;
   if (orbAttackTimer >= ORB_ATTACK_INTERVAL) {

--- a/game/raids.js
+++ b/game/raids.js
@@ -14,7 +14,8 @@ import {
   spawnBlob,
   clearBlobs,
   damageClosestBlob,
-  hasBlobs
+  hasBlobs,
+  canSpawn
 } from './blobRaids.js';
 
 export const raidState = {
@@ -57,6 +58,7 @@ export function startRaid() {
       damageClosestBlob(dmg);
     },
     isDefeated() {
+      if (!canSpawn()) return false;
       return !hasBlobs();
     },
     tick(dt) {


### PR DESCRIPTION
## Summary
- avoid premature raid ending when map elements aren't yet available
- ensure blob raid spawns only when DOM is ready
- spawn raiders immediately once the map and orb exist

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688447123a3083269e416f709f544aca