### PR TITLE
Fix incapacitation healing and add water shield

### DIFF
--- a/game/combat.js
+++ b/game/combat.js
@@ -18,6 +18,17 @@ import { raidState } from './raids.js';
 
 import addLog from './log.js';
 
+export function applyDamage(target, amount) {
+  let remaining = Math.round(amount);
+  if (target.water > 0) {
+    const absorbed = Math.min(target.water, remaining);
+    target.water -= absorbed;
+    remaining -= absorbed;
+  }
+  target.currentHp = Math.max(0, target.currentHp - remaining);
+  return remaining;
+}
+
 export function init() {}
 
 // Map of disciple id to their current attack timer used during exploration
@@ -110,7 +121,7 @@ export function cDealerDamage(damageAmount = null, source = 'dealer') {
   const idx = Math.floor(Math.random() * targets.length);
   const card = targets[idx];
 
-  card.currentHp = Math.round(Math.max(0, card.currentHp - finalDamage));
+  applyDamage(card, finalDamage);
   const targetName = card.name ? card.name : `${card.value}${card.symbol}`;
   addLog(`${source} hit ${targetName} for ${finalDamage} damage!`, 'damage');
 
@@ -146,7 +157,7 @@ export function damageDisciple(target, damageAmount, source = 'enemy') {
   if (!target || target.incapacitated) return;
 
   const amount = Math.round(damageAmount);
-  target.currentHp = Math.max(0, target.currentHp - amount);
+  applyDamage(target, amount);
   const targetName = target.name ? target.name : `${target.value}${target.symbol}`;
   addLog(`${source} hit ${targetName} for ${amount} damage!`, 'damage');
 

--- a/game/sect.js
+++ b/game/sect.js
@@ -13,8 +13,7 @@ import {
   TASK_GROUPS,
   ATTRIBUTE_FOR_GROUP,
   INCAPACITATED_FOOD_MULT,
-  DISCIPLE_MAX_HEALTH,
-  REST_TIME_SECONDS
+  DISCIPLE_MAX_HEALTH
 } from './constants.js';
 import { intelligenceXpMultiplier } from './attributes.js';
 import { addSkillXp, ensureDiscipleSkills, getTaskSkillProgress } from '../utils/skills.js';
@@ -1463,16 +1462,22 @@ export function tickSect(delta) {
   }
   sectSystem.disciples.forEach(d => {
     if (d.incapacitated) {
-      d.health = Math.min(
-        DISCIPLE_MAX_HEALTH,
-        d.health + (DISCIPLE_MAX_HEALTH / REST_TIME_SECONDS) * dt
-      );
+      tickInjuries(d, dt, d.resilience, 'Resting');
       d.currentHp = d.health;
       if (d.health >= DISCIPLE_MAX_HEALTH / 2) {
         d.incapacitated = false;
-      } else {
-        return;
       }
+      if (!d.starveTimer) d.starveTimer = 0;
+      if (d.water <= 0) {
+        d.starveTimer += dt;
+        while (d.starveTimer >= 1) {
+          applyStarvationHit(d);
+          d.starveTimer -= 1;
+        }
+      } else {
+        d.starveTimer = 0;
+      }
+      return;
     }
     const task = sectState.discipleTasks[d.id];
     if (!task || task === 'Idle' || task === 'Resting') {

--- a/test/incapacitation.test.js
+++ b/test/incapacitation.test.js
@@ -40,12 +40,12 @@ describe('incapacitated disciples', () => {
     const rate = FRUIT_CONSUMPTION_RATE;
 
     // simulate until just past 50% health
-    for (let i = 0; i < 151; i++) {
+    for (let i = 0; i < 5; i++) {
       tickSect(1000);
     }
     expect(d.health).to.be.closeTo(5, 0.1);
     expect(d.incapacitated).to.be.false;
-    const expectedFood = 10 - rate * 3 * 151;
+    const expectedFood = 10 - rate * 3 * 5;
     expect(sectState.fruits).to.be.closeTo(expectedFood, 1e-6);
   });
 });

--- a/test/water-shield.test.js
+++ b/test/water-shield.test.js
@@ -1,0 +1,53 @@
+/* global describe, it, before, after */
+import { expect } from 'chai';
+import Disciple from '../game/disciple.js';
+import { initializeDisciple } from '../utils/discipleInit.js';
+
+let combatModule;
+let applyDamage;
+
+before(async () => {
+  globalThis.document = {
+    getElementById: () => null,
+    getElementsByClassName: () => [null],
+    querySelector: () => null,
+    createElement: () => ({
+      appendChild() {},
+      addEventListener() {},
+      remove() {},
+      style: {},
+      classList: { add() {}, remove() {} },
+      getContext: () => ({ clearRect() {}, beginPath() {}, arc() {}, fill() {} }),
+      getBoundingClientRect: () => ({ width: 0, height: 0 })
+    }),
+    body: { appendChild() {} },
+    addEventListener() {},
+    removeEventListener() {}
+  };
+  global.document = globalThis.document;
+  globalThis.window = { dispatchEvent() {} };
+  combatModule = await import('../game/combat.js');
+  ({ applyDamage } = combatModule);
+});
+
+after(() => {
+  delete globalThis.document;
+  delete globalThis.window;
+});
+
+describe('water shield', () => {
+  it('absorbs damage before hp', () => {
+    const d = new Disciple({ id: 1 });
+    initializeDisciple(d);
+    d.water = 5;
+    d.currentHp = d.maxHp;
+
+    applyDamage(d, 3);
+    expect(d.water).to.equal(2);
+    expect(d.currentHp).to.equal(d.maxHp);
+
+    applyDamage(d, 3);
+    expect(d.water).to.equal(0);
+    expect(d.currentHp).to.equal(d.maxHp - 1);
+  });
+});


### PR DESCRIPTION
## Summary
- treat disciple water as a shield before HP
- heal incapacitated disciples via resilience
- cover water shield mechanic with new tests
- update incapacitation test for new healing rules

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6887646d5bd0832685d96f896f9a8a61