### PR TITLE
Adjust disciple water regen

### DIFF
--- a/docs/16-water-orb.md
+++ b/docs/16-water-orb.md
@@ -2,7 +2,7 @@
 
 **Saturday, July 12, 2025 • 3:07 PM**
 
-- Central map Water Orb gathers Water from disciples (1 Water/s each when not incapacitated).
+- Central map Water Orb gathers Water from disciples (0.1 Water/s each when not incapacitated).
 - Low‑food disciples divert to orb to replenish (+0.383 food/s) at cost of Water input.
 - Orb distributes Water as global energy; buildings can boost its output.
 - Disciples can direct % of personal Water to orb.

--- a/docs/20-skills.md
+++ b/docs/20-skills.md
@@ -7,7 +7,7 @@ Each skill has its own progression, yield formula, and spot data. Skills gain XP
 
 09.1 Water Sense
 
-Base Water: 30, 1 Water/s regen
+Base Water: 30, 0.1 Water/s regen
 
 Max Water Bonus: +2.4% of base Max Water per level
 

--- a/utils/water.js
+++ b/utils/water.js
@@ -1,6 +1,6 @@
 // Base maximum Water disciples can hold before bonuses
 export const BASE_WATER = 30;
-export const BASE_REGEN_PER_SEC = 1;
+export const BASE_REGEN_PER_SEC = 0.1;
 
 export function calculateMaxWater(waterSenseLevel = 0) {
   return BASE_WATER * (1 + 0.024 * waterSenseLevel);


### PR DESCRIPTION
## Summary
- set disciple base water regen to `0.1` per second
- document the reduced starting water regeneration

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68876dc20724832689733a62c218035e