### PR TITLE
Fix premature raid end on blob death

### DIFF
--- a/docs/23-raids.md
+++ b/docs/23-raids.md
@@ -19,6 +19,7 @@ Disciples may be called upon to defend the sect from occasional raids.
 * Fighters absorb damage with their personal Water first. When empty they lose HP.
 * Raiders randomly target a fighter when multiple disciples are on guard.
 * If the orb is depleted the sect loses **half** of its stored fruit and softwood.
+* Early raids send four SlowBlob raiders, one every 10&nbsp;s for 40&nbsp;s.
 
 * The Water orb lashes out every second, striking the closest blob for 5 damage.
 * Blobs show a small health meter as they crawl across the map.

--- a/game/blobRaids.js
+++ b/game/blobRaids.js
@@ -2,7 +2,10 @@ import { sectSystem } from './sect.js';
 import { sectState } from './state.js';
 import { runAnimation } from '../utils/animation.js';
 
-const SPAWN_INTERVAL = 5000; // ms
+// Blobs emerge in waves during raids. One spawns every 10 seconds
+// for a total of four attackers.
+const SPAWN_INTERVAL = 10000; // ms
+const MAX_BLOBS = 4;
 const BLOB_SPEED = 10; // px per second
 const ORB_ATTACK_INTERVAL = 1000; // ms
 const DISCIPLE_ATTACK_INTERVAL = 10000; // ms
@@ -12,6 +15,7 @@ const DISCIPLE_DAMAGE = 3;
 export const blobs = [];
 let spawnTimer = 0;
 let orbAttackTimer = 0;
+let spawnCount = 0;
 
 export function canSpawn() {
   return !!getMap() && !!getOrb();
@@ -19,9 +23,11 @@ export function canSpawn() {
 
 export function spawnBlob() {
   if (!canSpawn()) return false;
+  if (spawnCount >= MAX_BLOBS) return false;
   const blob = createBlob();
   if (blob) {
     blobs.push(blob);
+    spawnCount += 1;
     return true;
   }
   return false;
@@ -160,23 +166,18 @@ function discipleAttack() {
 }
 
 export function tickBlobRaid(delta) {
-  if (!hasBlobs() && canSpawn()) {
-    if (spawnBlob()) {
-      spawnTimer = 0;
-    }
-  }
   spawnTimer += delta;
-  if (spawnTimer >= SPAWN_INTERVAL) {
-    spawnTimer -= SPAWN_INTERVAL;
-    spawnBlob();
-  }
   orbAttackTimer += delta;
+  blobs.forEach(b => b.update(delta));
+  discipleAttack();
   if (orbAttackTimer >= ORB_ATTACK_INTERVAL) {
     orbAttackTimer -= ORB_ATTACK_INTERVAL;
     orbAttack();
   }
-  blobs.forEach(b => b.update(delta));
-  discipleAttack();
+  if (spawnTimer >= SPAWN_INTERVAL) {
+    spawnTimer -= SPAWN_INTERVAL;
+    if (spawnCount < MAX_BLOBS) spawnBlob();
+  }
 }
 
 export function clearBlobs() {
@@ -184,6 +185,7 @@ export function clearBlobs() {
   blobs.length = 0;
   spawnTimer = 0;
   orbAttackTimer = 0;
+  spawnCount = 0;
 }
 
 export function damageClosestBlob(dmg) {
@@ -197,4 +199,8 @@ export function damageClosestBlob(dmg) {
 
 export function hasBlobs() {
   return blobs.length > 0;
+}
+
+export function raidFinished() {
+  return spawnCount >= MAX_BLOBS && blobs.length === 0;
 }

--- a/game/raids.js
+++ b/game/raids.js
@@ -14,8 +14,8 @@ import {
   spawnBlob,
   clearBlobs,
   damageClosestBlob,
-  hasBlobs,
-  canSpawn
+  canSpawn,
+  raidFinished
 } from './blobRaids.js';
 
 export const raidState = {
@@ -74,7 +74,7 @@ export function startRaid() {
     },
     isDefeated() {
       if (!canSpawn()) return false;
-      return !hasBlobs();
+      return raidFinished();
     },
     tick(dt) {
       tickBlobRaid(dt);


### PR DESCRIPTION
## Summary
- ensure blob raids respawn before defeat check by reordering tick logic
- limit raid waves to four raiders over 40s

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6884e4419bbc8326aa2ee831b9417af8