### PR TITLE
Show orb repair progress on disciple badges

### DIFF
--- a/docs/16-water-orb.md
+++ b/docs/16-water-orb.md
@@ -20,6 +20,8 @@
   the orb graphic.
 - Disciples assigned to **Building** will automatically repair a cracked orb,
   requiring 2.5 minutes at base speed.
+- While repairing, each builder's badge shows an "Orb Repair" progress bar with
+  the remaining time.
 - Orb Revival research grants access to an Orb Management panel for the Water Orb.
 - Word of Haste orb spell speeds up work tasks for one minute at the cost of 15 Water.
 - Orb Spell Strength buildings raise the Water Orb's attack damage by 20% per level.

--- a/script.js
+++ b/script.js
@@ -31,7 +31,8 @@ import {
   tickSect,
   renderColonyResources,
   addDiscoveredLocation,
-  discoveredLocations
+  discoveredLocations,
+  ORB_REPAIR_SECONDS
 } from "./game/sect.js";
 import {
   BUILDINGS,
@@ -648,10 +649,21 @@ function updateTaskProgressDisplay() {
         rateEl.textContent = `+${rate.toFixed(0)}/m`;
       }
     } else if (taskName === 'Building') {
-      if (fill) fill.style.width = `${buildPct}%`;
-      if (label && buildData)
-        label.textContent = `${buildData.name} ${builderCount > 0 ? buildTime.toFixed(1) : '∞'}s`;
-      else if (label) label.textContent = '';
+      if (sectSystem.orbs.water.cracked && !buildData) {
+        const pct = sectState.orbRepairProgress * 100;
+        if (fill) fill.style.width = `${pct}%`;
+        const time =
+          builderCount > 0
+            ? ((1 - sectState.orbRepairProgress) * ORB_REPAIR_SECONDS) / builderCount
+            : Infinity;
+        if (label)
+          label.textContent = `Repair Orb ${builderCount > 0 ? time.toFixed(1) : '∞'}s`;
+      } else {
+        if (fill) fill.style.width = `${buildPct}%`;
+        if (label && buildData)
+          label.textContent = `${buildData.name} ${builderCount > 0 ? buildTime.toFixed(1) : '∞'}s`;
+        else if (label) label.textContent = '';
+      }
       if (rateEl) rateEl.textContent = '';
     } else if (taskName === 'Hunt') {
       const progress = sectState.discipleProgress[d.id] || 0;


### PR DESCRIPTION
## Summary
- import `ORB_REPAIR_SECONDS` constant for progress timing
- display orb repair progress bar and time on disciple badges
- document the new visual feedback for orb repair

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6887653763f08326b3257c284ae1166c