### PR TITLE
Add metamorphosis stage bonuses

### DIFF
--- a/docs/13-metamorphosis-stages-&-methods.md
+++ b/docs/13-metamorphosis-stages-&-methods.md
@@ -23,6 +23,17 @@ As a disciple progresses, their sprite on the sect map gains a brighter aura.
 Early stages feature a subtle glow while higher stages emit pulsing colors to
 reflect growing power.
 
+### Universal Stage Bonuses
+
+Every breakthrough grants the disciple cumulative stat increases regardless of their chosen Path:
+
+- **Max Water** +100
+- **Water Regeneration** +2 per second
+- **Resilience** +0.2% per second
+- **Spell Potency** +20%
+- **Base Attack Damage** +3
+- **Movement Speed** +10%
+
 ### 1. 🥚 Egg Stage
 
 - **Requirement**: 25,000 metamorphosis XP

--- a/game/badges.js
+++ b/game/badges.js
@@ -1,6 +1,6 @@
 import { makeBar } from './ui.js';
 import { sectState } from './state.js';
-import { calculateMaxWater } from '../utils/water.js';
+import { getMaxWater } from './metamorphosisBonuses.js';
 import { DISCIPLE_MAX_HEALTH } from './constants.js';
 
 export function createDiscipleBadge(d) {
@@ -26,7 +26,7 @@ export function createDiscipleBadge(d) {
   content.appendChild(lifeBar);
 
   const waterLvl = sectState.discipleSkills[d.id]?.WaterSense || 0;
-  const waterBar = makeBar(d.water, calculateMaxWater(waterLvl), '#7fd9ff');
+  const waterBar = makeBar(d.water, getMaxWater(d, waterLvl), '#7fd9ff');
   waterBar.classList.add('water-bar');
   content.appendChild(waterBar);
 

--- a/game/disciple.js
+++ b/game/disciple.js
@@ -4,6 +4,8 @@
 import { generateDiscipleAttributes } from './discipleAttributes.js';
 import { xpRequirement } from '../utils/xp.js';
 import { runAnimation } from '../utils/animation.js';
+import { sectState } from './state.js';
+import { STAGE_BONUS } from './metamorphosisBonuses.js';
 
 export default class Disciple {
   constructor({ id = 0, name = `Disciple ${id}`, maxHp = 10, combatLevel = 1, attributes = generateDiscipleAttributes() } = {}) {
@@ -44,8 +46,10 @@ export default class Disciple {
 
   updateCombatStats() {
     // Combat stats no longer scale with attributes.
-    // Damage and defense grow purely with combat level as documented.
-    this.damage = this.combatLevel * 3;
+    // Damage and defense grow purely with combat level and metamorphosis bonuses.
+    const stage = sectState.discipleMetamorphosis[this.id]?.stage || 0;
+    const stageBonus = stage * STAGE_BONUS.attack;
+    this.damage = this.combatLevel * 3 + stageBonus;
     this.attackSpeed = 10000;
     this.defense = this.combatLevel;
   }

--- a/game/metamorphosis.js
+++ b/game/metamorphosis.js
@@ -3,6 +3,7 @@ import { sectState } from './state.js';
 import { createDiscipleBadge } from './badges.js';
 import { METAMORPHOSIS_STAGE_REQ, TRAINING_NECTAR_RATE } from './constants.js';
 import { showPathOverlay } from './pathOverlay.js';
+import { applyStageBonuses } from './metamorphosisBonuses.js';
 
 export const metamorphosisState = {
   requirement: METAMORPHOSIS_STAGE_REQ
@@ -132,6 +133,11 @@ function breakthrough(id) {
   if (!meta) return;
   meta.xp = 0;
   meta.stage += 1;
+  const d = sectSystem.disciples.find(x => x.id === id);
+  if (d) {
+    applyStageBonuses(d);
+    d.updateCombatStats?.();
+  }
   sectSystem.orbs.water.current = 0;
   if (meta.stage === 1) {
     showPathOverlay({ onSelect: path => { sectState.disciplePaths[id] = path; } });

--- a/game/metamorphosisBonuses.js
+++ b/game/metamorphosisBonuses.js
@@ -1,0 +1,34 @@
+import { sectState } from './state.js';
+import { calculateMaxWater, calculateWaterRegen } from '../utils/water.js';
+import { BASE_MOVE_SPEED } from './constants.js';
+
+export const STAGE_BONUS = {
+  maxWater: 100,
+  waterRegen: 2,
+  resilience: 0.002,
+  potency: 0.2,
+  attack: 3,
+  moveSpeed: 0.1
+};
+
+export function getStage(d) {
+  return sectState.discipleMetamorphosis[d.id]?.stage || 0;
+}
+
+export function applyStageBonuses(d) {
+  const stage = getStage(d);
+  d.maxWaterBonus = stage * STAGE_BONUS.maxWater;
+  d.waterRegenBonus = stage * STAGE_BONUS.waterRegen;
+  d.resilience = stage * STAGE_BONUS.resilience;
+  d.spellPotency = 1 + stage * STAGE_BONUS.potency;
+  d.damageBonus = stage * STAGE_BONUS.attack;
+  d.moveSpeed = BASE_MOVE_SPEED * (1 + stage * STAGE_BONUS.moveSpeed);
+}
+
+export function getMaxWater(d, waterSenseLevel = 0) {
+  return calculateMaxWater(waterSenseLevel) + (d.maxWaterBonus || 0);
+}
+
+export function getWaterRegen(d, waterSenseLevel = 0) {
+  return calculateWaterRegen(waterSenseLevel) + (d.waterRegenBonus || 0);
+}

--- a/script.js
+++ b/script.js
@@ -63,6 +63,7 @@ import {
   calculateMaxWater,
   calculateWaterRegen
 } from './utils/water.js';
+import { getMaxWater, getWaterRegen } from './game/metamorphosisBonuses.js';
 import { initializeDisciple } from './utils/discipleInit.js';
 import { initializeSect } from './utils/sectInit.js';
 import {
@@ -682,7 +683,7 @@ function updateDiscipleWaterDisplay() {
     const waterLvl = getTaskSkillProgress(
       sectState.discipleSkills[d.id]?.WaterSense || 0
     ).level;
-    const max = calculateMaxWater(waterLvl);
+    const max = getMaxWater(d, waterLvl);
     document
       .querySelectorAll(`.disciple-badge[data-disciple-id="${d.id}"] .water-bar .bar-fill`)
       .forEach(fill => {
@@ -695,7 +696,7 @@ function updateDiscipleWaterDisplay() {
       const waterLvl = getTaskSkillProgress(
         sectState.discipleSkills[d.id]?.WaterSense || 0
       ).level;
-      const max = calculateMaxWater(waterLvl);
+      const max = getMaxWater(d, waterLvl);
       const row = discipleOverlay.box.querySelector(
         '.disciple-general .stat-row[data-stat="water"]'
       );
@@ -807,7 +808,7 @@ function updateSectDisplay() {
         el.className = 'sect-disciple';
         sectDiscipleEls[d.id] = el;
         sectDisciplesContainer.appendChild(el);
-        moveDisciple(el);
+        moveDisciple(d, el);
         initDiscipleVisual(d, el);
       }
     });
@@ -871,14 +872,14 @@ function updateMapBrightness(phase) {
 
 function feedDisciples() {}
 
-function moveDisciple(el) {
+function moveDisciple(d, el) {
   const cont = el.parentElement;
   if (!cont) return;
   const maxX = Math.max(cont.clientWidth - 20, 0);
   const maxY = Math.max(cont.clientHeight - 20, 0);
   const x = Math.random() * maxX;
   const y = Math.random() * maxY;
-  moveElement(el, x, y);
+  moveElement(el, x, y, d.moveSpeed);
 }
 
 function updateDiscipleGather(id, el) {
@@ -887,7 +888,8 @@ function updateDiscipleGather(id, el) {
   const px = patch.offsetLeft + patch.offsetWidth / 2 - 8;
   const py = patch.offsetTop + patch.offsetHeight / 2 - 8;
   el.style.opacity = '1';
-  moveElement(el, px, py);
+  const d = sectSystem.disciples.find(x => x.id === id);
+  moveElement(el, px, py, d?.moveSpeed);
 }
 
 function startDiscipleMovement() {
@@ -902,7 +904,7 @@ function startDiscipleMovement() {
         if (orb) {
           const bx = orb.offsetLeft + orb.offsetWidth / 2 - 2;
           const by = orb.offsetTop + orb.offsetHeight / 2 - 2;
-          moveElement(el, bx, by);
+          moveElement(el, bx, by, d.moveSpeed);
         }
         el.classList.add('incapacitated');
         taskName = 'Resting';
@@ -915,7 +917,7 @@ function startDiscipleMovement() {
           if (orb) {
             const bx = orb.offsetLeft + orb.offsetWidth / 2 - 2;
             const by = orb.offsetTop + orb.offsetHeight / 2 - 2;
-            moveElement(el, bx, by);
+            moveElement(el, bx, by, d.moveSpeed);
           }
                     taskName = task;
         } else if (phase !== 'Work') {
@@ -941,12 +943,12 @@ function startDiscipleMovement() {
                 }
               });
               if (target) {
-                moveElement(el, target.x, target.y, BASE_MOVE_SPEED);
+                moveElement(el, target.x, target.y, d.moveSpeed);
               } else {
-                moveDisciple(el);
+                moveDisciple(d, el);
               }
             }
-          } else moveDisciple(el);
+          } else moveDisciple(d, el);
         }
       }
       updateDiscipleVisual(d, el, taskName);
@@ -1027,11 +1029,11 @@ function buildDiscipleGeneralView(d) {
   const waterRow = makeStatRow(
     'Water',
     d.water,
-    calculateMaxWater(waterLvl),
+    getMaxWater(d, waterLvl),
     'linear-gradient(90deg,#39f,#6cf)'
   );
   const waterRate = document.createElement('span');
-  waterRate.textContent = ` (+${calculateWaterRegen(waterLvl).toFixed(2)}/s)`;
+  waterRate.textContent = ` (+${getWaterRegen(d, waterLvl).toFixed(2)}/s)`;
   waterRow.appendChild(waterRate);
   vit.appendChild(waterRow);
   body.appendChild(vit);

--- a/utils/discipleInit.js
+++ b/utils/discipleInit.js
@@ -2,6 +2,7 @@ import Disciple from '../game/disciple.js';
 import { calculateMaxWater } from './water.js';
 import { sectState } from '../game/state.js';
 import { ensureInjuryState } from '../game/injury.js';
+import { applyStageBonuses } from '../game/metamorphosisBonuses.js';
 
 export function initializeDisciple(d) {
   if (!d) return d;
@@ -47,5 +48,6 @@ export function initializeDisciple(d) {
   }
   Object.setPrototypeOf(d, Disciple.prototype);
   if (typeof d.updateCombatStats === 'function') d.updateCombatStats();
+  applyStageBonuses(d);
   return d;
 }


### PR DESCRIPTION
## Summary
- implement stat bonuses for metamorphosis breakthroughs
- add helper module `metamorphosisBonuses`
- update disciple initialization and combat stats
- scale movement speed and water stats with stage

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68866c3657a88326b9b46c805fac06aa