### PR TITLE
Add injury system and health tab

### DIFF
--- a/docs/24-injury-system.md
+++ b/docs/24-injury-system.md
@@ -1,0 +1,37 @@
+# 24 – Injury System and Health Tab
+
+This module introduces a granular injury system for disciples. Each body part contributes a portion of the disciple's maximum health. Injuries progress from **Bruise** → **Wound** → **Destroyed** and reduce available HP.
+
+## Body Part Contributions
+
+| Body Part     | HP % | Vital |
+|---------------|------|-------|
+| Head          | 20%  | ✅ |
+| Eye (×2)      | 5% (2.5% each) |  |
+| Vocal Sac     | 5%   | |
+| Hands (×2)    | 10% (5% each) | |
+| Legs (×2)     | 10% (5% each) | |
+| Belly         | 10%  | |
+| Inner Meridians | 10% | |
+
+The sum of healthy parts determines current maximum HP.
+
+## Injury Progression
+
+| Tier      | Effect                          | Progress Speed |
+|-----------|---------------------------------|----------------|
+| Bruise    | Minor penalty                   | 0.5%/s |
+| Wound     | HP drain and severe penalty     | 1.0%/s |
+| Destroyed | Part nonfunctional              | — |
+
+Resting reduces progress speed by 2. Positive resilience heals injuries over time. Destroyed parts cannot be healed.
+
+## Stacking and Death
+
+Only one injury per body part is tracked. Incoming injuries upgrade severity. Destroying any vital part immediately incapacitates the disciple.
+
+When all non-vital parts are destroyed the disciple is effectively crippled with only 1 HP remaining.
+
+## Health Tab
+
+The disciple overlay now contains a **Health** tab. Each body part displays an injury bar indicating current severity. Bruises fill the bar with a brown tint, wounds with red and destroyed parts appear dark.

--- a/docs/README.md
+++ b/docs/README.md
@@ -68,4 +68,5 @@ Table of Contents
 21. [Metamorphosis UI Expansion](21-metamorphosis-ui.md)
 22. [Affinities](22-affinities.md)
 23. [Raids](23-raids.md)
+24. [Injury System & Health Tab](24-injury-system.md)
 

--- a/game/injury.js
+++ b/game/injury.js
@@ -1,0 +1,71 @@
+export const BODY_PARTS = [
+  { key: 'head', label: 'Head', contribution: 0.2, vital: true },
+  { key: 'leftEye', label: 'Left Eye', contribution: 0.025, vital: false },
+  { key: 'rightEye', label: 'Right Eye', contribution: 0.025, vital: false },
+  { key: 'vocalSac', label: 'Vocal Sac', contribution: 0.05, vital: false },
+  { key: 'leftHand', label: 'Left Hand', contribution: 0.05, vital: false },
+  { key: 'rightHand', label: 'Right Hand', contribution: 0.05, vital: false },
+  { key: 'leftLeg', label: 'Left Leg', contribution: 0.05, vital: false },
+  { key: 'rightLeg', label: 'Right Leg', contribution: 0.05, vital: false },
+  { key: 'belly', label: 'Belly', contribution: 0.1, vital: false },
+  { key: "meridians", label: "Inner Meridians", contribution: 0.1, vital: false },
+];
+
+export const INJURY_TIERS = [
+  { key: 'bruise', rate: 0.5, heals: true },
+  { key: 'wound', rate: 1.0, heals: true },
+  { key: 'destroyed', rate: 0, heals: false }
+];
+
+export function ensureInjuryState(d) {
+  if (!d.injuries) d.injuries = {};
+  BODY_PARTS.forEach(p => {
+    if (!d.injuries[p.key]) {
+      d.injuries[p.key] = { tier: null, progress: 0 };
+    }
+  });
+}
+
+export function calculateMaxHealth(d) {
+  ensureInjuryState(d);
+  const base = d.maxHp;
+  let hp = 0;
+  BODY_PARTS.forEach(p => {
+    const state = d.injuries[p.key];
+    if (state.tier !== 'destroyed') hp += base * p.contribution;
+  });
+  return Math.round(hp);
+}
+
+export function applyInjury(d, partKey, tier) {
+  ensureInjuryState(d);
+  const part = d.injuries[partKey];
+  if (!part) return;
+  const currentIndex = INJURY_TIERS.findIndex(t => t.key === part.tier);
+  const newIndex = INJURY_TIERS.findIndex(t => t.key === tier);
+  if (newIndex > currentIndex) {
+    part.tier = tier;
+    part.progress = 0;
+  }
+}
+
+export function tickInjuries(d, dt, resilience = 0) {
+  ensureInjuryState(d);
+  const resting = (d.currentTask || '') === 'Resting';
+  BODY_PARTS.forEach(p => {
+    const state = d.injuries[p.key];
+    if (!state.tier || state.tier === 'destroyed') return;
+    const tierInfo = INJURY_TIERS.find(t => t.key === state.tier);
+    let rate = tierInfo.rate;
+    if (resting) rate -= 2;
+    const recover = resilience - rate;
+    state.progress = Math.max(0, state.progress + rate * dt);
+    if (recover > 0) state.progress = Math.max(0, state.progress - recover * dt);
+    if (state.progress >= 100 && tierInfo.key !== 'destroyed') {
+      const nextIndex = INJURY_TIERS.indexOf(tierInfo) + 1;
+      state.tier = INJURY_TIERS[Math.min(nextIndex, INJURY_TIERS.length - 1)].key;
+      state.progress = 0;
+    }
+  });
+  d.health = calculateMaxHealth(d);
+}

