### PR TITLE
refactor: centralize rendering

### DIFF
--- a/game/combat.js
+++ b/game/combat.js
@@ -1,11 +1,10 @@
 import { currentEnemy, stageData, sectState, playerStats } from './state.js';
 import { dealerLifeDisplay } from './ui.js';
-import { renderDealerLifeBarFill, removeBloodSplat, updateBloodSplat } from '../rendering.js';
+import { renderDealerLifeBarFill, removeBloodSplat, updateBloodSplat, animateDiscipleHit, showDamageFloat, animateDiscipleDeath } from './rendering.js';
 import { formatNumber } from '../utils/numberFormat.js';
 import { activeDisciples } from './disciples.js';
 import { calculateEnemyBasicDamage } from '../enemySpawning.js';
 import { sectSystem } from './sect.js';
-import { runAnimation } from '../utils/animation.js';
 import { showRestartScreen } from '../ui/restartOverlay.js';
 import addLog from '../log.js';
 import { raidState } from './raids.js';
@@ -57,38 +56,6 @@ export function setPartyDefeatHandler(fn) {
   partyDefeatHandler = fn;
 }
 
-export function animateDiscipleHit(card) {
-  const w = card.wrapperElement;
-  if (!w) return;
-  const target = card.cardElement || w;
-  runAnimation(target, 'hit-animate');
-}
-
-export function showDamageFloat(card, amount) {
-  const hp = card.hpDisplay;
-  if (!hp) return;
-  const dmg = document.createElement('div');
-  dmg.classList.add('damage-float');
-  dmg.textContent = `-${amount}`;
-  hp.appendChild(dmg);
-  dmg.addEventListener(
-    'animationend',
-    () => dmg.remove(),
-    {
-      once: true
-    }
-  );
-  setTimeout(() => dmg.remove(), 3000);
-}
-
-export function animateDiscipleDeath(card, callback) {
-  const w = card.wrapperElement;
-  if (!w) {
-    callback?.();
-    return;
-  }
-  runAnimation(w, 'card-death', 600).then(() => callback?.());
-}
 
 export function cDealerDamage(damageAmount = null, source = 'dealer') {
   const targets = activeDisciples;

--- a/game/rendering.js
+++ b/game/rendering.js
@@ -1,3 +1,5 @@
+import { runAnimation } from '../utils/animation.js';
+
 export function renderDealerLifeBar(dealerLifeDisplay, currentEnemy) {
   if (document.querySelector('.dealerLifeContainer')) return;
   const container = document.createElement('div');
@@ -131,4 +133,37 @@ export function updateBloodSplat(card) {
   } else {
     removeBloodSplat(card);
   }
+}
+
+export function animateDiscipleHit(card) {
+  const w = card.wrapperElement;
+  if (!w) return;
+  const target = card.cardElement || w;
+  runAnimation(target, 'hit-animate');
+}
+
+export function showDamageFloat(card, amount) {
+  const hp = card.hpDisplay;
+  if (!hp) return;
+  const dmg = document.createElement('div');
+  dmg.classList.add('damage-float');
+  dmg.textContent = `-${amount}`;
+  hp.appendChild(dmg);
+  dmg.addEventListener(
+    'animationend',
+    () => dmg.remove(),
+    {
+      once: true
+    }
+  );
+  setTimeout(() => dmg.remove(), 3000);
+}
+
+export function animateDiscipleDeath(card, callback) {
+  const w = card.wrapperElement;
+  if (!w) {
+    callback?.();
+    return;
+  }
+  runAnimation(w, 'card-death', 600).then(() => callback?.());
 }

--- a/game/ui.js
+++ b/game/ui.js
@@ -1,6 +1,5 @@
-import { renderDealerLifeBar, renderDealerLifeBarFill } from '../rendering.js';
+import { renderDealerLifeBar, renderDealerLifeBarFill, renderDiscipleCard } from './rendering.js';
 import { activeDisciples } from './disciples.js';
-import { renderDiscipleCard } from '../rendering.js';
 import { formatNumber } from '../utils/numberFormat.js';
 let mainTab;
 let starChartTab;

--- a/script.js
+++ b/script.js
@@ -76,7 +76,7 @@ import {
   applyBloodSplat,
   removeBloodSplat,
   updateBloodSplat
-} from "./rendering.js";
+} from "./game/rendering.js";
 
 // combat mechanics and timers
 import {


### PR DESCRIPTION
## Summary
- move rendering helpers into game/rendering.js
- import new helpers where needed
- remove leftover UI code from combat module

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6884e1585b6883268c018872181ca309