### PR TITLE
Add cracked orb mechanic and defeat overlay

### DIFF
--- a/docs/16-water-orb.md
+++ b/docs/16-water-orb.md
@@ -14,6 +14,9 @@
 - Soft light particles swirl around the orb at night, further brightening the surrounding darkness.
 - A radial light mask darkens the map at night while leaving a bright gradient around the orb.
 - The orb now holds up to 20 Water and regenerates at a flat 0.1 Water per second.
+- If the orb is ever drained to 0 Water it cracks, halving its maximum capacity
+  and regeneration rate until restored. A cracked orb displays visible cracks on
+  the orb graphic.
 - Orb Revival research grants access to an Orb Management panel showing spells like Water Burst.
 - Word of Haste orb spell speeds up work tasks for one minute at the cost of 15 Water.
 - Orb Spell Strength buildings raise Water Burst damage by 20% per level.

--- a/docs/23-raids.md
+++ b/docs/23-raids.md
@@ -40,3 +40,5 @@ Disciples may be called upon to defend the sect from occasional raids.
   rewards and how much combat XP each participating disciple earned. Each
   fighter now displays a small progress bar indicating their level and progress
   toward the next. Level ups are noted next to the fighter's name.
+* If defeated, a raid end overlay displays the resources lost when the orb was
+  drained.

--- a/game/raids.js
+++ b/game/raids.js
@@ -129,6 +129,19 @@ export function endRaid(victory = false) {
       rewards: { undeadNectar: 1 },
       fighters
     });
+  } else if (!victory) {
+    const lost = {
+      fruits: Math.floor(sectState.fruits / 2),
+      softwood: Math.floor(sectState.softwood / 2)
+    };
+    sectState.fruits -= lost.fruits;
+    sectState.softwood -= lost.softwood;
+    showRaidSummaryOverlay({
+      victory: false,
+      damageDealt: raidState.damageDealt,
+      damageReceived: raidState.damageReceived,
+      lost
+    });
   }
   document.dispatchEvent(new CustomEvent('raid-end', { detail: { victory } }));
   if (typeof updateSectDisplay === 'function') updateSectDisplay();
