### PR TITLE
Add blob burst animation

### DIFF
--- a/docs/23-raids.md
+++ b/docs/23-raids.md
@@ -23,6 +23,7 @@ Disciples may be called upon to defend the sect from occasional raids.
 
 * The Water orb lashes out every 5&nbsp;s at blobs within 75&nbsp;px, striking the closest target for 5 damage.
 * Blobs show a small health meter as they crawl across the map.
+* When killed, blobs burst in a brief animation.
 * 
 * Damage dealt to and by the Water orb is logged during raids.
 * All units traverse the map at a base rate of 10&nbsp;px per second.

--- a/game/blobRaids.js
+++ b/game/blobRaids.js
@@ -167,7 +167,7 @@ function createBlob() {
         this.lifeFill.style.width = `${pct}%`;
       }
       if (this.hp === 0) {
-        this.el.remove();
+        runAnimation(this.el, 'blob-burst', 400).then(() => this.el.remove());
         const idx = blobs.indexOf(this);
         if (idx >= 0) blobs.splice(idx, 1);
       }

--- a/style.css
+++ b/style.css
@@ -4083,3 +4083,10 @@ body.darkenshift-mode .tabsContainer button.active {
 .slow-blob .blob-eye.left{left:4px;}
 .slow-blob .blob-eye.right{right:4px;}
 
+@keyframes blob-burst {
+  0% { transform: scale(1); opacity: 1; }
+  100% { transform: scale(2); opacity: 0; }
+}
+.blob-burst {
+  animation: blob-burst 0.4s ease-out forwards;
+}

--- a/test/blob-raids.test.js
+++ b/test/blob-raids.test.js
@@ -1,0 +1,39 @@
+/* global describe, it, before, beforeEach */
+import { expect } from 'chai';
+
+function setupDom() {
+  const map = {
+    childNodes: [],
+    appendChild(el) { this.childNodes.push(el); },
+    getBoundingClientRect() { return { width: 100, height: 100, left: 0, top: 0 }; }
+  };
+  const orb = { getBoundingClientRect() { return { width: 10, height: 10, left: 50, top: 50 }; } };
+  globalThis.document = {
+    getElementById: id => (id === 'colonyMap' ? map : null),
+    querySelector: sel => (sel === '#sectOrbs .sect-orb.water' ? orb : null),
+    createElement: () => ({ appendChild() {}, style: {}, className: '', remove() {} })
+  };
+  globalThis.window = {};
+}
+
+describe('blob raids', () => {
+  let spawnBlob;
+  let clearBlobs;
+  let blobs;
+  before(async () => {
+    setupDom();
+    const module = await import(`../game/blobRaids.js?test=${Date.now()}`);
+    ({ spawnBlob, clearBlobs, blobs } = module);
+  });
+
+  beforeEach(() => {
+    clearBlobs();
+  });
+
+  it('spawns blobs with a life bar', () => {
+    const success = spawnBlob();
+    expect(success).to.be.true;
+    expect(blobs[0].lifeFill).to.exist;
+    expect(blobs[0].lifeFill.style.width).to.equal('100%');
+  });
+});


### PR DESCRIPTION
## Summary
- animate blob death with new `blob-burst` class
- document raid blob bursting
- test blob life bar creation

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68856d8e4d0883268ecf066c7eeea31e