### PR TITLE
Fix blob raid movement behavior

### DIFF
--- a/docs/23-raids.md
+++ b/docs/23-raids.md
@@ -16,7 +16,7 @@ Disciples may be called upon to defend the sect from occasional raids.
 * A red alert briefly appears on screen when a raid starts.
 * Raiders attack the Water orb, reducing its stored energy.
 * All disciples rush to intercept raiders as soon as they appear.
-* Raiders continue heading toward the Water orb but halt if a disciple enters a 50&nbsp;px radius, attacking while in range.
+* Raiders march directly toward the Water orb and halt to attack once the orb or a disciple comes within a 40&nbsp;px radius.
 * All disciples immediately pause their current task to join the defense.
 * After the raid ends, disciples automatically resume their previous work assignments, even if they were incapacitated at the start of the raid.
 * Each disciple seeks the nearest enemy and engages in melee when in range.

--- a/game/blobRaids.js
+++ b/game/blobRaids.js
@@ -21,7 +21,8 @@ const ORB_ATTACK_INTERVAL = 5000; // ms
 const ORB_ATTACK_RANGE = 75; // px
 const DISCIPLE_ATTACK_INTERVAL = 10000; // ms
 const DISCIPLE_RANGE = 50; // px
-const BLOB_ATTACK_RANGE = 50; // px distance to stop and attack disciples
+const BLOB_ATTACK_RANGE = 40; // px distance to stop and attack disciples
+const BLOB_ORB_RANGE = 40; // px distance to stop and attack the orb
 const DISCIPLE_DAMAGE = 3;
 const IN_MAP_BORDER = 8; // px blob must cross into view before interactions
 
@@ -151,7 +152,6 @@ function createBlob() {
         }
       }
       let target = null;
-      let targetPos = null;
       let min = Infinity;
       const now = performance.now();
       if (this.inMap) {
@@ -163,41 +163,35 @@ function createBlob() {
           const px = rect.left + rect.width / 2 - mapRect.left;
           const py = rect.top + rect.height / 2 - mapRect.top;
           const dd = Math.hypot(px - cx, py - cy);
-          if (dd <= DISCIPLE_RANGE && dd < min) {
+          if (dd <= BLOB_ATTACK_RANGE && dd < min) {
             min = dd;
             target = d;
-            targetPos = { x: px, y: py, dist: dd };
           }
         });
       }
 
-      if (target && targetPos) {
-        const dist = targetPos.dist;
-        if (dist <= BLOB_ATTACK_RANGE && now >= this.nextAttack && this.inMap) {
+      if (target) {
+        if (now >= this.nextAttack && this.inMap) {
           damageDisciple(target, 2, 'SlowBlob');
           this.nextAttack = now + BLOB_ATTACK_INTERVAL;
         }
-        // Blob stops moving while engaging a disciple
       } else {
         const ox = orbRect.left + orbRect.width / 2 - mapRect.left;
         const oy = orbRect.top + orbRect.height / 2 - mapRect.top;
-        const orbRadius = orbRect.width / 2;
-        const blobRadius = this.size / 2;
         const dx = ox - cx;
         const dy = oy - cy;
         const dist = Math.hypot(dx, dy);
-        const targetDist = orbRadius + blobRadius;
-        if (dist > targetDist) {
+        if (dist > BLOB_ORB_RANGE) {
           const move = Math.min(
             (BLOB_SPEED * dt) / 1000,
-            dist - targetDist
+            dist - BLOB_ORB_RANGE
           );
           this.x += (dx / dist) * move;
           this.y += (dy / dist) * move;
           this.el.style.left = `${this.x}px`;
           this.el.style.top = `${this.y}px`;
         }
-        if (dist <= targetDist && now >= this.nextAttack && this.inMap) {
+        if (dist <= BLOB_ORB_RANGE && now >= this.nextAttack && this.inMap) {
           sectSystem.orbs.water.current = Math.max(
             0,
             sectSystem.orbs.water.current - 2


### PR DESCRIPTION
## Summary
- raider blobs now only attack the Water orb once within 40px
- disciples or orbs within 40px cause raiders to halt and attack
- update raid guide to document the 40px engagement radius

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6887758b720c8326899fdbd3e2f88269