### PR TITLE
Add Metamorphosis cleanup function

### DIFF
--- a/docs/module-structure.md
+++ b/docs/module-structure.md
@@ -16,6 +16,6 @@ The project organizes game logic under the `game/` directory.
 - **game/tooltip.js** – simple helpers for showing and hiding the UI tooltip.
 - **game/sect.js** – implements the sect management system including constructs and colony helpers.
 - **game/buildings.js** – handles sect building logic and construction timers.
-- **game/metamorphosis.js** – manages disciple metamorphosis progression and its UI.
+- **game/metamorphosis.js** – manages disciple metamorphosis progression and its UI. Exposes `destroyMetamorphosis()` to clean up event listeners when the interface is rebuilt.
 
 The top-level `script.js` now merely orchestrates initialization, delegating all logic to the modules above.

--- a/game/metamorphosis.js
+++ b/game/metamorphosis.js
@@ -17,11 +17,14 @@ let listContainer;
 let breakthroughBtn;
 let statsContainer;
 let selectedDiscipleId = null;
+let breakthroughHandler;
 const RING_RADIUS = 80;
 const RING_CIRCUMFERENCE = 2 * Math.PI * RING_RADIUS;
 const STAGE_NAMES = ['Egg', 'Tadpole', 'Young Coquí', 'Elder Frog', 'Divine Coquí'];
 
 export function initMetamorphosis() {
+  // Clean up any existing listeners before reinitializing
+  destroyMetamorphosis();
   container = document.getElementById('metamorphosisTabContent');
   listContainer = document.getElementById('metamorphosisDiscipleList');
   statsContainer = document.getElementById('metamorphosisStats');
@@ -73,9 +76,10 @@ const bodyPath = `M200 150
   ringWrapper = container.querySelector('.metamorphosis-progress');
   breakthroughBtn = container.querySelector('#breakthroughBtn');
   if (breakthroughBtn) {
-    breakthroughBtn.addEventListener('click', () => {
+    breakthroughHandler = () => {
       if (selectedDiscipleId) breakthrough(selectedDiscipleId);
-    });
+    };
+    breakthroughBtn.addEventListener('click', breakthroughHandler);
   }
   selectedDiscipleId = sectSystem.disciples[0]?.id || null;
   window.addEventListener('orbs-changed', renderMetamorphosis);
@@ -177,6 +181,24 @@ function renderMetamorphosis() {
 
 export function refreshMetamorphosis() {
   renderMetamorphosis();
+}
+
+export function destroyMetamorphosis() {
+  if (breakthroughBtn && breakthroughHandler) {
+    breakthroughBtn.removeEventListener('click', breakthroughHandler);
+  }
+  window.removeEventListener('orbs-changed', renderMetamorphosis);
+  document.removeEventListener('disciple-gained', refreshMetamorphosis);
+  breakthroughHandler = null;
+  container = null;
+  progressFill = null;
+  progressText = null;
+  ringFill = null;
+  ringWrapper = null;
+  listContainer = null;
+  breakthroughBtn = null;
+  statsContainer = null;
+  selectedDiscipleId = null;
 }
 
 export function tickMetamorphosis(dt) {

--- a/script.js
+++ b/script.js
@@ -40,7 +40,11 @@ import {
 } from './game/buildings.js';
 import { formatNumber } from "./utils/numberFormat.js";
 import { runAnimation } from "./utils/animation.js";
-import { initMetamorphosis, refreshMetamorphosis } from './game/metamorphosis.js';
+import {
+  initMetamorphosis,
+  refreshMetamorphosis,
+  destroyMetamorphosis
+} from './game/metamorphosis.js';
 import { intelligenceXpMultiplier } from './game/attributes.js';
 import { createOverlay } from './ui/overlay.js';
 import { showLoadErrorOverlay } from './ui/loadErrorOverlay.js';
@@ -2224,12 +2228,13 @@ function hideSpeakerQuote() {
 
 // Fully wipe saved data and reload the page
 export function startNewGame() {
-if (typeof localStorage !== "undefined") {
-localStorage.removeItem("gameSave");
-}
-window.removeEventListener("beforeunload", saveGame);
-clearInterval(saveInterval);
-location.reload();
+  destroyMetamorphosis();
+  if (typeof localStorage !== "undefined") {
+    localStorage.removeItem("gameSave");
+  }
+  window.removeEventListener("beforeunload", saveGame);
+  clearInterval(saveInterval);
+  location.reload();
 }
 
 // Regroup disciples and refresh the combat party


### PR DESCRIPTION
## Summary
- add `destroyMetamorphosis` to remove event listeners and clear refs
- ensure `initMetamorphosis` cleans up before re‑initializing
- clean up metamorphosis when starting a new run
- document cleanup helper in `module-structure.md`

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68851aae84b88326bc3b097ee439d996