### PR TITLE
Add raid splatter visuals

### DIFF
--- a/docs/23-raids.md
+++ b/docs/23-raids.md
@@ -29,6 +29,7 @@ Disciples may be called upon to defend the sect from occasional raids.
 * When killed, blobs burst in a brief animation.
 * The Water orb displays a short attack timer bar above it and flashes each time it fires.
 * Disciples briefly grow in size when landing an attack.
+* When raiders are struck a red splatter appears on the ground and remains on the sect map.
 *
 * Damage dealt to and by the Water orb is logged during raids.
 * All units traverse the map at a base rate of 10&nbsp;px per second.

--- a/game/blobRaids.js
+++ b/game/blobRaids.js
@@ -5,6 +5,7 @@ import { BASE_MOVE_SPEED } from './constants.js';
 import { flashOrbGlow } from './orbGlow.js';
 import { raidState, endRaid } from './raids.js';
 import { damageDisciple } from './combat.js';
+import { createMapSplatter } from './rendering.js';
 
 
 
@@ -203,6 +204,7 @@ function createBlob() {
         const pct = (this.hp / this.maxHp) * 100;
         this.lifeFill.style.width = `${pct}%`;
       }
+      createMapSplatter(this.x, this.y);
       if (this.hp === 0) {
         runAnimation(this.el, 'blob-burst', 400).then(() => this.el.remove());
         const idx = blobs.indexOf(this);

--- a/game/rendering.js
+++ b/game/rendering.js
@@ -1,5 +1,34 @@
 import { runAnimation } from '../utils/animation.js';
 
+export function drawBloodSplat(canvas) {
+  const ctx = canvas.getContext && canvas.getContext('2d');
+  if (!ctx) return;
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  for (let i = 0; i < 6; i++) {
+    const r = Math.random() * 10 + 5;
+    const x = Math.random() * canvas.width;
+    const y = Math.random() * canvas.height;
+    ctx.beginPath();
+    ctx.fillStyle = `rgba(150,0,0,${0.5 + Math.random() * 0.5})`;
+    ctx.arc(x, y, r, 0, Math.PI * 2);
+    ctx.fill();
+  }
+}
+
+export function createMapSplatter(x, y) {
+  const map = document.getElementById('colonyMap');
+  if (!map) return;
+  const size = 20 + Math.random() * 20;
+  const canvas = document.createElement('canvas');
+  canvas.className = 'map-splatter';
+  canvas.width = size;
+  canvas.height = size;
+  canvas.style.left = `${x - size / 2}px`;
+  canvas.style.top = `${y - size / 2}px`;
+  drawBloodSplat(canvas);
+  map.appendChild(canvas);
+}
+
 export function renderDealerLifeBar(dealerLifeDisplay, currentEnemy) {
   if (document.querySelector('.dealerLifeContainer')) return;
   const container = document.createElement('div');
@@ -91,19 +120,6 @@ export function renderDiscipleCard(disciple, handContainer) {
 }
 
 
-function drawBloodSplat(canvas) {
-  const ctx = canvas.getContext('2d');
-  ctx.clearRect(0, 0, canvas.width, canvas.height);
-  for (let i = 0; i < 6; i++) {
-    const r = Math.random() * 10 + 5;
-    const x = Math.random() * canvas.width;
-    const y = Math.random() * canvas.height;
-    ctx.beginPath();
-    ctx.fillStyle = `rgba(150,0,0,${0.5 + Math.random() * 0.5})`;
-    ctx.arc(x, y, r, 0, Math.PI * 2);
-    ctx.fill();
-  }
-}
 
 export function applyBloodSplat(card) {
   if (!card.cardElement) return;

--- a/style.css
+++ b/style.css
@@ -4129,3 +4129,9 @@ body.darkenshift-mode .tabsContainer button.active {
 .blob-burst {
   animation: blob-burst 0.4s ease-out forwards;
 }
+
+.map-splatter {
+  position: absolute;
+  pointer-events: none;
+  z-index: 0;
+}

--- a/test/blob-raids.test.js
+++ b/test/blob-raids.test.js
@@ -11,7 +11,14 @@ function setupDom() {
   globalThis.document = {
     getElementById: id => (id === 'colonyMap' ? map : null),
     querySelector: sel => (sel === '#sectOrbs .sect-orb.water' ? orb : null),
-    createElement: () => ({ appendChild() {}, style: {}, className: '', remove() {} })
+    createElement: tag => ({
+      tagName: tag,
+      childNodes: [],
+      appendChild(el) { this.childNodes.push(el); },
+      style: {},
+      className: '',
+      remove() {}
+    })
   };
   globalThis.window = {};
 }
@@ -35,5 +42,15 @@ describe('blob raids', () => {
     expect(success).to.be.true;
     expect(blobs[0].lifeFill).to.exist;
     expect(blobs[0].lifeFill.style.width).to.equal('100%');
+  });
+
+  it('creates map splatter when damaged', () => {
+    spawnBlob();
+    const map = document.getElementById('colonyMap');
+    const before = map.childNodes.length;
+    blobs[0].takeDamage(1);
+    expect(map.childNodes.length).to.be.above(before);
+    const last = map.childNodes[map.childNodes.length - 1];
+    expect(last.className).to.equal('map-splatter');
   });
 });

--- a/test/transmutation.test.js
+++ b/test/transmutation.test.js
@@ -1,4 +1,4 @@
-/* global describe, it, beforeEach */
+/* global describe, it, before, after, beforeEach */
 import { expect } from 'chai';
 import { sectState, systems } from '../game/state.js';
 


### PR DESCRIPTION
## Summary
- show blood splatter canvas when raiders take damage
- factor out blood splat drawing logic and reuse it in rendering
- style map splatter and document new raid effect
- test for map splatter

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6886631866988326973af78e52242fb1