### PR TITLE
fix: keep disciple badge bright at night

### DIFF
--- a/script.js
+++ b/script.js
@@ -855,11 +855,8 @@ function applyNightFilters(brightness) {
   });
   document.querySelectorAll('.disciple-badge, .disciple-orb').forEach(el => {
     if (!el.dataset.baseFilter) el.dataset.baseFilter = el.style.filter || '';
-    if (brightness < 1) {
-      el.style.filter = `${el.dataset.baseFilter} brightness(${inv})`;
-    } else {
-      el.style.filter = el.dataset.baseFilter;
-    }
+    // Keep badges and orbs unaffected by the night filter
+    el.style.filter = el.dataset.baseFilter;
   });
 }
 


### PR DESCRIPTION
## Summary
- avoid applying brightness filter to disciple badges and orbs when the map is dark

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6887606543f88326a898dfd3e0bcd82c