### PR TITLE
fix: keep blood splatter circles inside canvas

### DIFF
--- a/game/rendering.js
+++ b/game/rendering.js
@@ -7,8 +7,8 @@ export function drawBloodSplat(canvas) {
   const count = 3 + Math.floor(Math.random() * 2);
   for (let i = 0; i < count; i++) {
     const r = 2 + Math.random() * 2;
-    const x = Math.random() * canvas.width;
-    const y = Math.random() * canvas.height;
+    const x = r + Math.random() * (canvas.width - 2 * r);
+    const y = r + Math.random() * (canvas.height - 2 * r);
     ctx.beginPath();
     ctx.fillStyle = '#a00';
     ctx.arc(x, y, r, 0, Math.PI * 2);

--- a/test/injury-system.test.js
+++ b/test/injury-system.test.js
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 import Disciple from '../game/disciple.js';
 import { initializeDisciple } from '../utils/discipleInit.js';
 import { sectState } from '../game/state.js';
+import { BODY_PARTS } from '../game/injury.js';
 
 let sectModule;
 let sectSystem;


### PR DESCRIPTION
## Summary
- prevent blood splatter circles from clipping by ensuring random spots stay inside the canvas
- import `BODY_PARTS` constant for linting in injury tests

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6887047f41a08326aa2f75876ab32f77