### PR TITLE
Add research toggle button

### DIFF
--- a/docs/15-research.md
+++ b/docs/15-research.md
@@ -4,6 +4,8 @@ This section outlines the major research branches and their unlock progression.
 
 Build a Research Desk to unlock the Research screen and begin accumulating Research Points.
 
+The research overlay includes a **Show Purchased** button so you can toggle visibility of completed topics.
+
 
 ---
 

--- a/style.css
+++ b/style.css
@@ -3687,6 +3687,13 @@ body.darkenshift-mode .tabsContainer button.active {
     border: 1px solid #333;
     border-radius: 4px;
 }
+.research-entry.completed {
+    opacity: 0.6;
+}
+.research-status {
+    font-size: 0.8rem;
+    font-style: italic;
+}
 
 .research-entry button {
     align-self: flex-start;

--- a/ui/colonyOverlays.js
+++ b/ui/colonyOverlays.js
@@ -503,6 +503,16 @@ export function openResearchOverlay() {
   researchList.className = 'research-list';
   box.appendChild(researchList);
 
+  let showCompleted = false;
+  const toggleBtn = document.createElement('button');
+  toggleBtn.textContent = 'Show Purchased';
+  toggleBtn.addEventListener('click', () => {
+    showCompleted = !showCompleted;
+    toggleBtn.textContent = showCompleted ? 'Hide Purchased' : 'Show Purchased';
+    renderResearch();
+  });
+  box.appendChild(toggleBtn);
+
   const topics = [
     {
       key: 'orbRevival',
@@ -541,29 +551,38 @@ export function openResearchOverlay() {
   function renderResearch() {
     researchList.innerHTML = '';
     topics.forEach(t => {
-      if (sectState.completedResearch.includes(t.key)) return;
+      const completed = sectState.completedResearch.includes(t.key);
+      if (completed && !showCompleted) return;
       const row = document.createElement('div');
       row.className = 'research-entry';
+      if (completed) row.classList.add('completed');
       const name = document.createElement('div');
       name.className = 'research-name';
       name.textContent = t.label;
       const desc = document.createElement('div');
       desc.className = 'research-desc';
       desc.textContent = t.desc;
-      const btn = document.createElement('button');
-      btn.textContent = `Unlock (${t.cost})`;
-      btn.disabled = sectState.researchPoints < t.cost;
-      btn.addEventListener('click', () => {
-        if (sectState.researchPoints < t.cost) return;
-        sectState.researchPoints -= t.cost;
-        sectState.completedResearch.push(t.key);
-        t.unlock();
-        if (typeof window.updateSectDisplay === 'function') window.updateSectDisplay();
-        renderResearch();
-      });
       row.appendChild(name);
       row.appendChild(desc);
-      row.appendChild(btn);
+      if (completed) {
+        const status = document.createElement('div');
+        status.className = 'research-status';
+        status.textContent = 'Purchased';
+        row.appendChild(status);
+      } else {
+        const btn = document.createElement('button');
+        btn.textContent = `Unlock (${t.cost})`;
+        btn.disabled = sectState.researchPoints < t.cost;
+        btn.addEventListener('click', () => {
+          if (sectState.researchPoints < t.cost) return;
+          sectState.researchPoints -= t.cost;
+          sectState.completedResearch.push(t.key);
+          t.unlock();
+          if (typeof window.updateSectDisplay === 'function') window.updateSectDisplay();
+          renderResearch();
+        });
+        row.appendChild(btn);
+      }
       researchList.appendChild(row);
     });
   }


### PR DESCRIPTION
## Summary
- show/hide purchased research topics in overlay
- style completed research entries
- document the new toggle option

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68858c8eb7a88326946e49e170a28f25