### PR TITLE
Improve raid behavior and disciple visibility

### DIFF
--- a/docs/16-water-orb.md
+++ b/docs/16-water-orb.md
@@ -11,6 +11,7 @@
 - SlowBlob raiders display a small life bar above them as they approach.
 - At night the orb glows with a bright blue hue, illuminating nearby terrain using a Pixi.js GlowFilter (radius ~30, outer strength ~4, inner strength ~1).
 - The glow color is `#7fd9ff` and brightness is doubled at night to help the orb stand out against the dimmed map.
+- Disciple badges remain fully illuminated at night so players can easily locate their followers.
 - Soft light particles swirl around the orb at night, further brightening the surrounding darkness.
 - A radial light mask darkens the map at night while leaving a bright gradient around the orb.
 - The orb now holds up to 20 Water and regenerates at a flat 0.1 Water per second.

--- a/docs/23-raids.md
+++ b/docs/23-raids.md
@@ -16,9 +16,9 @@ Disciples may be called upon to defend the sect from occasional raids.
 * A red alert briefly appears on screen when a raid starts.
 * Raiders attack the Water orb, reducing its stored energy.
 * All disciples rush to intercept raiders as soon as they appear.
-* Raiders now chase nearby disciples instead of continuing toward the Water orb.
+* Raiders now chase nearby disciples instead of continuing toward the Water orb and stop to attack when within 50&nbsp;px.
 * All disciples immediately pause their current task to join the defense.
-* After the raid ends, disciples automatically resume their previous work assignments.
+* After the raid ends, disciples automatically resume their previous work assignments, even if they were incapacitated at the start of the raid.
 * Each disciple seeks the nearest enemy and engages in melee when in range.
 * If the orb is depleted the sect loses **half** of its stored fruit and softwood.
 * Early raids send four SlowBlob raiders, one every 10&nbsp;s for 40&nbsp;s.

--- a/game/blobRaids.js
+++ b/game/blobRaids.js
@@ -83,7 +83,6 @@ function createBlob() {
   const orb = getOrb();
   if (!map || !orb) return null;
   const mapRect = map.getBoundingClientRect();
-  const orbRect = orb.getBoundingClientRect();
   const size = 16;
   const blob = document.createElement('div');
   blob.className = 'slow-blob';
@@ -134,6 +133,8 @@ function createBlob() {
     nextAttack: performance.now() + BLOB_ATTACK_INTERVAL,
     size,
     update(dt) {
+      const mapRect = map.getBoundingClientRect();
+      const orbRect = orb.getBoundingClientRect();
       let target = null;
       let targetPos = null;
       let min = Infinity;

--- a/game/raids.js
+++ b/game/raids.js
@@ -43,8 +43,8 @@ export function startRaid() {
   raidState.xpStart = {};
   raidState.prevTasks = {};
   sectSystem.disciples.forEach(d => {
+    raidState.prevTasks[d.id] = sectState.discipleTasks[d.id];
     if (!d.incapacitated) {
-      raidState.prevTasks[d.id] = sectState.discipleTasks[d.id];
       sectState.discipleTasks[d.id] = 'Idle';
     }
   });

--- a/script.js
+++ b/script.js
@@ -853,6 +853,14 @@ function applyNightFilters(brightness) {
       icon.style.stroke = icon.dataset.baseStroke;
     }
   });
+  document.querySelectorAll('.disciple-badge, .disciple-orb').forEach(el => {
+    if (!el.dataset.baseFilter) el.dataset.baseFilter = el.style.filter || '';
+    if (brightness < 1) {
+      el.style.filter = `${el.dataset.baseFilter} brightness(${inv})`;
+    } else {
+      el.style.filter = el.dataset.baseFilter;
+    }
+  });
 }
 
 function updateMapBrightness(phase) {

--- a/test/injury-system.test.js
+++ b/test/injury-system.test.js
@@ -9,7 +9,6 @@ let sectSystem;
 let tickSect;
 let tickInjuries;
 let applyInjury;
-let BODY_PARTS;
 
 before(async () => {
   globalThis.document = {
@@ -20,7 +19,7 @@ before(async () => {
   };
   sectModule = await import('../game/sect.js');
   ({ sectSystem, tickSect } = sectModule);
-  ({ tickInjuries, applyInjury, BODY_PARTS } = await import('../game/injury.js'));
+  ({ tickInjuries, applyInjury } = await import('../game/injury.js'));
 });
 
 after(() => {


### PR DESCRIPTION
## Summary
- store disciple tasks for all units during raids
- refresh blob AI each update so raiders chase disciples properly
- keep disciple badges bright in night mode
- document raid behavior tweaks and visible badges
- fix unused variable in injury-system tests

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68867af3b8648326b769394072e925cb