### PR TITLE
Implement injury system with resilience

### DIFF
--- a/docs/24-injury-system.md
+++ b/docs/24-injury-system.md
@@ -2,6 +2,22 @@
 
 This module introduces a granular injury system for disciples. Each body part contributes a portion of the disciple's maximum health. Injuries progress from **Bruise** → **Wound** → **Destroyed** and reduce available HP.
 
+When a disciple's Water reaches 0 they start taking damage each second. Every hit randomly targets a body part using the following chances:
+
+| Body Part | Chance |
+|-----------|-------|
+| Head | 5% |
+| Left Eye | 2% |
+| Right Eye | 2% |
+| Vocal Sac | 10% |
+| Belly | 15% |
+| Left Hand | 5% |
+| Right Hand | 5% |
+| Left Leg | 10% |
+| Right Leg | 10% |
+| Inner Meridians | 10% |
+| General | 26% |
+
 ## Body Part Contributions
 
 | Body Part     | HP % | Vital |
@@ -20,11 +36,11 @@ The sum of healthy parts determines current maximum HP.
 
 | Tier      | Effect                          | Progress Speed |
 |-----------|---------------------------------|----------------|
-| Bruise    | Minor penalty                   | 0.5%/s |
-| Wound     | HP drain and severe penalty     | 1.0%/s |
+| Bruise    | Minor penalty                   | 0.25–0.5%/s |
+| Wound     | HP drain and severe penalty     | 0.5–1%/s |
 | Destroyed | Part nonfunctional              | — |
 
-Resting reduces progress speed by 2. Positive resilience heals injuries over time. Destroyed parts cannot be healed.
+Resting halves the injury rate. Each disciple has a **Resilience** stat (starting at 1%/s) that reduces progress and also restores lost HP at the same rate. Destroyed parts cannot be healed.
 
 ## Stacking and Death
 

