### PR TITLE
Fix raid visuals

### DIFF
--- a/docs/23-raids.md
+++ b/docs/23-raids.md
@@ -27,7 +27,9 @@ Disciples may be called upon to defend the sect from occasional raids.
 * The Water orb lashes out every 5&nbsp;s at blobs within 75&nbsp;px, striking the closest target for 5 damage.
 * Blobs show a small health meter as they crawl across the map.
 * When killed, blobs burst in a brief animation.
-* 
+* The Water orb displays a short attack timer bar above it and flashes each time it fires.
+* Disciples briefly grow in size when landing an attack.
+*
 * Damage dealt to and by the Water orb is logged during raids.
 * All units traverse the map at a base rate of 10&nbsp;px per second.
 * SlowBlob raiders crawl at half this speed, moving only 5&nbsp;px per second.

--- a/game/blobRaids.js
+++ b/game/blobRaids.js
@@ -265,6 +265,7 @@ function discipleAttack() {
       if (target) {
         target.takeDamage(DISCIPLE_DAMAGE);
         raidState.damageDealt += DISCIPLE_DAMAGE;
+        runAnimation(el, 'disciple-strike');
         d._attackTimer = now + DISCIPLE_ATTACK_INTERVAL;
       }
     }

--- a/style.css
+++ b/style.css
@@ -2531,6 +2531,16 @@ body.darkenshift-mode .tabsContainer button.active {
     100% { transform: scale(1); }
 }
 
+@keyframes disciple-strike {
+    0% { transform: scale(1); }
+    50% { transform: scale(1.2); }
+    100% { transform: scale(1); }
+}
+
+.disciple-strike {
+    animation: disciple-strike 0.3s ease;
+}
+
 .construct-orb .orb-fill {
     position: absolute;
     bottom: 0;
@@ -3256,6 +3266,8 @@ body.darkenshift-mode .tabsContainer button.active {
     border-radius: 4px;
     overflow: hidden;
     margin-bottom: 2px;
+    pointer-events: none;
+    z-index: 1;
 }
 
 .orb-attack-fill {
@@ -4079,6 +4091,8 @@ body.darkenshift-mode .tabsContainer button.active {
   border:1px solid #7fd9ff;
   border-radius:4px;
   overflow:hidden;
+  pointer-events:none;
+  z-index:1;
 }
 .blob-life-fill{
   height:100%;


### PR DESCRIPTION
## Summary
- ensure blob health bars and orb attack bar appear above units
- animate the orb pulse and disciple attacks during raids
- document raid animations

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68863f3608b88326b5832a3d196e92c6