### PR TITLE
Add storage caps for softwood and fruit

### DIFF
--- a/debugTools.js
+++ b/debugTools.js
@@ -72,7 +72,10 @@ export const devTools = {
   giveCash: () => {
     const amount = parseFloat(document.getElementById('debugCash').value);
     if (isNaN(amount)) return;
-    sectState.fruits += amount;
+    sectState.fruits = Math.min(
+      sectState.fruitCap,
+      sectState.fruits + amount
+    );
   },
   toggleZones,
   save: saveGame,

--- a/docs/12-buildings.md
+++ b/docs/12-buildings.md
@@ -13,6 +13,7 @@ progressing through different levels improves the housing building as follows an
 each level provides +1 max disciple. every 10 levels 5% additive to other bonuses.
 levels 1-10: 
 Bohio	20 × (2^lvl)	+1 disciple	each level Start/ allows building research desk
+        +50 softwood cap and +200 fruit cap per level
 Outer Quarters Lv11-20
 Meditation Hall Lv 21-30
 Inner Hall Lv31- 40

--- a/game/buildings.js
+++ b/game/buildings.js
@@ -1,5 +1,5 @@
 // Building-related logic extracted from script.js
-import { sectState, systems } from './state.js';
+import { sectState, systems, updateResourceCaps } from './state.js';
 import { sectSystem } from './sect.js';
 import { addSkillXp, ensureDiscipleSkills, getTaskSkillProgress } from '../utils/skills.js';
 import { intelligenceXpMultiplier } from './attributes.js';
@@ -91,6 +91,7 @@ export function tickBuilding(dt) {
     if (builtKey === 'bohio') {
       sectState.maxDisciples = 3 + sectState.buildings.bohio;
       sectState.housingBonus = 0.05 * Math.floor(sectState.buildings.bohio / 10);
+      updateResourceCaps();
     }
   if (sectState.buildings.bohio >= 1) {
       const shack = document.getElementById('sectBohio');

--- a/game/constants.js
+++ b/game/constants.js
@@ -19,6 +19,8 @@ export const ANIMALS = [
 ];
 export const SOFTWOOD_CYCLE_SECONDS = 215;
 export const SOFTWOOD_CYCLE_AMOUNT = 10;
+export const SOFTWOOD_CAP_BASE = 150;
+export const FRUIT_CAP_BASE = 250;
 // Fruits consumed per disciple each second
 export const FRUIT_CONSUMPTION_RATE = 0.01;
 export const TRAINING_NECTAR_RATE = 0.01;

--- a/game/sect.js
+++ b/game/sect.js
@@ -1463,8 +1463,17 @@ export function tickSect(delta) {
       const yieldMult = 1 + 0.05 * (d[groupAttr] || 0) + 0.02 * lvl;
       const gatherRate = spot.baseYield * yieldMult;
 
-      if (task === 'Gather Fruit') sectState.fruits += gatherRate * dt;
-      else sectState.softwood += gatherRate * dt;
+      if (task === 'Gather Fruit') {
+        sectState.fruits = Math.min(
+          sectState.fruitCap,
+          sectState.fruits + gatherRate * dt
+        );
+      } else {
+        sectState.softwood = Math.min(
+          sectState.softwoodCap,
+          sectState.softwood + gatherRate * dt
+        );
+      }
       if (typeof updateSectDisplay === 'function') updateSectDisplay();
     } else if (task === 'Research') {
       sectState.researchProgress += 4 * dt;

--- a/game/state.js
+++ b/game/state.js
@@ -90,11 +90,15 @@ export const systems = {
 // Fruit gathering and growth configuration
 export const FRUIT_MAX_CAP = 120;
 export const FRUIT_GROWTH_RATES = [60, 40, 30, 20, 0];
+export const SOFTWOOD_CAP_BASE = 150;
+export const FRUIT_CAP_BASE = 250;
 
 export const sectState = {
   fruits: 0,
   softwood: 0,
   undeadNectar: 0,
+  softwoodCap: SOFTWOOD_CAP_BASE,
+  fruitCap: FRUIT_CAP_BASE,
   availableFruits: FRUIT_MAX_CAP,
   animals: { Chicken: 3, Boar: 1, Deer: 0 },
   discipleTasks: {},
@@ -131,4 +135,12 @@ export const FAST_MODE_SCALE = 10;
 export let timeScale = 1;
 export function setTimeScale(value) {
   timeScale = value;
+}
+
+export function updateResourceCaps() {
+  const lvl = sectState.buildings.bohio || 0;
+  sectState.softwoodCap = SOFTWOOD_CAP_BASE + lvl * 50;
+  sectState.fruitCap = FRUIT_CAP_BASE + lvl * 200;
+  sectState.fruits = Math.min(sectState.fruitCap, sectState.fruits);
+  sectState.softwood = Math.min(sectState.softwoodCap, sectState.softwood);
 }

--- a/script.js
+++ b/script.js
@@ -155,7 +155,8 @@ import {
   worldProgressTimer,
   setWorldProgressTimer,
   worldProgressRateTracker,
-  setNightMode
+  setNightMode,
+  updateResourceCaps
 } from "./game/state.js";
 import {
   BASE_STATS,
@@ -693,8 +694,8 @@ function updateSectDisplay() {
     const woodRate = formatRate(sectSystem.gains?.softwood);
     sectSummaryDisplay.innerHTML = `
       <span>👥 ${total}/${sectState.maxDisciples} (Idle: ${idle})</span>
-      <span>${sectState.fruits.toFixed(2)} (${fruitRate}/s)</span>
-      <span>🪵 ${sectState.softwood.toFixed(2)} (${woodRate}/s)</span>`;
+      <span>${sectState.fruits.toFixed(2)}/${sectState.fruitCap} (${fruitRate}/s)</span>
+      <span>🪵 ${sectState.softwood.toFixed(2)}/${sectState.softwoodCap} (${woodRate}/s)</span>`;
     const timer = document.getElementById('resourceTimer');
     if (timer) {
       timer.textContent = `${mm}:${ss}`;
@@ -1315,6 +1316,7 @@ function init() {
   initDebug();
   window.addEventListener('location-discovered', e => addDiscoveredLocation(e.detail.name, locationListContainer, LOCATION_DEFS));
   loadGame();
+  updateResourceCaps();
   // Apply current brightness settings immediately after loading saved data
   updateMapBrightness(getCurrentSchedule().phase);
   if (sectSystem.disciples.length === 0) {
@@ -2370,6 +2372,7 @@ Object.assign(playerStats, state.playerStats || {});
       res.current = sectState.undeadNectar || 0;
       res.unlocked = res.current > 0;
     }
+    updateResourceCaps();
   }
 
   // synchronize disciple global levels with saved skill data

--- a/test/resource-gathering.test.js
+++ b/test/resource-gathering.test.js
@@ -80,4 +80,24 @@ describe('resource gathering', () => {
   it('collects softwood each second', () => {
     runGatherTest('Gather Softwood');
   });
+
+  it('respects fruit cap', () => {
+    const d = new Disciple({ id: 2, attributes: { strength: 1, dexterity: 1, endurance: 1, intelligence: 1, charisma: 1, potential: 1 } });
+    initializeDisciple(d);
+    sectSystem.disciples.push(d);
+    sectState.discipleTasks[d.id] = 'Gather Fruit';
+    sectState.fruits = sectState.fruitCap - 0.05;
+    tickSect(1000);
+    expect(sectState.fruits).to.be.closeTo(sectState.fruitCap, 1e-6);
+  });
+
+  it('respects softwood cap', () => {
+    const d = new Disciple({ id: 3, attributes: { strength: 1, dexterity: 1, endurance: 1, intelligence: 1, charisma: 1, potential: 1 } });
+    initializeDisciple(d);
+    sectSystem.disciples.push(d);
+    sectState.discipleTasks[d.id] = 'Gather Softwood';
+    sectState.softwood = sectState.softwoodCap - 0.05;
+    tickSect(1000);
+    expect(sectState.softwood).to.be.closeTo(sectState.softwoodCap, 1e-6);
+  });
 });


### PR DESCRIPTION
## Summary
- limit stored softwood and fruit
- show resource caps on the sect screen
- increase caps when Bohio levels up
- clamp debug tool cash
- test caps
- document Bohio effects

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6885262105248326998c5152562cd7f4