### PR TITLE
Fix resilience regeneration

### DIFF
--- a/game/disciple.js
+++ b/game/disciple.js
@@ -23,7 +23,8 @@ export default class Disciple {
     this.charisma = attributes.charisma || 0;
     this.potential = attributes.potential || 0;
     // base resilience percentage per second for healing injuries and HP
-    this.resilience = 1;
+    this.baseResilience = 1;
+    this.resilience = this.baseResilience;
     this.defense = 1;
     this.lastTab = 'general';
     this.updateCombatStats();

--- a/game/metamorphosisBonuses.js
+++ b/game/metamorphosisBonuses.js
@@ -19,7 +19,8 @@ export function applyStageBonuses(d) {
   const stage = getStage(d);
   d.maxWaterBonus = stage * STAGE_BONUS.maxWater;
   d.waterRegenBonus = stage * STAGE_BONUS.waterRegen;
-  d.resilience = stage * STAGE_BONUS.resilience;
+  const base = d.baseResilience ?? 1;
+  d.resilience = base + stage * STAGE_BONUS.resilience;
   d.spellPotency = 1 + stage * STAGE_BONUS.potency;
   d.damageBonus = stage * STAGE_BONUS.attack;
   d.moveSpeed = BASE_MOVE_SPEED * (1 + stage * STAGE_BONUS.moveSpeed);

--- a/test/injury-system.test.js
+++ b/test/injury-system.test.js
@@ -58,4 +58,16 @@ describe('injury system', () => {
     tickInjuries(d, 1, 0.4, 'Idle');
     expect(d.injuries.head.progress).to.be.closeTo(0.1, 1e-6);
   });
+
+  it('base resilience persists with stage bonuses', async () => {
+    const d = new Disciple({ id: 1 });
+    initializeDisciple(d);
+    const { applyStageBonuses } = await import('../game/metamorphosisBonuses.js');
+    sectState.discipleMetamorphosis[d.id] = { stage: 0 };
+    applyStageBonuses(d);
+    expect(d.resilience).to.equal(1);
+    sectState.discipleMetamorphosis[d.id].stage = 2;
+    applyStageBonuses(d);
+    expect(d.resilience).to.be.closeTo(1 + 2 * 0.002, 1e-6);
+  });
 });

--- a/utils/discipleInit.js
+++ b/utils/discipleInit.js
@@ -27,6 +27,7 @@ export function initializeDisciple(d) {
   if (d.baseCharisma === undefined) d.baseCharisma = d.charisma;
   if (d.basePotential === undefined) d.basePotential = d.potential;
   if (d.resilience === undefined) d.resilience = 1;
+  if (d.baseResilience === undefined) d.baseResilience = d.resilience;
   if (d.incapacitated === undefined) d.incapacitated = false;
   if (!d.name) d.name = `Disciple ${d.id}`;
   if (d.inventorySlots === undefined) d.inventorySlots = 10;


### PR DESCRIPTION
## Summary
- retain baseResilience value when applying stage bonuses
- expose baseResilience on Disciple objects and during initialization
- verify resilience bonus application in tests

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68875ff85c4883268d4d9b44ea152d2e