### PR TITLE
Fix raid summary overlay

### DIFF
--- a/game/combat.js
+++ b/game/combat.js
@@ -73,6 +73,7 @@ export function cDealerDamage(damageAmount = null, source = 'dealer') {
     damageAmount ?? Math.floor(Math.random() * (maxDamage - minDamage + 1)) + minDamage;
 
   let finalDamage = dDamage;
+  if (raidState.active) raidState.damageReceived += finalDamage;
 
   const idx = Math.floor(Math.random() * targets.length);
   const card = targets[idx];

--- a/game/raids.js
+++ b/game/raids.js
@@ -5,6 +5,7 @@ import {
   setCurrentEnemy
 } from './state.js';
 import { updateDealerLifeDisplay } from './ui.js';
+import { showRaidSummaryOverlay } from '../ui/raidSummaryOverlay.js';
 
 import addLog from '../log.js';
 import { showRaidAlert } from './alerts.js';
@@ -93,23 +94,48 @@ export function startRaid() {
   if (typeof updateSectDisplay === 'function') updateSectDisplay();
 }
 
-export function endRaid() {
+export function endRaid(victory = false) {
   if (!raidState.active) return;
+  const enemy = raidState.enemy;
   raidState.active = false;
   setCurrentEnemy(null);
   raidState.enemy = null;
   raidState.attackTimers = {};
   raidState.orbTimer = 0;
+  const xpStart = raidState.xpStart;
   raidState.xpStart = {};
   clearBlobs();
   addLog('The raid has ended.', 'info');
   updateDealerLifeDisplay(null);
-  document.dispatchEvent(new CustomEvent('raid-end'));
+  if (victory && enemy) {
+    const fighters = Object.keys(xpStart).map(id => {
+      const start = xpStart[id];
+      const xp =
+        sectState.discipleSkills[id]?.Combat || 0;
+      const diff = xp - start.xp;
+      const prog = getTaskSkillProgress(xp);
+      return {
+        name: start.name,
+        xp: diff,
+        level: prog.level,
+        progress: prog.progress,
+        leveled: prog.level > start.level
+      };
+    });
+    sectState.undeadNectar = (sectState.undeadNectar || 0) + 1;
+    showRaidSummaryOverlay({
+      damageDealt: raidState.damageDealt,
+      damageReceived: raidState.damageReceived,
+      rewards: { undeadNectar: 1 },
+      fighters
+    });
+  }
+  document.dispatchEvent(new CustomEvent('raid-end', { detail: { victory } }));
   if (typeof updateSectDisplay === 'function') updateSectDisplay();
 }
 
 export function tickRaid(delta) {
   if (!raidState.active || !raidState.enemy) return;
   raidState.enemy.tick(delta);
-  if (raidState.enemy.isDefeated()) endRaid();
+  if (raidState.enemy.isDefeated()) endRaid(true);
 }

--- a/game/sect.js
+++ b/game/sect.js
@@ -1489,7 +1489,7 @@ export function tickSect(delta) {
           raidState.enemy.takeDamage(d.damage);
           updateRaidLifeBar(raidState.enemy);
           raidState.attackTimers[d.id] = 0;
-          if (raidState.enemy.isDefeated()) endRaid();
+          if (raidState.enemy.isDefeated()) endRaid(true);
         }
       }
       xpRate = COMBAT_XP_RATE;


### PR DESCRIPTION
## Summary
- track damage received during raids
- show victory overlay with XP and rewards
- trigger raid victory when all blobs die

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68851e683da08326ade0a21e8a1bd65c