### PR TITLE
Fix raider targeting behavior

### DIFF
--- a/docs/23-raids.md
+++ b/docs/23-raids.md
@@ -16,7 +16,7 @@ Disciples may be called upon to defend the sect from occasional raids.
 * A red alert briefly appears on screen when a raid starts.
 * Raiders attack the Water orb, reducing its stored energy.
 * All disciples rush to intercept raiders as soon as they appear.
-* Raiders stop when intercepted and direct their attacks at the nearby disciples.
+* Raiders now chase nearby disciples instead of continuing toward the Water orb.
 * All disciples immediately pause their current task to join the defense.
 * Each disciple seeks the nearest enemy and engages in melee when in range.
 * If the orb is depleted the sect loses **half** of its stored fruit and softwood.

--- a/game/blobRaids.js
+++ b/game/blobRaids.js
@@ -134,6 +134,7 @@ function createBlob() {
     size,
     update(dt) {
       let target = null;
+      let targetPos = null;
       let min = Infinity;
       const now = performance.now();
       sectSystem.disciples.forEach(d => {
@@ -147,11 +148,22 @@ function createBlob() {
         if (dd <= DISCIPLE_RANGE && dd < min) {
           min = dd;
           target = d;
+          targetPos = { x: px, y: py, dist: dd };
         }
       });
 
-      if (target) {
-        if (now >= this.nextAttack) {
+      if (target && targetPos) {
+        const dx = targetPos.x - this.x;
+        const dy = targetPos.y - this.y;
+        const dist = targetPos.dist;
+        if (dist > 1) {
+          const move = Math.min((BLOB_SPEED * dt) / 1000, dist);
+          this.x += (dx / dist) * move;
+          this.y += (dy / dist) * move;
+          this.el.style.left = `${this.x}px`;
+          this.el.style.top = `${this.y}px`;
+        }
+        if (dist <= this.size && now >= this.nextAttack) {
           damageDisciple(target, 5, 'SlowBlob');
           this.nextAttack = now + BLOB_ATTACK_INTERVAL;
         }


### PR DESCRIPTION
## Summary
- make SlowBlob raiders move toward nearby disciples
- clarify docs on raider behavior

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68863d6f8fd08326a8c94b8bb75c9596