### PR TITLE
Implement CAN event bus

### DIFF
--- a/docs/23-raids.md
+++ b/docs/23-raids.md
@@ -4,6 +4,8 @@
 **Sunday, July 20, 2025 • 8:15 PM**
 
 Night raids escalate the longer your sect survives. Each evening hostile frogs or spirits attack from the edge of the sect map and attempt to reach the Water Orb.
+All raid interactions are coordinated through a small event bus so the combat,
+raid and rendering modules remain loosely coupled.
 
 - **Enemy scaling** – raid size and enemy stats grow with the current stage and world. Early attacks feature sluggish "SlowBlob" spirits that spawn every few seconds and crawl toward the orb.
 - **Orb damage** – the Water Orb pulses damage in a small radius, harming nearby attackers. Buildings can boost this effect.

--- a/docs/module-structure.md
+++ b/docs/module-structure.md
@@ -9,6 +9,8 @@ The project organizes game logic under the `game/` directory.
 - **game/combat.js** – handles exploration battles and disciple hit animations.
 - **game/raids.js** and **game/blobRaids.js** – implement raid encounters and the
   defensive combat loop.
+- **game/canBus.js** – lightweight event bus used for in-game modules to
+  communicate without direct imports.
 - **game/debug.js** – wiring for optional debug controls.
 - **debugTools.js** – development helpers lazily loaded when a debug
   button is clicked.

--- a/game/blobRaids.js
+++ b/game/blobRaids.js
@@ -3,8 +3,8 @@ import { runAnimation } from '../utils/animation.js';
 import addLog from './log.js';
 import { BASE_MOVE_SPEED } from './constants.js';
 import { flashOrbGlow } from './orbGlow.js';
-import { raidState, endRaid } from './raids.js';
-import { damageDisciple } from './combat.js';
+import bus from './canBus.js';
+import { raidState } from './raids.js';
 import { createMapSplatter } from './rendering.js';
 
 
@@ -174,7 +174,7 @@ function createBlob() {
       if (target && targetPos) {
         const dist = targetPos.dist;
         if (dist <= BLOB_ATTACK_RANGE && now >= this.nextAttack && this.inMap) {
-          damageDisciple(target, 2, 'SlowBlob');
+          bus.publish('BLOB_ATTACK_DISCIPLE', { id: target.id, damage: 2 });
           this.nextAttack = now + BLOB_ATTACK_INTERVAL;
         }
         // Blob stops moving while engaging a disciple
@@ -198,19 +198,8 @@ function createBlob() {
           this.el.style.top = `${this.y}px`;
         }
         if (dist <= targetDist && now >= this.nextAttack && this.inMap) {
-          sectSystem.orbs.water.current = Math.max(
-            0,
-            sectSystem.orbs.water.current - 2
-          );
-          raidState.damageReceived += 2;
-          const orbEl = getOrb();
-          runAnimation(orbEl, 'orb-hit');
-          addLog('SlowBlob hits the Water Orb for 2 damage.', 'damage');
+          bus.publish('BLOB_ATTACK_ORB', { damage: 2 });
           this.nextAttack = now + BLOB_ATTACK_INTERVAL;
-          if (sectSystem.orbs.water.current <= 0 && raidState.active) {
-            endRaid(false);
-            return;
-          }
         }
       }
     },
@@ -342,3 +331,16 @@ export function hasBlobs() {
 export function raidFinished() {
   return spawnCount >= MAX_BLOBS && blobs.length === 0;
 }
+
+// Event bus wiring
+bus.subscribe('BLOB_SPAWN', () => {
+  spawnBlob();
+});
+
+bus.subscribe('DISCIPLE_ATTACK', ({ damage }) => {
+  damageClosestBlob(damage);
+});
+
+bus.subscribe('TICK', ({ delta }) => {
+  tickBlobRaid(delta);
+});

--- a/game/canBus.js
+++ b/game/canBus.js
@@ -1,0 +1,13 @@
+class CANBus {
+  constructor() {
+    this.handlers = {};
+  }
+  subscribe(event, fn) {
+    (this.handlers[event] ||= []).push(fn);
+  }
+  publish(event, payload) {
+    (this.handlers[event] || []).forEach(fn => fn(payload));
+  }
+}
+
+export default new CANBus();

--- a/game/combat.js
+++ b/game/combat.js
@@ -17,6 +17,7 @@ import { showRestartScreen } from '../ui/restartOverlay.js';
 import { raidState } from './raids.js';
 
 import addLog from './log.js';
+import bus from './canBus.js';
 
 export function applyDamage(target, amount) {
   let remaining = Math.round(amount);
@@ -189,5 +190,11 @@ export function damageDisciple(target, damageAmount, source = 'enemy') {
     });
   }
 }
