### PR TITLE
Implement raid end trigger and slower blobs

### DIFF
--- a/docs/23-raids.md
+++ b/docs/23-raids.md
@@ -20,9 +20,10 @@ Disciples may be called upon to defend the sect from occasional raids.
 * Raiders randomly target a fighter when multiple disciples are on guard.
 * If the orb is depleted the sect loses **half** of its stored fruit and softwood.
 * Early raids send four SlowBlob raiders, one every 10&nbsp;s for 40&nbsp;s.
+* SlowBlob attacks now occur every 10&nbsp;s.
 
 * The Water orb lashes out every 5&nbsp;s at blobs within 75&nbsp;px, striking the closest target for 5 damage.
-* Blobs show a small health meter as they crawl across the 
+* Blobs show a small health meter as they crawl across the map.
 * 
 * Damage dealt to and by the Water orb is logged during raids.
 * All units traverse the map at a base rate of 10&nbsp;px per second.
@@ -32,7 +33,7 @@ Disciples may be called upon to defend the sect from occasional raids.
 
 * Defeating a raid yields **Undead Nectar** in addition to experience. The nectar
   is added to your resources side panel for later use.
-* The raid ends when the enemy is defeated or the orb is drained.
+* The raid ends immediately when the enemy is defeated or the Water orb is drained.
 * A summary overlay appears after victory showing damage dealt, damage received,
   rewards and how much combat XP each participating disciple earned. Each
   fighter now displays a small progress bar indicating their level and progress

--- a/game/blobRaids.js
+++ b/game/blobRaids.js
@@ -4,7 +4,7 @@ import { runAnimation } from '../utils/animation.js';
 import addLog from './log.js';
 import { BASE_MOVE_SPEED } from './constants.js';
 import { flashOrbGlow } from './orbGlow.js';
-import { raidState } from './raids.js';
+import { raidState, endRaid } from './raids.js';
 
 
 
@@ -14,6 +14,8 @@ const SPAWN_INTERVAL = 10000; // ms
 const MAX_BLOBS = 4;
 // Blobs move at the base unit speed
 const BLOB_SPEED = BASE_MOVE_SPEED;
+// Blobs attack every 10 seconds
+const BLOB_ATTACK_INTERVAL = 10000; // ms
 const ORB_ATTACK_INTERVAL = 5000; // ms
 const ORB_ATTACK_RANGE = 75; // px
 const DISCIPLE_ATTACK_INTERVAL = 10000; // ms
@@ -128,7 +130,7 @@ function createBlob() {
     y,
     hp: 20,
     maxHp: 20,
-    nextAttack: performance.now() + 1000,
+    nextAttack: performance.now() + BLOB_ATTACK_INTERVAL,
     size,
     update(dt) {
       const ox = orbRect.left + orbRect.width / 2 - mapRect.left;
@@ -149,9 +151,14 @@ function createBlob() {
           sectSystem.orbs.water.current - 5
         );
         raidState.damageReceived += 5;
-        runAnimation(orb, 'orb-hit');
+        const orbEl = getOrb();
+        runAnimation(orbEl, 'orb-hit');
         addLog('SlowBlob hits the Water Orb for 5 damage.', 'damage');
-        this.nextAttack = performance.now() + 1000;
+        this.nextAttack = performance.now() + BLOB_ATTACK_INTERVAL;
+        if (sectSystem.orbs.water.current <= 0 && raidState.active) {
+          endRaid(false);
+          return;
+        }
       }
     },
     takeDamage(dmg) {


### PR DESCRIPTION
## Summary
- finish raids immediately when the Water orb is drained
- slow blob attack cooldown to 10 seconds
- check the orb element on each hit so the animation always plays
- document new raid behaviour

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68853edbcc588326bcfa68b734e27606