--- a/game/disciple.js
+++ b/game/disciple.js
@@ -20,6 +20,8 @@ export default class Disciple {
     this.intelligence = attributes.intelligence || 0;
     this.charisma = attributes.charisma || 0;
     this.potential = attributes.potential || 0;
+    // base resilience percentage per second for healing injuries and HP
+    this.resilience = 1;
     this.defense = 1;
     this.lastTab = 'general';
     this.updateCombatStats();

--- a/game/injury.js
+++ b/game/injury.js
@@ -11,10 +11,34 @@ export const BODY_PARTS = [
   { key: "meridians", label: "Inner Meridians", contribution: 0.1, vital: false },
 ];
 
+export const BODY_PART_CHANCES = [
+  { key: 'head', chance: 5 },
+  { key: 'leftEye', chance: 2 },
+  { key: 'rightEye', chance: 2 },
+  { key: 'vocalSac', chance: 10 },
+  { key: 'belly', chance: 15 },
+  { key: 'leftHand', chance: 5 },
+  { key: 'rightHand', chance: 5 },
+  { key: 'leftLeg', chance: 10 },
+  { key: 'rightLeg', chance: 10 },
+  { key: 'meridians', chance: 10 },
+  { key: 'general', chance: 26 }
+];
+
+export function randomBodyPart() {
+  const roll = Math.random() * 100;
+  let sum = 0;
+  for (const entry of BODY_PART_CHANCES) {
+    sum += entry.chance;
+    if (roll < sum) return entry.key;
+  }
+  return 'general';
+}
+
 export const INJURY_TIERS = [
-  { key: 'bruise', rate: 0.5, heals: true },
-  { key: 'wound', rate: 1.0, heals: true },
-  { key: 'destroyed', rate: 0, heals: false }
+  { key: 'bruise', rateRange: [0.25, 0.5], heals: true },
+  { key: 'wound', rateRange: [0.5, 1.0], heals: true },
+  { key: 'destroyed', rateRange: [0, 0], heals: false }
 ];
 
 export function ensureInjuryState(d) {
@@ -37,6 +61,16 @@ export function calculateMaxHealth(d) {
   return Math.round(hp);
 }
 
+export function applyStarvationHit(d) {
+  const part = randomBodyPart();
+  if (part !== 'general') {
+    const tier = Math.random() < 0.5 ? 'bruise' : 'wound';
+    applyInjury(d, part, tier);
+  }
+  d.health = Math.max(0, d.health - 1);
+  if (d.health === 0) d.incapacitated = true;
+}
+
 export function applyInjury(d, partKey, tier) {
   ensureInjuryState(d);
   const part = d.injuries[partKey];
@@ -45,27 +79,39 @@ export function applyInjury(d, partKey, tier) {
   const newIndex = INJURY_TIERS.findIndex(t => t.key === tier);
   if (newIndex > currentIndex) {
     part.tier = tier;
+    const range = INJURY_TIERS[newIndex].rateRange;
+    part.rate = Math.random() * (range[1] - range[0]) + range[0];
     part.progress = 0;
   }
 }
 
-export function tickInjuries(d, dt, resilience = 0) {
+export function tickInjuries(d, dt, resilience = 0, task = 'Idle') {
   ensureInjuryState(d);
-  const resting = (d.currentTask || '') === 'Resting';
+  const resting = task === 'Resting';
   BODY_PARTS.forEach(p => {
     const state = d.injuries[p.key];
     if (!state.tier || state.tier === 'destroyed') return;
     const tierInfo = INJURY_TIERS.find(t => t.key === state.tier);
-    let rate = tierInfo.rate;
-    if (resting) rate -= 2;
-    const recover = resilience - rate;
-    state.progress = Math.max(0, state.progress + rate * dt);
-    if (recover > 0) state.progress = Math.max(0, state.progress - recover * dt);
-    if (state.progress >= 100 && tierInfo.key !== 'destroyed') {
-      const nextIndex = INJURY_TIERS.indexOf(tierInfo) + 1;
-      state.tier = INJURY_TIERS[Math.min(nextIndex, INJURY_TIERS.length - 1)].key;
+    const baseRate = state.rate ??
+      (Math.random() * (tierInfo.rateRange[1] - tierInfo.rateRange[0]) + tierInfo.rateRange[0]);
+    state.rate = baseRate;
+    let rate = baseRate;
+    if (resting) rate /= 2;
+    const net = rate - resilience;
+    state.progress = Math.max(0, state.progress + net * dt);
+    if (state.progress >= 200) {
+      state.tier = 'destroyed';
+      state.progress = 200;
+      if (p.vital) d.incapacitated = true;
+    } else if (state.progress >= 100 && state.tier === 'bruise') {
+      state.tier = 'wound';
+      const range = INJURY_TIERS[1].rateRange;
+      state.rate = Math.random() * (range[1] - range[0]) + range[0];
       state.progress = 0;
+    } else if (state.progress === 0 && net < 0) {
+      state.tier = null;
     }
   });
-  d.health = calculateMaxHealth(d);
+  const maxHp = calculateMaxHealth(d);
+  d.health = Math.min(maxHp, d.health + resilience * dt);
 }

--- a/game/sect.js
+++ b/game/sect.js
@@ -33,6 +33,7 @@ import { applyDiscipleAttacks } from './combat.js';
 import { startRaid, tickRaid, raidState, endRaid } from './raids.js';
 import { updateRaidLifeBar } from './ui.js';
 import { tickOrbSpells } from './orbSpells.js';
+import { applyStarvationHit, tickInjuries } from './injury.js';
 
 export { addDiscoveredLocation } from "./ui.js";
 export const discoveredLocations = [];
@@ -1539,6 +1540,18 @@ export function tickSect(delta) {
       const mult = intelligenceXpMultiplier() * getAffinityMultiplier(d, group);
       addSkillXp(d, group, xpRate * dt * mult);
     }
+
+    if (!d.starveTimer) d.starveTimer = 0;
+    if (d.water <= 0) {
+      d.starveTimer += dt;
+      while (d.starveTimer >= 1) {
+        applyStarvationHit(d);
+        d.starveTimer -= 1;
+      }
+    } else {
+      d.starveTimer = 0;
+    }
+    tickInjuries(d, dt, d.resilience, task);
   });
 
 }

--- a/script.js
+++ b/script.js
@@ -1034,6 +1034,14 @@ function buildDiscipleGeneralView(d) {
   waterRate.textContent = ` (+${calculateWaterRegen(waterLvl).toFixed(2)}/s)`;
   waterRow.appendChild(waterRate);
   vit.appendChild(waterRow);
+  const resRow = makeStatRow(
+    'Resilience',
+    d.resilience.toFixed(2),
+    5,
+    'linear-gradient(90deg,#9bf,#bdf)'
+  );
+  resRow.querySelector('.stat-value').textContent = `${d.resilience.toFixed(2)}%/s`;
+  vit.appendChild(resRow);
   body.appendChild(vit);
 
   const task = document.createElement('div');

--- a/test/injury-system.test.js
+++ b/test/injury-system.test.js
@@ -1,0 +1,56 @@
+/* global describe, it, before, after, beforeEach */
+import { expect } from 'chai';
+import Disciple from '../game/disciple.js';
+import { initializeDisciple } from '../utils/discipleInit.js';
+import { sectState } from '../game/state.js';
+
+let sectModule;
+let sectSystem;
+let tickSect;
+let tickInjuries;
+let applyInjury;
+let BODY_PARTS;
+
+before(async () => {
+  globalThis.document = {
+    getElementsByClassName: () => [null],
+    getElementById: () => null,
+    addEventListener: () => {},
+    removeEventListener: () => {}
+  };
+  sectModule = await import('../game/sect.js');
+  ({ sectSystem, tickSect } = sectModule);
+  ({ tickInjuries, applyInjury, BODY_PARTS } = await import('../game/injury.js'));
+});
+
+after(() => {
+  delete globalThis.document;
+});
+
+beforeEach(() => {
+  sectSystem.disciples.length = 0;
+});
+
+describe('injury system', () => {
+  it('applies starvation damage and injuries', () => {
+    const d = new Disciple({ id: 1 });
+    initializeDisciple(d);
+    d.water = 0;
+    sectSystem.disciples.push(d);
+    sectState.discipleTasks[d.id] = 'Research';
+    const prev = Math.random;
+    Math.random = () => 0; // always hit head and apply bruise
+    tickSect(1000);
+    Math.random = prev;
+    expect(d.health).to.be.below(10);
+  });
+
+  it('resilience slows injury progress', () => {
+    const d = new Disciple({ id: 1 });
+    initializeDisciple(d);
+    applyInjury(d, 'head', 'bruise');
+    d.injuries.head.rate = 0.5;
+    tickInjuries(d, 1, 0.4, 'Idle');
+    expect(d.injuries.head.progress).to.be.closeTo(0.1, 1e-6);
+  });
+});

--- a/utils/discipleInit.js
+++ b/utils/discipleInit.js
@@ -25,6 +25,7 @@ export function initializeDisciple(d) {
   if (d.baseIntelligence === undefined) d.baseIntelligence = d.intelligence;
   if (d.baseCharisma === undefined) d.baseCharisma = d.charisma;
   if (d.basePotential === undefined) d.basePotential = d.potential;
+  if (d.resilience === undefined) d.resilience = 1;
   if (d.incapacitated === undefined) d.incapacitated = false;
   if (!d.name) d.name = `Disciple ${d.id}`;
   if (d.inventorySlots === undefined) d.inventorySlots = 10;


### PR DESCRIPTION
## Summary
- expand injury system with body part hit chances and starvation damage
- add resilience stat to disciples and show it in the UI
- update injury progression docs with hit table and resilience info
- provide basic unit tests for injuries

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68866d8776a88326b906f5b730e4b318