### PR TITLE
feat: add cracked orb overlay

### DIFF
--- a/game/combat.js
+++ b/game/combat.js
@@ -16,7 +16,6 @@ import { sectSystem } from './sect.js';
 import { showRestartScreen } from '../ui/restartOverlay.js';
 
 import addLog from './log.js';
-import { raidState } from './raids.js';
 
 export function init() {}
 

--- a/img/orb-crack.svg
+++ b/img/orb-crack.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <line x1="2" y1="2" x2="30" y2="30" stroke="#7fd9ff" stroke-width="2"/>
+  <line x1="2" y1="30" x2="30" y2="2" stroke="#7fd9ff" stroke-width="2"/>
+  <line x1="16" y1="0" x2="16" y2="32" stroke="#7fd9ff" stroke-width="2"/>
+</svg>

--- a/style.css
+++ b/style.css
@@ -3231,10 +3231,10 @@ body.darkenshift-mode .tabsContainer button.active {
     position: absolute;
     inset: 0;
     pointer-events: none;
-    background-image:
-      linear-gradient(45deg, transparent 47%, #7fd9ff 48%, #7fd9ff 52%, transparent 53%),
-      linear-gradient(-45deg, transparent 47%, #7fd9ff 48%, #7fd9ff 52%, transparent 53%);
-    opacity: 0.5;
+    background-image: url('./img/orb-crack.svg');
+    background-size: cover;
+    background-repeat: no-repeat;
+    opacity: 0.7;
 }
 .sect-orb.water .orb-fill {
     background: linear-gradient(to top, rgba(40,110,180,0.9), rgba(80,160,220,0.7));


### PR DESCRIPTION
## Summary
- add a simple crack graphic for the water orb
- clean up unused import

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688539791cb08326908b2c6b03dff954