### PR TITLE
Add Circle of Areito transmutation building

### DIFF
--- a/docs/12-buildings.md
+++ b/docs/12-buildings.md
@@ -38,6 +38,7 @@ Research Desk   Softwood: 15    Unlocks Research navigation; allows disciples to
 Research Table	Softwood: 30 × (lvl^1.3)	Convert 4% global Water → Insight per level	Chanting research
 Library	Wood: 200 × (lvl^1.1); Stone: 100 × (lvl^1.1)	Unlock learning/spell teaching; +4% teaching rate per level	Research Table Lv1
 Jadefire Pavilion	Softwood & Stone: 20 × (1.1^lvl) each	Enables Transmutation; +3% spell potency per level	Transmutation research
+Circle of Areito   Softwood: 150 × (1.5^lvl); Water: 10 × (1.5^lvl)   Unlocks Transmutation nav; +4% transmute power per level  Gather 100 Softwood
 Chanting Halls	Wood: 300 × (1.15^lvl)	–4% chant cooldown per level; +1 chanter per 3 levels	Library Lv2
 Orb Spell Strength  Softwood: 100 × (1.3^lvl)  +20% orb spell damage per level   Research: Orb Spell Strength
 

--- a/docs/14-crafting.md
+++ b/docs/14-crafting.md
@@ -9,6 +9,7 @@ Transmutation is performed at the Jadefire Pavilion and is a core progression sc
 
 Spell	Requirement	Cost	Creates
 
+Plank Transmute   Circle of Areito   100 Softwood   1 Plank
 Assemble Wood	Jadefire Pavilion unlocked	175 Softwood	1 Plank
 Assemble Stone	Jadefire Pavilion unlocked	250 Stone	1 Brick
 Burn Wood	Coal Transmute researched	1 Softwood	0.003 Coal

--- a/game/buildings.js
+++ b/game/buildings.js
@@ -20,6 +20,13 @@ export const BUILDINGS = {
     costFunc: lvl => Math.round(100 * Math.pow(1.3, lvl)),
     max: 10,
     requires: 'researchDesk'
+  },
+  areitoCircle: {
+    name: 'Circle of Areito',
+    time: 600,
+    costFunc: lvl => Math.round(150 * Math.pow(1.5, lvl - 1)),
+    costWaterFunc: lvl => Math.round(10 * Math.pow(1.5, lvl - 1)),
+    max: 10
   }
 };
 
