### PR TITLE
Fix disciple vitals update

### DIFF
--- a/docs/00-wireframes.md
+++ b/docs/00-wireframes.md
@@ -89,6 +89,7 @@ Footer
   mood, HP bar, Water bar and current task.
 * Disciples on the sect map appear as slightly larger side-facing coquí sprites (about 20% bigger). The bamboo frame is drawn using
   the CSS `border-image` property so the texture tiles cleanly around the badge. Every 10–20 seconds they emit a small croak bubble, and when assigned work they display a task icon such as a pickaxe or scroll.
+* HP and Water bars animate in real time on both the badge and within the disciple overlay.
 
 * All overlays now use the same parchment-style box for a consistent look.
 

--- a/script.js
+++ b/script.js
@@ -722,6 +722,36 @@ function updateDiscipleWaterDisplay() {
   }
 }
 
+function updateDiscipleHealthDisplay() {
+  sectSystem.disciples.forEach(d => {
+    document
+      .querySelectorAll(
+        `.disciple-badge[data-disciple-id="${d.id}"] .life-bar .bar-fill`
+      )
+      .forEach(fill => {
+        fill.style.width = `${Math.min(100, (d.health / DISCIPLE_MAX_HEALTH) * 100)}%`;
+      });
+  });
+  if (discipleOverlay && discipleOverlayActiveTab === 'general') {
+    const d = discipleOverlayData.disciple;
+    if (d) {
+      const row = discipleOverlay.box.querySelector(
+        '.disciple-general .stat-row[data-stat="health"]'
+      );
+      if (row) {
+        const fill = row.querySelector('.bar-fill');
+        if (fill)
+          fill.style.width = `${Math.min(
+            100,
+            (d.health / DISCIPLE_MAX_HEALTH) * 100
+          )}%`;
+        const val = row.querySelector('.stat-value');
+        if (val) val.textContent = `${Math.round(d.health)}/${DISCIPLE_MAX_HEALTH}`;
+      }
+    }
+  }
+}
+
 function updateSectDisplay() {
   checkBuildingUnlock();
   if (sectNavBuildBtn) {
@@ -2605,6 +2635,7 @@ function gameLoop(currentTime) {
   // refresh sect resource UI every tick for real-time updates
   if (typeof updateSectDisplay === 'function') updateSectDisplay();
   updateTaskProgressDisplay();
+  updateDiscipleHealthDisplay();
   updateDiscipleWaterDisplay();
   updateOrbGlow(deltaTime);
   requestAnimationFrame(gameLoop);

--- a/test/water-shield.test.js
+++ b/test/water-shield.test.js
@@ -24,7 +24,6 @@ before(async () => {
     addEventListener() {},
     removeEventListener() {}
   };
-  global.document = globalThis.document;
   globalThis.window = { dispatchEvent() {} };
   combatModule = await import('../game/combat.js');
   ({ applyDamage } = combatModule);


### PR DESCRIPTION
## Summary
- update HP and water bars continuously in disciple badge and overlay
- note real-time badge updates in documentation
- remove unused global reference in tests

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68876b92d39483268978b0cbfb551d4a