### PR TITLE
Restore tasks after raids

### DIFF
--- a/docs/23-raids.md
+++ b/docs/23-raids.md
@@ -18,6 +18,7 @@ Disciples may be called upon to defend the sect from occasional raids.
 * All disciples rush to intercept raiders as soon as they appear.
 * Raiders stop when intercepted and direct their attacks at the nearby disciples.
 * All disciples immediately pause their current task to join the defense.
+* After the raid ends, disciples automatically resume their previous work assignments.
 * Each disciple seeks the nearest enemy and engages in melee when in range.
 * If the orb is depleted the sect loses **half** of its stored fruit and softwood.
 * Early raids send four SlowBlob raiders, one every 10&nbsp;s for 40&nbsp;s.

--- a/game/raids.js
+++ b/game/raids.js
@@ -28,7 +28,8 @@ export const raidState = {
   orbTimer: 0,
   damageDealt: 0,
   damageReceived: 0,
-  xpStart: {}
+  xpStart: {},
+  prevTasks: {}
 };
 
 
@@ -40,8 +41,12 @@ export function startRaid() {
   raidState.damageDealt = 0;
   raidState.damageReceived = 0;
   raidState.xpStart = {};
+  raidState.prevTasks = {};
   sectSystem.disciples.forEach(d => {
-    if (!d.incapacitated) sectState.discipleTasks[d.id] = 'Idle';
+    if (!d.incapacitated) {
+      raidState.prevTasks[d.id] = sectState.discipleTasks[d.id];
+      sectState.discipleTasks[d.id] = 'Idle';
+    }
   });
   sectSystem.disciples.forEach(d => {
     if (!d.incapacitated) {
@@ -111,6 +116,10 @@ export function endRaid(victory = false) {
   raidState.orbTimer = 0;
   const xpStart = raidState.xpStart;
   raidState.xpStart = {};
+  Object.keys(raidState.prevTasks).forEach(id => {
+    sectState.discipleTasks[id] = raidState.prevTasks[id] || 'Idle';
+  });
+  raidState.prevTasks = {};
   clearBlobs();
   hideOrbAttackBar();
   addLog('The raid has ended.', 'info');

--- a/style.css
+++ b/style.css
@@ -735,7 +735,7 @@ body.darkenshift-mode .tabsContainer button.active {
 }
 .work-output {
     font-size: 0.7rem;
-    color: #ddd;
+    color: #222;
 }
 
 .work-task-option {
@@ -747,7 +747,7 @@ body.darkenshift-mode .tabsContainer button.active {
 
 .work-task-info {
     font-size: 0.7rem;
-    color: #ddd;
+    color: #222;
     display: flex;
     align-items: center;
     gap: 2px;


### PR DESCRIPTION
## Summary
- preserve each disciple's active task when a raid begins
- restore those tasks once the raid ends
- darken the text color in the Work overlay for readability
- document that tasks resume automatically

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68863cca1c7c8326b0c1ec1600d0871e