@@ -44,6 +51,9 @@ export function checkBuildingUnlock() {
   if (!systems.buildingUnlocked && sectState.softwood >= 20) {
     systems.buildingUnlocked = true;
   }
+  if (!systems.areitoBuildingAvailable && sectState.softwood >= 100) {
+    systems.areitoBuildingAvailable = true;
+  }
 }
 
 export function startBuilding(key) {
@@ -51,13 +61,16 @@ export function startBuilding(key) {
   if (!b) return;
   const built = sectState.buildings[key] || 0;
   const cost = b.costFunc ? b.costFunc(built + 1) : b.cost;
+  const waterCost = b.costWaterFunc ? b.costWaterFunc(built + 1) : 0;
   if (sectState.softwood < cost) return;
+  if (sectSystem.orbs.water.current < waterCost) return;
   if (built >= b.max) return;
   if (sectState.currentBuild) return;
   if (b.requires && sectState.buildings[b.requires] < b.max) return;
   if (key === 'chantingHall' && !systems.chantingHallUnlocked) return;
   if (key === 'orbSpellStrength' && !systems.spellStrengthUnlocked) return;
   sectState.softwood -= cost;
+  if (waterCost) sectSystem.orbs.water.current -= waterCost;
   sectState.currentBuild = key;
   sectState.buildProgress = 0;
   if (typeof globalThis.updateBuildOverlay === 'function') {
@@ -116,6 +129,9 @@ export function tickBuilding(dt) {
   }
     if (builtKey === 'researchDesk' && !systems.researchUnlocked) {
       systems.researchUnlocked = true;
+    }
+    if (builtKey === 'areitoCircle') {
+      if (!systems.transmutationUnlocked) systems.transmutationUnlocked = true;
     }
     if (typeof globalThis.updateBuildOverlay === 'function') {
       globalThis.updateBuildOverlay();

--- a/game/constants.js
+++ b/game/constants.js
@@ -21,6 +21,7 @@ export const SOFTWOOD_CYCLE_SECONDS = 215;
 export const SOFTWOOD_CYCLE_AMOUNT = 10;
 export const SOFTWOOD_CAP_BASE = 150;
 export const FRUIT_CAP_BASE = 250;
+export const PLANK_CAP_BASE = 100;
 // Fruits consumed per disciple each second
 export const FRUIT_CONSUMPTION_RATE = 0.01;
 export const TRAINING_NECTAR_RATE = 0.01;

--- a/game/state.js
+++ b/game/state.js
@@ -84,7 +84,9 @@ export const systems = {
   chantingHallUnlocked: false,
   explorationUnlocked: false,
   orbManagementUnlocked: false,
-  spellStrengthUnlocked: false
+  spellStrengthUnlocked: false,
+  areitoBuildingAvailable: false,
+  transmutationUnlocked: false
 };
 
 // Fruit gathering and growth configuration
@@ -92,13 +94,16 @@ export const FRUIT_MAX_CAP = 120;
 export const FRUIT_GROWTH_RATES = [60, 40, 30, 20, 0];
 export const SOFTWOOD_CAP_BASE = 150;
 export const FRUIT_CAP_BASE = 250;
+export const PLANK_CAP_BASE = 100;
 
 export const sectState = {
   fruits: 0,
   softwood: 0,
   undeadNectar: 0,
+  planks: 0,
   softwoodCap: SOFTWOOD_CAP_BASE,
   fruitCap: FRUIT_CAP_BASE,
+  plankCap: PLANK_CAP_BASE,
   availableFruits: FRUIT_MAX_CAP,
   animals: { Chicken: 3, Boar: 1, Deer: 0 },
   discipleTasks: {},
@@ -112,7 +117,13 @@ export const sectState = {
   discipleRest: {},
   maxDisciples: 3,
   housingBonus: 0,
-  buildings: { bohio: 0, researchDesk: 0, chantingHall: 0, orbSpellStrength: 0 },
+  buildings: {
+    bohio: 0,
+    researchDesk: 0,
+    chantingHall: 0,
+    orbSpellStrength: 0,
+    areitoCircle: 0
+  },
   researchPoints: 0,
   researchProgress: 0,
   completedResearch: [],
@@ -142,6 +153,8 @@ export function updateResourceCaps() {
   const lvl = sectState.buildings.bohio || 0;
   sectState.softwoodCap = SOFTWOOD_CAP_BASE + lvl * 50;
   sectState.fruitCap = FRUIT_CAP_BASE + lvl * 200;
+  sectState.plankCap = PLANK_CAP_BASE + lvl * 20;
   sectState.fruits = Math.min(sectState.fruitCap, sectState.fruits);
   sectState.softwood = Math.min(sectState.softwoodCap, sectState.softwood);
+  sectState.planks = Math.min(sectState.plankCap, sectState.planks);
 }

--- a/game/transmutation.js
+++ b/game/transmutation.js
@@ -1,0 +1,34 @@
+export const TRANSMUTES = {
+  plank: {
+    name: 'Plank',
+    input: { softwood: 100 },
+    output: { planks: 1 },
+    unlocked: true
+  }
+};
+
+import { sectState } from './state.js';
+
+export function getTransmutePower() {
+  const lvl = sectState.buildings.areitoCircle || 0;
+  return 1 + lvl * 0.04;
+}
+
+export function canTransmute(key) {
+  const def = TRANSMUTES[key];
+  if (!def || !def.unlocked) return false;
+  return Object.entries(def.input).every(([res, amt]) => (sectState[res] || 0) >= amt);
+}
+
+export function performTransmute(key) {
+  const def = TRANSMUTES[key];
+  if (!canTransmute(key)) return false;
+  Object.entries(def.input).forEach(([res, amt]) => {
+    sectState[res] -= amt;
+  });
+  const mult = getTransmutePower();
+  Object.entries(def.output).forEach(([res, amt]) => {
+    sectState[res] = (sectState[res] || 0) + amt * mult;
+  });
+  return true;
+}

--- a/index.html
+++ b/index.html
@@ -89,6 +89,7 @@
             <button id="sectNavWorkBtn" title="Work"><i data-lucide="hammer"></i><span>Work</span></button>
             <button id="sectNavResourceBtn" title="Resources"><i data-lucide="utensils"></i><span id="resourceTimer"></span></button>
             <button id="sectNavBuildBtn" title="Build"><i data-lucide="circle"></i><span>Build</span></button>
+            <button id="sectNavTransmuteBtn" title="Transmutation"><i data-lucide="shuffle"></i><span>Transmute</span></button>
             <button id="sectNavScheduleBtn" title="Schedule"><i data-lucide="clock"></i><span>Sched</span></button>
             <button id="sectNavChantBtn" title="Chanting"><i data-lucide="mic-2"></i><span>Chant</span></button>
             <button id="sectNavMapBtn" title="Map"><i data-lucide="map"></i><span>Map</span></button>

--- a/script.js
+++ b/script.js
@@ -48,7 +48,7 @@ import {
 import { intelligenceXpMultiplier } from './game/attributes.js';
 import { createOverlay } from './ui/overlay.js';
 import { showLoadErrorOverlay } from './ui/loadErrorOverlay.js';
-import { openExplorationOverlay, closeExplorationOverlay, openWorkOverlay, openScheduleOverlay, openPlaceholderOverlay, openResourceOverlay, openBuildOverlay, openResearchOverlay, openOrbOverlay, closeDungeonOverlay, locationListContainer, explorationListContainer } from "./ui/colonyOverlays.js";
+import { openExplorationOverlay, closeExplorationOverlay, openWorkOverlay, openScheduleOverlay, openPlaceholderOverlay, openResourceOverlay, openBuildOverlay, openTransmuteOverlay, openResearchOverlay, openOrbOverlay, closeDungeonOverlay, locationListContainer, explorationListContainer } from "./ui/colonyOverlays.js";
 import { createDiscipleBadge } from "./game/badges.js";
 import { calculateKillXp } from './utils/xp.js';
 import { initTooltip } from './game/tooltip.js';
@@ -349,6 +349,7 @@ let statsEconomyContainer;
 let sectNavWorkBtn;
 let sectNavResourceBtn;
 let sectNavBuildBtn;
+let sectNavTransmuteBtn;
 let sectNavChantBtn;
 let sectNavMapBtn;
 let sectNavInfluenceBtn;
@@ -445,6 +446,7 @@ function initTabs() {
   sectNavWorkBtn = document.getElementById("sectNavWorkBtn");
   sectNavResourceBtn = document.getElementById("sectNavResourceBtn");
   sectNavBuildBtn = document.getElementById("sectNavBuildBtn");
+  sectNavTransmuteBtn = document.getElementById("sectNavTransmuteBtn");
   sectNavChantBtn = document.getElementById("sectNavChantBtn");
   sectNavMapBtn = document.getElementById("sectNavMapBtn");
   sectNavInfluenceBtn = document.getElementById("sectNavInfluenceBtn");
@@ -475,7 +477,7 @@ function initTabs() {
       }
       openExplorationOverlay();
     });
-  const navButtons = [sectNavWorkBtn, sectNavResourceBtn, sectNavBuildBtn, sectNavScheduleBtn, sectNavChantBtn, sectNavMapBtn, sectNavInfluenceBtn, sectNavResearchBtn, sectNavOrbBtn, sectNavCultivationBtn];
+  const navButtons = [sectNavWorkBtn, sectNavResourceBtn, sectNavBuildBtn, sectNavTransmuteBtn, sectNavScheduleBtn, sectNavChantBtn, sectNavMapBtn, sectNavInfluenceBtn, sectNavResearchBtn, sectNavOrbBtn, sectNavCultivationBtn];
   function setActiveNavBtn(btn) {
     navButtons.forEach(b => b && b.classList.remove("active"));
     if (btn) btn.classList.add("active");
@@ -487,6 +489,12 @@ function initTabs() {
       setActiveNavBtn(sectNavBuildBtn);
       if (systems.buildingUnlocked) openBuildOverlay();
       else openPlaceholderOverlay("Building");
+    });
+  if (sectNavTransmuteBtn)
+    sectNavTransmuteBtn.addEventListener("click", () => {
+      setActiveNavBtn(sectNavTransmuteBtn);
+      if (systems.transmutationUnlocked) openTransmuteOverlay();
+      else openPlaceholderOverlay("Transmutation");
     });
   if (sectNavScheduleBtn)
     sectNavScheduleBtn.addEventListener("click", () => {
@@ -678,6 +686,9 @@ function updateSectDisplay() {
   }
   if (sectNavOrbBtn) {
     sectNavOrbBtn.style.display = systems.orbManagementUnlocked ? '' : 'none';
+  }
+  if (sectNavTransmuteBtn) {
+    sectNavTransmuteBtn.style.display = systems.transmutationUnlocked ? '' : 'none';
   }
   if (!sectTabUnlocked || !playerSectPanel) return;
   const total = sectSystem.disciples.length;

--- a/style.css
+++ b/style.css
@@ -837,6 +837,24 @@ body.darkenshift-mode .tabsContainer button.active {
     transition: width 0.3s ease;
 }
 
+.transmute-overlay .overlay-box {
+    max-width: 300px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+.transmute-list {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+.transmute-entry {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 4px;
+}
+
 .work-disciples .sect-disciple-card.selected {
     background: #fbf6e0;
     color: #000;

--- a/test/transmutation.test.js
+++ b/test/transmutation.test.js
@@ -1,0 +1,64 @@
+/* global describe, it, beforeEach */
+import { expect } from 'chai';
+import { sectState, systems } from '../game/state.js';
+
+let startBuilding;
+let tickBuilding;
+let performTransmute;
+let checkBuildingUnlock;
+let sectSystem;
+
+describe('Circle of Areito', () => {
+  before(() => {
+    globalThis.document = {
+      getElementsByClassName: () => [null],
+      getElementById: () => null,
+      addEventListener: () => {},
+      removeEventListener: () => {}
+    };
+    return import('../game/buildings.js').then(mod => {
+      ({ startBuilding, tickBuilding, checkBuildingUnlock } = mod);
+    }).then(() => import('../game/transmutation.js')).then(mod => {
+      ({ performTransmute } = mod);
+    }).then(() => import('../game/sect.js')).then(mod => {
+      ({ sectSystem } = mod);
+    });
+  });
+  after(() => {
+    delete globalThis.document;
+  });
+  beforeEach(() => {
+    systems.areitoBuildingAvailable = false;
+    systems.transmutationUnlocked = false;
+    sectState.softwood = 0;
+    sectSystem.orbs.water.current = sectSystem.orbs.water.max;
+    sectSystem.disciples.length = 0;
+    Object.keys(sectState.discipleTasks).forEach(k => delete sectState.discipleTasks[k]);
+    sectState.buildings.areitoCircle = 0;
+    sectState.planks = 0;
+  });
+
+  it('unlocks after gathering 100 softwood', () => {
+    sectState.softwood = 99;
+    checkBuildingUnlock();
+    expect(systems.areitoBuildingAvailable).to.be.false;
+    sectState.softwood = 100;
+    checkBuildingUnlock();
+    expect(systems.areitoBuildingAvailable).to.be.true;
+  });
+
+  it('builds and transmutes planks', () => {
+    systems.areitoBuildingAvailable = true;
+    sectState.softwood = 150;
+    startBuilding('areitoCircle');
+    const d = { id: 1, endurance: 0 };
+    sectSystem.disciples.push(d);
+    sectState.discipleTasks[d.id] = 'Building';
+    tickBuilding(600);
+    expect(sectState.buildings.areitoCircle).to.equal(1);
+    expect(systems.transmutationUnlocked).to.be.true;
+    sectState.softwood = 100;
+    performTransmute('plank');
+    expect(sectState.planks).to.be.above(0);
+  });
+});

--- a/ui/colonyOverlays.js
+++ b/ui/colonyOverlays.js
@@ -9,6 +9,7 @@ import { systems, sectState, worldProgress } from '../game/state.js';
 import { createSectDiscipleCard, renderExplorationTab, startExploration, startWorldCombat, discipleGatherPhase } from '../script.js';
 import { BUILDINGS, startBuilding } from '../game/buildings.js';
 import { castWordOfHaste, toggleReverberation } from '../game/orbSpells.js';
+import { TRANSMUTES, performTransmute, canTransmute, getTransmutePower } from '../game/transmutation.js';
 import { TASK_GROUPS } from '../game/constants.js';
 import { getTaskSkillProgress } from '../utils/skills.js';
 
@@ -354,6 +355,55 @@ export function openOrbOverlay() {
   render();
 }
 
+let transmuteOverlay = null;
+export function openTransmuteOverlay() {
+  if (transmuteOverlay) return;
+  transmuteOverlay = createOverlay({ className: 'transmute-overlay', boxClass: 'parchment-box' });
+  transmuteOverlay.box.classList.add('parchment-box');
+  transmuteOverlay.onClose(() => { transmuteOverlay = null; globalThis.updateTransmuteOverlay = null; });
+  const { box } = transmuteOverlay;
+
+  const header = document.createElement('div');
+  header.className = 'panel-heading';
+  header.textContent = 'Transmutation';
+  box.appendChild(header);
+
+  const powerEl = document.createElement('div');
+  box.appendChild(powerEl);
+
+  const list = document.createElement('div');
+  list.className = 'transmute-list';
+  box.appendChild(list);
+
+  function formatCost(cost) {
+    return Object.entries(cost)
+      .map(([res, amt]) => `${amt}${res === 'softwood' ? '\u{1FAB5}' : ''}`)
+      .join(', ');
+  }
+
+  function render() {
+    powerEl.textContent = `Power: ${((getTransmutePower() - 1) * 100).toFixed(0)}%`;
+    list.innerHTML = '';
+    Object.entries(TRANSMUTES).forEach(([key, def]) => {
+      if (!def.unlocked) return;
+      const row = document.createElement('div');
+      row.className = 'transmute-entry';
+      const label = document.createElement('div');
+      label.textContent = def.name;
+      row.appendChild(label);
+      const btn = document.createElement('button');
+      btn.textContent = `Transmute (${formatCost(def.input)})`;
+      btn.disabled = !canTransmute(key);
+      btn.addEventListener('click', () => { performTransmute(key); render(); });
+      row.appendChild(btn);
+      list.appendChild(row);
+    });
+  }
+
+  globalThis.updateTransmuteOverlay = render;
+  render();
+}
+
 let buildOverlay = null;
 export function openBuildOverlay() {
   if (buildOverlay) return;
@@ -379,6 +429,7 @@ export function openBuildOverlay() {
     Object.entries(BUILDINGS).forEach(([key, def]) => {
       if (def.requires && !(sectState.buildings[def.requires] > 0)) return;
       if (key === 'orbSpellStrength' && !systems.spellStrengthUnlocked) return;
+      if (key === 'areitoCircle' && !systems.areitoBuildingAvailable) return;
       const built = sectState.buildings[key] || 0;
       const row = document.createElement('div');
       row.className = 'build-entry';
@@ -395,9 +446,16 @@ export function openBuildOverlay() {
         row.appendChild(progress);
       } else {
         const cost = def.costFunc ? def.costFunc(built + 1) : def.cost;
+        const waterCost = def.costWaterFunc ? def.costWaterFunc(built + 1) : 0;
         const btn = document.createElement('button');
-        btn.textContent = `Build (${cost}\u{1FAB5})`;
-        btn.disabled = sectState.softwood < cost || built >= def.max || sectState.currentBuild;
+        const costParts = [`${cost}\u{1FAB5}`];
+        if (waterCost) costParts.push(`${waterCost}\u{1F4A7}`);
+        btn.textContent = `Build (${costParts.join(', ')})`;
+        btn.disabled =
+          sectState.softwood < cost ||
+          sectSystem.orbs.water.current < waterCost ||
+          built >= def.max ||
+          sectState.currentBuild;
         btn.addEventListener('click', () => {
           startBuilding(key);
           render();


### PR DESCRIPTION
## Summary
- implement Circle of Areito building
- enable building unlock after collecting 100 softwood
- add transmutation system with plank recipe
- create transmute overlay and nav button
- document new building and transmute recipe
- add unit tests

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68863ac1f77083269de98106280633f9