### PR TITLE
Increase water orb glow

### DIFF
--- a/docs/16-water-orb.md
+++ b/docs/16-water-orb.md
@@ -8,8 +8,8 @@
 - Disciples can direct % of personal Water to orb.
 - The orb is now larger and displays its regeneration rate centered within.
 - The orb fill displays the current Water against its maximum capacity.
-- At night the orb glows with a bright blue hue, illuminating nearby terrain using a Pixi.js GlowFilter (radius ~30, outer strength ~2.5, inner strength ~0.5).
-- The glow color is `#7fd9ff` and brightness is boosted 50% at night to help the orb stand out against the dimmed map.
+- At night the orb glows with a bright blue hue, illuminating nearby terrain using a Pixi.js GlowFilter (radius ~30, outer strength ~4, inner strength ~1).
+- The glow color is `#7fd9ff` and brightness is doubled at night to help the orb stand out against the dimmed map.
 - Soft light particles swirl around the orb at night, further brightening the surrounding darkness.
 - A radial light mask darkens the map at night while leaving a bright gradient around the orb.
 - The orb now holds up to 20 Water and regenerates at a flat 0.1 Water per second.

--- a/game/orbGlow.js
+++ b/game/orbGlow.js
@@ -56,8 +56,8 @@ export function attachOrbGlow(element) {
   }
   glowFilter = new PIXI.filters.GlowFilter({
     distance: 30,
-    outerStrength: 2.5,
-    innerStrength: 0.5,
+    outerStrength: 4,
+    innerStrength: 1,
     color: 0x7fd9ff
   });
   orbSprite.filters = [];

--- a/script.js
+++ b/script.js
@@ -779,7 +779,7 @@ function applyNightFilters(brightness) {
   document.querySelectorAll('#sectOrbs .sect-orb.water').forEach(o => {
     if (!o.dataset.baseFilter) o.dataset.baseFilter = o.style.filter || '';
     if (brightness < 1) {
-      o.style.filter = `${o.dataset.baseFilter} brightness(${inv * 1.5}) saturate(1.2)`;
+      o.style.filter = `${o.dataset.baseFilter} brightness(${inv * 2}) saturate(1.2)`;
     } else {
       o.style.filter = o.dataset.baseFilter;
     }


### PR DESCRIPTION
## Summary
- boost nighttime orb brightness multiplier
- intensify GlowFilter effect for the Water orb
- document new glow values

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6884e0da61b08326bb7908f0169aca9e