### PR TITLE
Adjust starting water and blob damage

### DIFF
--- a/docs/20-skills.md
+++ b/docs/20-skills.md
@@ -7,7 +7,7 @@ Each skill has its own progression, yield formula, and spot data. Skills gain XP
 
 09.1 Water Sense
 
-Base Water: 10, 1 Water/s regen
+Base Water: 30, 1 Water/s regen
 
 Max Water Bonus: +2.4% of base Max Water per level
 

--- a/docs/23-raids.md
+++ b/docs/23-raids.md
@@ -24,7 +24,7 @@ Disciples may be called upon to defend the sect from occasional raids.
 * Early raids send four SlowBlob raiders, one every 10&nbsp;s for 40&nbsp;s.
 * SlowBlob attacks now occur every 10&nbsp;s.
 
-* The Water orb lashes out every 5&nbsp;s at blobs within 75&nbsp;px, striking the closest target for 5 damage.
+* The Water orb lashes out every 5&nbsp;s at blobs within 75&nbsp;px, striking the closest target for 2 damage.
 * Blobs show a small health meter as they crawl across the map.
 * When killed, blobs burst in a brief animation.
 * The Water orb displays a short attack timer bar above it and flashes each time it fires.

--- a/game/blobRaids.js
+++ b/game/blobRaids.js
@@ -158,7 +158,7 @@ function createBlob() {
       if (target && targetPos) {
         const dist = targetPos.dist;
         if (dist <= BLOB_ATTACK_RANGE && now >= this.nextAttack) {
-          damageDisciple(target, 5, 'SlowBlob');
+          damageDisciple(target, 2, 'SlowBlob');
           this.nextAttack = now + BLOB_ATTACK_INTERVAL;
         }
         // Blob stops moving while engaging a disciple
@@ -184,12 +184,12 @@ function createBlob() {
         if (dist <= targetDist && now >= this.nextAttack) {
           sectSystem.orbs.water.current = Math.max(
             0,
-            sectSystem.orbs.water.current - 5
+            sectSystem.orbs.water.current - 2
           );
-          raidState.damageReceived += 5;
+          raidState.damageReceived += 2;
           const orbEl = getOrb();
           runAnimation(orbEl, 'orb-hit');
-          addLog('SlowBlob hits the Water Orb for 5 damage.', 'damage');
+          addLog('SlowBlob hits the Water Orb for 2 damage.', 'damage');
           this.nextAttack = now + BLOB_ATTACK_INTERVAL;
           if (sectSystem.orbs.water.current <= 0 && raidState.active) {
             endRaid(false);
@@ -232,13 +232,13 @@ function orbAttack() {
     }
   });
   if (target) {
-    target.takeDamage(5);
-    raidState.damageDealt += 5;
+    target.takeDamage(2);
+    raidState.damageDealt += 2;
     runAnimation(target.el, 'hit-animate');
     runAnimation(orb, 'orb-burst');
     flashOrbGlow();
     if (orbAttackFill) orbAttackFill.style.width = '0%';
-    addLog('Water Orb hits a SlowBlob for 5 damage.', 'damage');
+    addLog('Water Orb hits a SlowBlob for 2 damage.', 'damage');
   }
 }
 

--- a/test/water-shield.test.js
+++ b/test/water-shield.test.js
@@ -24,7 +24,6 @@ before(async () => {
     addEventListener() {},
     removeEventListener() {}
   };
-  global.document = globalThis.document;
   globalThis.window = { dispatchEvent() {} };
   combatModule = await import('../game/combat.js');
   ({ applyDamage } = combatModule);

--- a/utils/water.js
+++ b/utils/water.js
@@ -1,5 +1,5 @@
 // Base maximum Water disciples can hold before bonuses
-export const BASE_WATER = 10;
+export const BASE_WATER = 30;
 export const BASE_REGEN_PER_SEC = 1;
 
 export function calculateMaxWater(waterSenseLevel = 0) {


### PR DESCRIPTION
## Summary
- raise BASE_WATER to 30 so disciples start with more Water
- update docs with new starting Water value
- reduce SlowBlob damage to 2
- fix lint error in water shield test

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68876b436ff08326a75bceb811e491c3