@@ -137,5 +150,9 @@ export function endRaid(victory = false) {
 export function tickRaid(delta) {
   if (!raidState.active || !raidState.enemy) return;
   raidState.enemy.tick(delta);
+  if (sectSystem.orbs.water.current <= 0) {
+    endRaid(false);
+    return;
+  }
   if (raidState.enemy.isDefeated()) endRaid(true);
 }

--- a/game/sect.js
+++ b/game/sect.js
@@ -85,7 +85,7 @@ export function setSeasonBackdrop(season) {
 
 export const sectSystem = {
   orbs: {
-    water: { current: 0, max: 20, regen: ORB_REGEN_PER_SEC }
+    water: { current: 0, max: 20, regen: ORB_REGEN_PER_SEC, cracked: false }
   },
   resources: {
     thought: { current: 0, max: 10, regen: 0, unlocked: false },
@@ -1009,6 +1009,9 @@ function renderOrbs() {
   const orb = document.querySelector('#sectOrbs .sect-orb.water');
   const fill = orb?.querySelector('.orb-fill');
   const value = orb?.querySelector('.orb-value');
+  if (orb) {
+    orb.classList.toggle('cracked', !!sectSystem.orbs.water.cracked);
+  }
   if (fill) {
     const pct = Math.max(0, Math.min(1, sectSystem.orbs.water.current / sectSystem.orbs.water.max)) * 100;
     fill.style.height = `${pct}%`;
@@ -1238,7 +1241,13 @@ export function tickSectSystem(delta) {
     if (sectSystem.weather.duration <= 0) sectSystem.weather = null;
   }
   const ins = sectSystem.resources.water;
-  const regen = ORB_REGEN_PER_SEC;
+  if (ins.current <= 0 && !ins.cracked) {
+    ins.cracked = true;
+    ins.max = Math.floor(ins.max / 2);
+    if (ins.current > ins.max) ins.current = ins.max;
+    if (hasUI) renderOrbs();
+  }
+  const regen = ORB_REGEN_PER_SEC * (ins.cracked ? 0.5 : 1);
   sectSystem.waterRegenBase = regen;
   ins.current = Math.min(ins.max, ins.current + regen * dt);
   const echo = recipes.find(r => r.name === 'Echo of Mind');

--- a/style.css
+++ b/style.css
@@ -3226,6 +3226,16 @@ body.darkenshift-mode .tabsContainer button.active {
     border: 1px solid #7fd9ff;
     color: #7fd9ff;
 }
+.sect-orb.water.cracked::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background-image:
+      linear-gradient(45deg, transparent 47%, #7fd9ff 48%, #7fd9ff 52%, transparent 53%),
+      linear-gradient(-45deg, transparent 47%, #7fd9ff 48%, #7fd9ff 52%, transparent 53%);
+    opacity: 0.5;
+}
 .sect-orb.water .orb-fill {
     background: linear-gradient(to top, rgba(40,110,180,0.9), rgba(80,160,220,0.7));
 }
@@ -4020,6 +4030,12 @@ body.darkenshift-mode .tabsContainer button.active {
   width: 100px;
   height: 8px;
   margin-top: 2px;
+}
+.raid-summary-rewards ul,
+.raid-summary-loss ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
 }
 
 

--- a/test/combat-xp.test.js
+++ b/test/combat-xp.test.js
@@ -16,7 +16,13 @@ function setupDom() {
   globalThis.document = {
     getElementById: () => null,
     getElementsByClassName: () => [{ textContent: '', style: {}, appendChild() {} }],
-    createElement: () => ({ appendChild() {}, style: {}, addEventListener() {}, remove() {} }),
+    createElement: () => ({
+      appendChild() {},
+      style: {},
+      addEventListener() {},
+      remove() {},
+      classList: { add() {}, toggle() {} }
+    }),
     querySelector: () => null,
     addEventListener: () => {},
     removeEventListener: () => {},

--- a/test/water-orb.test.js
+++ b/test/water-orb.test.js
@@ -4,6 +4,7 @@ import { expect } from 'chai';
 let sectModule;
 let sectSystem;
 let tickSectSystem;
+let ORB_REGEN_PER_SEC;
 
 // Setup DOM stubs to satisfy module imports
 before(async () => {
@@ -16,7 +17,7 @@ before(async () => {
   };
   globalThis.window = { dispatchEvent() {} };
   sectModule = await import('../game/sect.js');
-  ({ sectSystem, tickSectSystem } = sectModule);
+  ({ sectSystem, tickSectSystem, ORB_REGEN_PER_SEC } = sectModule);
 });
 
 after(() => {
@@ -26,10 +27,21 @@ after(() => {
 
 describe('water orb regeneration', () => {
   it('regenerates over time', () => {
-    sectSystem.resources.water.current = 0;
+    sectSystem.resources.water.current = 1;
+    sectSystem.resources.water.cracked = false;
     for (let i = 0; i < 10; i++) {
       tickSectSystem(1000);
     }
-    expect(sectSystem.resources.water.current).to.be.closeTo(1, 1e-6);
+    expect(sectSystem.resources.water.current).to.be.closeTo(2, 1e-6);
+  });
+
+  it('cracks when emptied', () => {
+    sectSystem.orbs.water.current = 0;
+    sectSystem.orbs.water.max = 20;
+    sectSystem.orbs.water.cracked = false;
+    tickSectSystem(1000);
+    expect(sectSystem.orbs.water.cracked).to.be.true;
+    expect(sectSystem.orbs.water.max).to.equal(10);
+    expect(sectSystem.orbs.water.current).to.be.closeTo(ORB_REGEN_PER_SEC * 0.5, 1e-6);
   });
 });

--- a/ui/raidSummaryOverlay.js
+++ b/ui/raidSummaryOverlay.js
@@ -1,17 +1,19 @@
 import { createOverlay } from './overlay.js';
 
 export function showRaidSummaryOverlay({
+  victory = true,
   damageDealt = 0,
   damageReceived = 0,
   rewards = {},
-  fighters = []
+  fighters = [],
+  lost = {}
 } = {}) {
   const overlay = createOverlay({ className: 'raid-summary-overlay', boxClass: 'parchment-box' });
   overlay.box.classList.add('parchment-box');
   const { box, close } = overlay;
 
   const title = document.createElement('h2');
-  title.textContent = 'Raid Defeated';
+  title.textContent = victory ? 'Raid Defeated' : 'Raid Failed';
   box.appendChild(title);
 
   const stats = document.createElement('div');
@@ -54,6 +56,16 @@ export function showRaidSummaryOverlay({
     rewardSection.className = 'raid-summary-rewards';
     rewardSection.innerHTML = '<p>Rewards:</p><ul>' + rewardLines.map(r => `<li>${r}</li>`).join('') + '</ul>';
     box.appendChild(rewardSection);
+  }
+
+  const lostLines = [];
+  if (lost.fruits) lostLines.push(`Fruit -${lost.fruits}`);
+  if (lost.softwood) lostLines.push(`Softwood -${lost.softwood}`);
+  if (lostLines.length > 0) {
+    const lostSection = document.createElement('div');
+    lostSection.className = 'raid-summary-loss';
+    lostSection.innerHTML = '<p>Resources Lost:</p><ul>' + lostLines.map(r => `<li>${r}</li>`).join('') + '</ul>';
+    box.appendChild(lostSection);
   }
 
   overlay.appendButton('Close', close);


### PR DESCRIPTION
## Summary
- crack the water orb when empty and reduce capacity and regen
- mark cracked state in orb UI
- show a broken orb overlay effect with CSS
- display raid summary overlay on defeat including resources lost
- document cracked orb and defeat overlay behavior
- test cracked orb functionality and adjust DOM stubs

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68852d5886b08326933ce2b94b003ed8