--- a/script.js
+++ b/script.js
@@ -58,6 +58,7 @@ import {
   calculateMaxStamina,
   calculateStaminaRegen
 } from './utils/stamina.js';
+import { BODY_PARTS } from './game/injury.js';
 import {
   calculateMaxWater,
   calculateWaterRegen
@@ -1183,6 +1184,32 @@ function buildDiscipleMoodletsView() {
   return container;
 }
 
+function buildDiscipleHealthView(d) {
+  const container = document.createElement('div');
+  container.className = 'disciple-health-view';
+  BODY_PARTS.forEach(p => {
+    const row = document.createElement('div');
+    row.className = 'body-part-row';
+    const label = document.createElement('span');
+    label.className = 'body-part-label';
+    label.textContent = p.label;
+    const bar = document.createElement('div');
+    bar.className = 'injury-bar';
+    const fill = document.createElement('div');
+    fill.className = 'injury-bar-fill';
+    const state = d.injuries?.[p.key];
+    if (state) {
+      fill.style.width = `${Math.min(100, state.progress)}%`;
+      if (state.tier) fill.classList.add(state.tier);
+    }
+    bar.appendChild(fill);
+    row.append(label);
+    row.appendChild(bar);
+    container.appendChild(row);
+  });
+  return container;
+}
+
 function renderSectDiscipleList() {
   if (!sectDiscipleListContainer) return;
   sectDiscipleListContainer.innerHTML = '';
@@ -1222,6 +1249,7 @@ function openDiscipleOverlay(d) {
 
   const defs = [
     { key: 'general', label: 'General' },
+    { key: 'health', label: 'Health' },
     { key: 'proficiency', label: 'Proficiency' },
     { key: 'moodlets', label: 'Moodlets' },
     { key: 'stats', label: 'Stats' }
@@ -1232,6 +1260,8 @@ function openDiscipleOverlay(d) {
     if (active === 'general') {
       const view = buildDiscipleGeneralView(d);
       content.appendChild(view);
+    } else if (active === 'health') {
+      content.appendChild(buildDiscipleHealthView(d));
     } else if (active === 'proficiency') {
       content.appendChild(buildDiscipleProficiencyView(d));
     } else if (active === 'moodlets') {

--- a/style.css
+++ b/style.css
@@ -4129,3 +4129,32 @@ body.darkenshift-mode .tabsContainer button.active {
 .blob-burst {
   animation: blob-burst 0.4s ease-out forwards;
 }
+
+.injury-bar {
+  width: 100%;
+  height: 6px;
+  background: #444;
+  border: 1px solid #222;
+  position: relative;
+  margin-top: 2px;
+}
+
+.injury-bar-fill {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 0%;
+}
+
+.injury-bar-fill.bruise {
+  background: #b86;
+}
+
+.injury-bar-fill.wound {
+  background: #e33;
+}
+
+.injury-bar-fill.destroyed {
+  background: #111;
+}

--- a/test/transmutation.test.js
+++ b/test/transmutation.test.js
@@ -1,4 +1,4 @@
-/* global describe, it, beforeEach */
+/* global describe, it, beforeEach, before, after */
 import { expect } from 'chai';
 import { sectState, systems } from '../game/state.js';
 

--- a/utils/discipleInit.js
+++ b/utils/discipleInit.js
@@ -1,6 +1,7 @@
 import Disciple from '../game/disciple.js';
 import { calculateMaxWater } from './water.js';
 import { sectState } from '../game/state.js';
+import { ensureInjuryState } from '../game/injury.js';
 
 export function initializeDisciple(d) {
   if (!d) return d;
@@ -33,6 +34,7 @@ export function initializeDisciple(d) {
   if (d.currentHp === undefined) d.currentHp = d.maxHp;
   if (d.foundationXp === undefined) d.foundationXp = 0;
   if (d.lastTab === undefined) d.lastTab = 'general';
+  ensureInjuryState(d);
   if (!sectState.discipleMetamorphosis[d.id]) {
     sectState.discipleMetamorphosis[d.id] = {
       xp: 0,


### PR DESCRIPTION
## Summary
- document new injury system rules
- implement injury model with body parts and tiers
- initialize injuries for disciples and expose to overlay
- add Health tab to disciple overlay showing injuries
- style injury bars and update docs index

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6886620ef6d88326b4e677bf309f7043