+
+// Event bus wiring
+bus.subscribe('BLOB_ATTACK_DISCIPLE', ({ id, damage }) => {
+  const disc = sectSystem.disciples.find(d => d.id === id);
+  if (disc) damageDisciple(disc, damage, 'SlowBlob');
+});
 
 globalThis.cDealerDamage = cDealerDamage;

--- a/game/raids.js
+++ b/game/raids.js
@@ -6,20 +6,19 @@ import {
 } from './state.js';
 import { updateDealerLifeDisplay } from './ui.js';
 import { showRaidSummaryOverlay } from '../ui/raidSummaryOverlay.js';
+import { runAnimation } from '../utils/animation.js';
 
 import addLog from './log.js';
 import { showRaidAlert } from './alerts.js';
 import { ensureDiscipleSkills, getTaskSkillProgress } from '../utils/skills.js';
 import {
-  tickBlobRaid,
-  spawnBlob,
   clearBlobs,
-  damageClosestBlob,
   canSpawn,
   raidFinished,
   showOrbAttackBar,
   hideOrbAttackBar
 } from './blobRaids.js';
+import bus from './canBus.js';
 
 export const raidState = {
   active: false,
@@ -68,20 +67,20 @@ export function startRaid() {
   ) {
     const check = () => {
       if (canSpawn()) {
-        spawnBlob();
+        bus.publish('BLOB_SPAWN');
       } else {
         window.requestAnimationFrame(check);
       }
     };
     window.requestAnimationFrame(check);
   } else {
-    spawnBlob();
+    bus.publish('BLOB_SPAWN');
   }
   raidState.enemy = {
     maxHp: 20,
     currentHp: 20,
     takeDamage(dmg) {
-      damageClosestBlob(dmg);
+      bus.publish('DISCIPLE_ATTACK', { damage: dmg });
       raidState.damageDealt += dmg;
     },
     isDefeated() {
@@ -89,7 +88,7 @@ export function startRaid() {
       return raidFinished();
     },
     tick(dt) {
-      tickBlobRaid(dt);
+      bus.publish('TICK', { delta: dt });
     }
   };
   setCurrentEnemy(raidState.enemy);
@@ -178,3 +177,15 @@ export function tickRaid(delta) {
   }
   if (raidState.enemy.isDefeated()) endRaid(true);
 }
+
+// Event bus wiring
+bus.subscribe('BLOB_ATTACK_ORB', ({ damage }) => {
+  sectSystem.orbs.water.current = Math.max(0, sectSystem.orbs.water.current - damage);
+  raidState.damageReceived += damage;
+  const orbEl = document.querySelector('#sectOrbs .sect-orb.water');
+  if (orbEl) runAnimation(orbEl, 'orb-hit');
+  addLog('SlowBlob hits the Water Orb for ' + damage + ' damage.', 'damage');
+  if (sectSystem.orbs.water.current <= 0 && raidState.active) {
+    endRaid(false);
+  }
+});

--- a/script.js
+++ b/script.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-unused-vars, no-undef */
 // Core modules that power combat systems
 import Disciple from "./game/disciple.js";
+import bus from './game/canBus.js';
 import addLog from "./game/log.js"; // helper for appending to the event log
 import Enemy from "./game/enemy.js"; // base enemy class
 import {
@@ -2592,6 +2593,7 @@ function gameLoop(currentTime) {
   const rawDelta = currentTime - lastFrameTime;
   lastFrameTime = currentTime;
   const deltaTime = rawDelta * timeScale;
+  bus.publish('TICK', { delta: deltaTime });
   const startWater = sectSystem.resources.water.current;
   const startFruit = sectState.fruits;
   const startSoftwood = sectState.softwood;


### PR DESCRIPTION
## Summary
- add central CAN bus utility
- publish raid ticks and attacks via event bus
- update blob raid logic to emit events
- handle disciple and orb damage through subscriptions
- document new bus module

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68893cb9034c83268570b9f5e6f6137a