### PR TITLE
Implement incapacitated disciple healing

### DIFF
--- a/docs/11-needs.md
+++ b/docs/11-needs.md
@@ -12,6 +12,12 @@
 - Max 100; regenerates in 1 day.
 - < 4 → incapacitated; –25% happiness.
 
+### Health
+- Depleted by combat damage; at 0 the disciple is incapacitated.
+- Incapacitated disciples eat 3× food while recovering.
+- Health regenerates to full over 5 minutes.
+- They may resume tasks once reaching 50% health.
+
 ### Sleep
 - Requires 60 s rest per day.
 

--- a/game/constants.js
+++ b/game/constants.js
@@ -35,6 +35,7 @@ export const EXPLORATION_CYCLE_SECONDS = 150;
 export const STAMINA_DRAIN_PER_EXPLORATION = 1;
 export const DISCIPLE_MAX_HEALTH = 10;
 export const REST_TIME_SECONDS = 300; // health fully restored over 5 minutes
+export const INCAPACITATED_FOOD_MULT = 3; // times normal consumption
 
 export const GATHER_WORK_SECONDS = 120; // WorkDuration per slot
 export const MIN_TRAVEL_SECONDS = 1; // minimum travel/haul time

--- a/game/sect.js
+++ b/game/sect.js
@@ -11,7 +11,10 @@ import {
   GATHER_WORK_SECONDS,
   GATHER_SPOTS,
   TASK_GROUPS,
-  ATTRIBUTE_FOR_GROUP
+  ATTRIBUTE_FOR_GROUP,
+  INCAPACITATED_FOOD_MULT,
+  DISCIPLE_MAX_HEALTH,
+  REST_TIME_SECONDS
 } from './constants.js';
 import { intelligenceXpMultiplier } from './attributes.js';
 import { addSkillXp, ensureDiscipleSkills, getTaskSkillProgress } from '../utils/skills.js';
@@ -1442,7 +1445,11 @@ export function getDailyResourceDelta() {
 
 export function tickSect(delta) {
   const dt = delta / 1000;
-  const foodNeed = FRUIT_CONSUMPTION_RATE * sectSystem.disciples.length * dt;
+  let foodNeed = 0;
+  sectSystem.disciples.forEach(d => {
+    const mult = d.incapacitated ? INCAPACITATED_FOOD_MULT : 1;
+    foodNeed += FRUIT_CONSUMPTION_RATE * mult * dt;
+  });
   if (sectState.fruits >= foodNeed) {
     sectState.fruits -= foodNeed;
   } else {
@@ -1454,7 +1461,18 @@ export function tickSect(delta) {
     );
   }
   sectSystem.disciples.forEach(d => {
-    if (d.incapacitated) return;
+    if (d.incapacitated) {
+      d.health = Math.min(
+        DISCIPLE_MAX_HEALTH,
+        d.health + (DISCIPLE_MAX_HEALTH / REST_TIME_SECONDS) * dt
+      );
+      d.currentHp = d.health;
+      if (d.health >= DISCIPLE_MAX_HEALTH / 2) {
+        d.incapacitated = false;
+      } else {
+        return;
+      }
+    }
     const task = sectState.discipleTasks[d.id];
     if (!task || task === 'Idle' || task === 'Resting') {
       if (!(raidState.active && raidState.enemy)) return;

--- a/test/incapacitation.test.js
+++ b/test/incapacitation.test.js
@@ -1,0 +1,51 @@
+/* global describe, it, before, after, beforeEach */
+import { expect } from 'chai';
+import Disciple from '../game/disciple.js';
+import { initializeDisciple } from '../utils/discipleInit.js';
+import { sectState } from '../game/state.js';
+import { FRUIT_CONSUMPTION_RATE } from '../game/constants.js';
+
+let sectModule;
+let sectSystem;
+let tickSect;
+
+before(async () => {
+  globalThis.document = {
+    getElementsByClassName: () => [null],
+    getElementById: () => null,
+    addEventListener: () => {},
+    removeEventListener: () => {}
+  };
+  sectModule = await import('../game/sect.js');
+  ({ sectSystem, tickSect } = sectModule);
+});
+
+after(() => {
+  delete globalThis.document;
+});
+
+beforeEach(() => {
+  sectSystem.disciples.length = 0;
+  Object.keys(sectState.discipleTasks).forEach(k => delete sectState.discipleTasks[k]);
+  sectState.fruits = 10;
+});
+
+describe('incapacitated disciples', () => {
+  it('consume triple food and recover over time', () => {
+    const d = new Disciple({ id: 1 });
+    initializeDisciple(d);
+    d.incapacitated = true;
+    d.health = 0;
+    sectSystem.disciples.push(d);
+    const rate = FRUIT_CONSUMPTION_RATE;
+
+    // simulate until just past 50% health
+    for (let i = 0; i < 151; i++) {
+      tickSect(1000);
+    }
+    expect(d.health).to.be.closeTo(5, 0.1);
+    expect(d.incapacitated).to.be.false;
+    const expectedFood = 10 - rate * 3 * 151;
+    expect(sectState.fruits).to.be.closeTo(expectedFood, 1e-6);
+  });
+});

--- a/test/transmutation.test.js
+++ b/test/transmutation.test.js
@@ -1,4 +1,4 @@
-/* global describe, it, beforeEach */
+/* global describe, it, before, after, beforeEach */
 import { expect } from 'chai';
 import { sectState, systems } from '../game/state.js';
 


### PR DESCRIPTION
## Summary
- add INCAPACITATED_FOOD_MULT constant
- regenerate health for incapacitated disciples in `tickSect`
- allow disciples to return to work once past 50% health
- document new health rules
- fix ESLint globals for tests
- test incapacitated disciple recovery

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688643c3b4ec8326afe0522c6229e0c3