### PR TITLE
Fix raid task restoration

### DIFF
--- a/game/sect.js
+++ b/game/sect.js
@@ -1208,20 +1208,22 @@ export function tickSectSystem(delta) {
       SECT_SCHEDULE[sectSystem.scheduleIndex].duration;
     sectSystem.scheduleIndex =
       (sectSystem.scheduleIndex + 1) % SECT_SCHEDULE.length;
+    const schedule = getCurrentSchedule();
+    if (schedule.phase === 'Night') startRaid();
     document.dispatchEvent(
-      new CustomEvent('schedule-phase', { detail: getCurrentSchedule() })
+      new CustomEvent('schedule-phase', { detail: schedule })
     );
-    if (getCurrentSchedule().phase === 'Night') startRaid();
   }
   sectSystem.seasonTimer += dt;
   if (sectSystem.seasonTimer >= DAY_LENGTH_SECONDS) {
     sectSystem.seasonTimer -= DAY_LENGTH_SECONDS;
     sectSystem.scheduleIndex = 0;
     sectSystem.scheduleTimer = 0;
+    const scheduleDayStart = getCurrentSchedule();
+    if (scheduleDayStart.phase === 'Night') startRaid();
     document.dispatchEvent(
-      new CustomEvent('schedule-phase', { detail: getCurrentSchedule() })
+      new CustomEvent('schedule-phase', { detail: scheduleDayStart })
     );
-    if (getCurrentSchedule().phase === 'Night') startRaid();
     sectSystem.seasonDay += 1;
     document.dispatchEvent(new CustomEvent('day-passed', {
       detail: { day: sectSystem.seasonDay, season: sectSystem.seasonIndex }
@@ -1581,8 +1583,9 @@ export function skipToNextNight() {
   sectSystem.seasonTimer = nightStart;
   sectSystem.scheduleIndex = nightIndex;
   sectSystem.scheduleTimer = 0;
-  document.dispatchEvent(
-    new CustomEvent('schedule-phase', { detail: getCurrentSchedule() })
-  );
+  const scheduleNight = getCurrentSchedule();
   startRaid();
+  document.dispatchEvent(
+    new CustomEvent('schedule-phase', { detail: scheduleNight })
+  );
 }


### PR DESCRIPTION
## Summary
- start raids before schedule-phase listeners clear disciple tasks
- preserve tasks when skipping to night

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68876f5a42c48326888fa9341529375e