### PR TITLE
Fix blob raid movement logic

### DIFF
--- a/docs/23-raids.md
+++ b/docs/23-raids.md
@@ -16,7 +16,7 @@ Disciples may be called upon to defend the sect from occasional raids.
 * A red alert briefly appears on screen when a raid starts.
 * Raiders attack the Water orb, reducing its stored energy.
 * All disciples rush to intercept raiders as soon as they appear.
-* Raiders now chase nearby disciples instead of continuing toward the Water orb and stop to attack when within 50&nbsp;px.
+* Raiders continue heading toward the Water orb but halt if a disciple enters a 50&nbsp;px radius, attacking while in range.
 * All disciples immediately pause their current task to join the defense.
 * After the raid ends, disciples automatically resume their previous work assignments, even if they were incapacitated at the start of the raid.
 * Each disciple seeks the nearest enemy and engages in melee when in range.

--- a/game/blobRaids.js
+++ b/game/blobRaids.js
@@ -156,20 +156,12 @@ function createBlob() {
       });
 
       if (target && targetPos) {
-        const dx = targetPos.x - this.x;
-        const dy = targetPos.y - this.y;
         const dist = targetPos.dist;
-        if (dist > BLOB_ATTACK_RANGE) {
-          const move = Math.min((BLOB_SPEED * dt) / 1000, dist - BLOB_ATTACK_RANGE);
-          this.x += (dx / dist) * move;
-          this.y += (dy / dist) * move;
-          this.el.style.left = `${this.x}px`;
-          this.el.style.top = `${this.y}px`;
-        }
         if (dist <= BLOB_ATTACK_RANGE && now >= this.nextAttack) {
           damageDisciple(target, 5, 'SlowBlob');
           this.nextAttack = now + BLOB_ATTACK_INTERVAL;
         }
+        // Blob stops moving while engaging a disciple
       } else {
         const ox = orbRect.left + orbRect.width / 2 - mapRect.left;
         const oy = orbRect.top + orbRect.height / 2 - mapRect.top;


### PR DESCRIPTION
## Summary
- stop blobs from chasing disciples
- document updated raid behavior

## Testing
- `npm test`
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688764f745c883268704e8a40b7452b7