### PR TITLE
Make metamorphosis stats panel collapsible

### DIFF
--- a/docs/21-metamorphosis-ui.md
+++ b/docs/21-metamorphosis-ui.md
@@ -21,7 +21,7 @@ Egg → Tail → Limbs → Body → Crown. Hovering near a threshold causes the 
 
 ## Optional Modifiers Panel
 
-The game displays a stats panel on the right side of the metamorphosis screen. This panel lists the season, room and weather multipliers that affect the growth formula and shows the resulting XP per second. **Hover over any stat** to view a tooltip detailing how that value is calculated.
+A collapsible stats panel can be toggled from the right edge of the metamorphosis screen. Click the arrow handle to slide the panel in or out. It lists the season, room and weather multipliers that affect the growth formula and shows the resulting XP per second. **Hover over any stat** to view a tooltip detailing how that value is calculated.
 
 ## Formula
 

--- a/game/metamorphosis.js
+++ b/game/metamorphosis.js
@@ -16,6 +16,8 @@ let ringWrapper;
 let listContainer;
 let breakthroughBtn;
 let statsContainer;
+let statsPanel;
+let statsToggle;
 let selectedDiscipleId = null;
 const RING_RADIUS = 80;
 const RING_CIRCUMFERENCE = 2 * Math.PI * RING_RADIUS;
@@ -25,6 +27,8 @@ export function initMetamorphosis() {
   container = document.getElementById('metamorphosisTabContent');
   listContainer = document.getElementById('metamorphosisDiscipleList');
   statsContainer = document.getElementById('metamorphosisStats');
+  statsPanel = document.querySelector('.metamorphosis-stats-panel');
+  statsToggle = document.getElementById('metaStatsToggle');
   if (!container) return;
 const bodyPath = `M200 150
                m -25 0
@@ -83,6 +87,13 @@ const bodyPath = `M200 150
   document.addEventListener('disciple-gained', refreshMetamorphosis);
   renderDiscipleList();
   renderMetamorphosis();
+  if (statsToggle) {
+    statsToggle.addEventListener('click', toggleStatsPanel);
+    statsToggle.addEventListener('mouseenter', e => {
+      window.showTooltip('Toggle stats panel', e.pageX + 10, e.pageY + 10);
+    });
+    statsToggle.addEventListener('mouseleave', window.hideTooltip);
+  }
 }
 
 function ensureMeta(id) {
@@ -254,5 +265,16 @@ function updateStats() {
     });
     el.addEventListener('mouseleave', window.hideTooltip);
   });
+}
+
+function toggleStatsPanel() {
+  if (!statsPanel) return;
+  const open = statsPanel.classList.contains('open');
+  if (open) {
+    statsPanel.classList.remove('open');
+  } else {
+    statsPanel.classList.add('open');
+  }
+  if (statsToggle) statsToggle.textContent = open ? '❮' : '❯';
 }
 

--- a/index.html
+++ b/index.html
@@ -189,6 +189,7 @@
       <div class="metamorphosis-main">
         <div id="metamorphosisTabContent"></div>
       </div>
+      <div id="metaStatsToggle" class="meta-stats-toggle">❮</div>
       <div class="metamorphosis-stats-panel sidePanel">
         <div id="metamorphosisStats"></div>
       </div>

--- a/style.css
+++ b/style.css
@@ -2140,11 +2140,38 @@ body.darkenshift-mode .tabsContainer button.active {
     min-width: 120px;
 }
 .metamorphosis-stats-panel {
+    position: absolute;
+    top: 0;
+    right: 0;
     display: flex;
     flex-direction: column;
     gap: 6px;
     font-size: 0.8rem;
-    min-width: 120px;
+    min-width: 160px;
+    height: 100%;
+    background: rgba(252, 236, 194, 0.95);
+    border-left: 1px solid var(--core-border);
+    box-shadow: -2px 0 6px rgba(0,0,0,0.3);
+    padding: 8px;
+    transform: translateX(100%);
+    transition: transform 0.3s;
+    z-index: 10;
+}
+.metamorphosis-stats-panel.open {
+    transform: translateX(0);
+}
+.meta-stats-toggle {
+    position: absolute;
+    top: 50%;
+    right: 0;
+    transform: translate(100%, -50%);
+    background: var(--core-accent);
+    color: #000;
+    padding: 4px 6px;
+    border-radius: 4px 0 0 4px;
+    cursor: pointer;
+    z-index: 11;
+    user-select: none;
 }
 .metamorphosis-stats-panel .meta-stat {
     background: rgba(252, 236, 194, 0.5);


### PR DESCRIPTION
## Summary
- allow players to toggle metamorphosis stats in a slide-out panel
- update styles for the new modal panel and toggle handle
- document the new behaviour

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68852005b2508326a625ceb6a027e8c2