### PR TITLE
Add disciple interception combat logic

### DIFF
--- a/docs/23-raids.md
+++ b/docs/23-raids.md
@@ -16,6 +16,8 @@ Disciples may be called upon to defend the sect from occasional raids.
 * A red alert briefly appears on screen when a raid starts.
 * Raiders attack the Water orb, reducing its stored energy.
 * All disciples rush to intercept raiders as soon as they appear.
+* Raiders stop when intercepted and direct their attacks at the nearby disciples.
+* All disciples immediately pause their current task to join the defense.
 * Each disciple seeks the nearest enemy and engages in melee when in range.
 * If the orb is depleted the sect loses **half** of its stored fruit and softwood.
 * Early raids send four SlowBlob raiders, one every 10&nbsp;s for 40&nbsp;s.

--- a/game/blobRaids.js
+++ b/game/blobRaids.js
@@ -4,6 +4,7 @@ import addLog from './log.js';
 import { BASE_MOVE_SPEED } from './constants.js';
 import { flashOrbGlow } from './orbGlow.js';
 import { raidState, endRaid } from './raids.js';
+import { damageDisciple } from './combat.js';
 
 
 
@@ -132,31 +133,55 @@ function createBlob() {
     nextAttack: performance.now() + BLOB_ATTACK_INTERVAL,
     size,
     update(dt) {
-      const ox = orbRect.left + orbRect.width / 2 - mapRect.left;
-      const oy = orbRect.top + orbRect.height / 2 - mapRect.top;
-      const dx = ox - this.x;
-      const dy = oy - this.y;
-      const dist = Math.hypot(dx, dy);
-      if (dist > 1) {
-        const move = Math.min((BLOB_SPEED * dt) / 1000, dist);
-        this.x += (dx / dist) * move;
-        this.y += (dy / dist) * move;
-        this.el.style.left = `${this.x}px`;
-        this.el.style.top = `${this.y}px`;
-      }
-      if (dist <= this.size && performance.now() >= this.nextAttack) {
-        sectSystem.orbs.water.current = Math.max(
-          0,
-          sectSystem.orbs.water.current - 5
-        );
-        raidState.damageReceived += 5;
-        const orbEl = getOrb();
-        runAnimation(orbEl, 'orb-hit');
-        addLog('SlowBlob hits the Water Orb for 5 damage.', 'damage');
-        this.nextAttack = performance.now() + BLOB_ATTACK_INTERVAL;
-        if (sectSystem.orbs.water.current <= 0 && raidState.active) {
-          endRaid(false);
-          return;
+      let target = null;
+      let min = Infinity;
+      const now = performance.now();
+      sectSystem.disciples.forEach((d, idx) => {
+        if (d.incapacitated) return;
+        const el = document.querySelector(`.sect-disciple:nth-child(${idx + 1})`);
+        if (!el) return;
+        const rect = el.getBoundingClientRect();
+        const px = rect.left + rect.width / 2 - mapRect.left;
+        const py = rect.top + rect.height / 2 - mapRect.top;
+        const dd = Math.hypot(px - this.x, py - this.y);
+        if (dd <= DISCIPLE_RANGE && dd < min) {
+          min = dd;
+          target = d;
+        }
+      });
+
+      if (target) {
+        if (now >= this.nextAttack) {
+          damageDisciple(target, 5, 'SlowBlob');
+          this.nextAttack = now + BLOB_ATTACK_INTERVAL;
+        }
+      } else {
+        const ox = orbRect.left + orbRect.width / 2 - mapRect.left;
+        const oy = orbRect.top + orbRect.height / 2 - mapRect.top;
+        const dx = ox - this.x;
+        const dy = oy - this.y;
+        const dist = Math.hypot(dx, dy);
+        if (dist > 1) {
+          const move = Math.min((BLOB_SPEED * dt) / 1000, dist);
+          this.x += (dx / dist) * move;
+          this.y += (dy / dist) * move;
+          this.el.style.left = `${this.x}px`;
+          this.el.style.top = `${this.y}px`;
+        }
+        if (dist <= this.size && now >= this.nextAttack) {
+          sectSystem.orbs.water.current = Math.max(
+            0,
+            sectSystem.orbs.water.current - 5
+          );
+          raidState.damageReceived += 5;
+          const orbEl = getOrb();
+          runAnimation(orbEl, 'orb-hit');
+          addLog('SlowBlob hits the Water Orb for 5 damage.', 'damage');
+          this.nextAttack = now + BLOB_ATTACK_INTERVAL;
+          if (sectSystem.orbs.water.current <= 0 && raidState.active) {
+            endRaid(false);
+            return;
+          }
         }
       }
     },

--- a/game/combat.js
+++ b/game/combat.js
@@ -139,4 +139,41 @@ export function cDealerDamage(damageAmount = null, source = 'dealer') {
   }
 }
 
+export function damageDisciple(target, damageAmount, source = 'enemy') {
+  if (!target || target.incapacitated) return;
+
+  const amount = Math.round(damageAmount);
+  target.currentHp = Math.max(0, target.currentHp - amount);
+  const targetName = target.name ? target.name : `${target.value}${target.symbol}`;
+  addLog(`${source} hit ${targetName} for ${amount} damage!`, 'damage');
+
+  if (target.hpDisplay) {
+    target.hpDisplay.textContent = `HP: ${formatNumber(Math.round(target.currentHp))}/${formatNumber(
+      Math.round(target.maxHp)
+    )}`;
+  }
+  if (target.wrapperElement) {
+    animateDiscipleHit(target);
+    showDamageFloat(target, amount);
+  }
+  updateBloodSplat(target);
+
+  if (target.currentHp === 0) {
+    const idx = activeDisciples.indexOf(target);
+    if (idx >= 0) activeDisciples.splice(idx, 1);
+    target.incapacitated = true;
+    target.health = 0;
+    target.stamina = 0;
+    sectState.discipleTasks[target.id] = 'Idle';
+    animateDiscipleDeath(target, () => {
+      removeBloodSplat(target);
+      target.wrapperElement?.remove();
+      if (activeDisciples.length === 0) {
+        playerStats.hasDied = true;
+        showRestartScreen(partyDefeatHandler);
+      }
+    });
+  }
+}
+
 globalThis.cDealerDamage = cDealerDamage;


### PR DESCRIPTION
## Summary
- stop raiders when a disciple is near them
- let raiders attack the intercepting disciple
- log targeted disciple damage in new helper
- document raid interception behaviour

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68856d48c0748326b587b31bb48f182e