### PR TITLE
Implement CAN event bus

### DIFF
--- a/docs/23-raids.md
+++ b/docs/23-raids.md
@@ -4,6 +4,10 @@
 **Sunday, July 20, 2025 • 8:15 PM**
 
 Night raids escalate the longer your sect survives. Each evening hostile frogs or spirits attack from the edge of the sect map and attempt to reach the Water Orb.
+All raid interactions are coordinated through a small event bus so the combat,
+raid and rendering modules remain loosely coupled.
+Damage totals are broadcast via `RAID_DAMAGE_DEALT` and `BLOB_ATTACK_ORB` events
+which update the raid summary.
 
 - **Enemy scaling** – raid size and enemy stats grow with the current stage and world. Early attacks feature sluggish "SlowBlob" spirits that spawn every few seconds and crawl toward the orb.
 - **Orb damage** – the Water Orb pulses damage in a small radius, harming nearby attackers. Buildings can boost this effect.
@@ -16,7 +20,7 @@ Disciples may be called upon to defend the sect from occasional raids.
 * A red alert briefly appears on screen when a raid starts.
 * Raiders attack the Water orb, reducing its stored energy.
 * All disciples rush to intercept raiders as soon as they appear.
-* Raiders continue heading toward the Water orb but halt if a disciple enters a 50&nbsp;px radius, attacking while in range.
+* Raiders continue heading toward the Water orb but halt if a disciple enters a 100&nbsp;px radius, attacking while in range.
 * All disciples immediately pause their current task to join the defense.
 * After the raid ends, disciples automatically resume their previous work assignments, even if they were incapacitated at the start of the raid.
 * Each disciple seeks the nearest enemy and engages in melee when in range.

--- a/docs/module-structure.md
+++ b/docs/module-structure.md
@@ -9,6 +9,8 @@ The project organizes game logic under the `game/` directory.
 - **game/combat.js** – handles exploration battles and disciple hit animations.
 - **game/raids.js** and **game/blobRaids.js** – implement raid encounters and the
   defensive combat loop.
+- **game/canBus.js** – lightweight event bus used for in-game modules to
+  communicate without direct imports.
 - **game/debug.js** – wiring for optional debug controls.
 - **debugTools.js** – development helpers lazily loaded when a debug
   button is clicked.

--- a/game/blobRaids.js
+++ b/game/blobRaids.js
@@ -3,8 +3,7 @@ import { runAnimation } from '../utils/animation.js';
 import addLog from './log.js';
 import { BASE_MOVE_SPEED } from './constants.js';
 import { flashOrbGlow } from './orbGlow.js';
-import { raidState, endRaid } from './raids.js';
-import { damageDisciple } from './combat.js';
+import bus from './canBus.js';
 import { createMapSplatter } from './rendering.js';
 
 
@@ -20,10 +19,13 @@ const BLOB_ATTACK_INTERVAL = 10000; // ms
 const ORB_ATTACK_INTERVAL = 5000; // ms
 const ORB_ATTACK_RANGE = 75; // px
 const DISCIPLE_ATTACK_INTERVAL = 10000; // ms
-const DISCIPLE_RANGE = 50; // px
-const BLOB_ATTACK_RANGE = 50; // px distance to stop and attack disciples
+const DISCIPLE_RANGE = 100; // px
+const BLOB_ATTACK_RANGE = 100; // px distance to stop and attack disciples
+const BLOB_ORB_ATTACK_RANGE = 100; // px distance to stop and attack the orb
 const DISCIPLE_DAMAGE = 3;
 const IN_MAP_BORDER = 8; // px blob must cross into view before interactions
+
+let activeRaid = false;
 
 export const blobs = [];
 let spawnTimer = 0;
@@ -174,19 +176,17 @@ function createBlob() {
       if (target && targetPos) {
         const dist = targetPos.dist;
         if (dist <= BLOB_ATTACK_RANGE && now >= this.nextAttack && this.inMap) {
-          damageDisciple(target, 2, 'SlowBlob');
+          bus.publish('BLOB_ATTACK_DISCIPLE', { id: target.id, damage: 2 });
           this.nextAttack = now + BLOB_ATTACK_INTERVAL;
         }
         // Blob stops moving while engaging a disciple
       } else {
         const ox = orbRect.left + orbRect.width / 2 - mapRect.left;
         const oy = orbRect.top + orbRect.height / 2 - mapRect.top;
-        const orbRadius = orbRect.width / 2;
-        const blobRadius = this.size / 2;
         const dx = ox - cx;
         const dy = oy - cy;
         const dist = Math.hypot(dx, dy);
-        const targetDist = orbRadius + blobRadius;
+        const targetDist = BLOB_ORB_ATTACK_RANGE;
         if (dist > targetDist) {
           const move = Math.min(
             (BLOB_SPEED * dt) / 1000,
@@ -198,19 +198,8 @@ function createBlob() {
           this.el.style.top = `${this.y}px`;
         }
         if (dist <= targetDist && now >= this.nextAttack && this.inMap) {
-          sectSystem.orbs.water.current = Math.max(
-            0,
-            sectSystem.orbs.water.current - 2
-          );
-          raidState.damageReceived += 2;
-          const orbEl = getOrb();
-          runAnimation(orbEl, 'orb-hit');
-          addLog('SlowBlob hits the Water Orb for 2 damage.', 'damage');
+          bus.publish('BLOB_ATTACK_ORB', { damage: 2 });
           this.nextAttack = now + BLOB_ATTACK_INTERVAL;
-          if (sectSystem.orbs.water.current <= 0 && raidState.active) {
-            endRaid(false);
-            return;
-          }
         }
       }
     },
@@ -252,7 +241,7 @@ function orbAttack() {
   });
   if (target) {
     target.takeDamage(2);
-    raidState.damageDealt += 2;
+    bus.publish('RAID_DAMAGE_DEALT', { amount: 2 });
     runAnimation(target.el, 'hit-animate');
     runAnimation(orb, 'orb-burst');
     flashOrbGlow();
@@ -288,7 +277,7 @@ function discipleAttack() {
       });
       if (target) {
         target.takeDamage(DISCIPLE_DAMAGE);
-        raidState.damageDealt += DISCIPLE_DAMAGE;
+        bus.publish('RAID_DAMAGE_DEALT', { amount: DISCIPLE_DAMAGE });
         runAnimation(el, 'disciple-strike');
         d._attackTimer = now + DISCIPLE_ATTACK_INTERVAL;
       }
@@ -297,6 +286,7 @@ function discipleAttack() {
 }
 
 export function tickBlobRaid(delta) {
+  if (!activeRaid) return;
   spawnTimer += delta;
   orbAttackTimer += delta;
   const fill = getOrbAttackFill();
@@ -332,7 +322,7 @@ export function damageClosestBlob(dmg) {
     if (b.hp < target.hp) target = b;
   });
   target.takeDamage(dmg);
-  raidState.damageDealt += dmg;
+  bus.publish('RAID_DAMAGE_DEALT', { amount: dmg });
 }
 
 export function hasBlobs() {
@@ -341,4 +331,28 @@ export function hasBlobs() {
 
 export function raidFinished() {
   return spawnCount >= MAX_BLOBS && blobs.length === 0;
+}
+
+// Event bus wiring
+bus.subscribe('BLOB_SPAWN', () => {
+  spawnBlob();
+});
+
+bus.subscribe('DISCIPLE_ATTACK', ({ damage }) => {
+  damageClosestBlob(damage);
+});
+
+bus.subscribe('TICK', ({ delta }) => {
+  tickBlobRaid(delta);
+});
+
+// Track raid activity
+if (typeof document !== 'undefined' && typeof document.addEventListener === 'function') {
+  document.addEventListener('raid-start', () => {
+    activeRaid = true;
+  });
+
+  document.addEventListener('raid-end', () => {
+    activeRaid = false;
+  });
 }

--- a/game/canBus.js
+++ b/game/canBus.js
@@ -1,0 +1,13 @@
+class CANBus {
+  constructor() {
+    this.handlers = {};
+  }
+  subscribe(event, fn) {
+    (this.handlers[event] ||= []).push(fn);
+  }
+  publish(event, payload) {
+    (this.handlers[event] || []).forEach(fn => fn(payload));
+  }
+}
+
+export default new CANBus();

--- a/game/combat.js
+++ b/game/combat.js
@@ -17,6 +17,7 @@ import { showRestartScreen } from '../ui/restartOverlay.js';
 import { raidState } from './raids.js';
 
 import addLog from './log.js';
+import bus from './canBus.js';
 
 export function applyDamage(target, amount) {
   let remaining = Math.round(amount);
@@ -189,5 +190,11 @@ export function damageDisciple(target, damageAmount, source = 'enemy') {
     });
   }
 }
+
+// Event bus wiring
+bus.subscribe('BLOB_ATTACK_DISCIPLE', ({ id, damage }) => {
+  const disc = sectSystem.disciples.find(d => d.id === id);
+  if (disc) damageDisciple(disc, damage, 'SlowBlob');
+});
 
 globalThis.cDealerDamage = cDealerDamage;

--- a/game/raids.js
+++ b/game/raids.js
@@ -6,20 +6,19 @@ import {
 } from './state.js';
 import { updateDealerLifeDisplay } from './ui.js';
 import { showRaidSummaryOverlay } from '../ui/raidSummaryOverlay.js';
+import { runAnimation } from '../utils/animation.js';
 
 import addLog from './log.js';
 import { showRaidAlert } from './alerts.js';
 import { ensureDiscipleSkills, getTaskSkillProgress } from '../utils/skills.js';
 import {
-  tickBlobRaid,
-  spawnBlob,
   clearBlobs,
-  damageClosestBlob,
   canSpawn,
   raidFinished,
   showOrbAttackBar,
   hideOrbAttackBar
 } from './blobRaids.js';
+import bus from './canBus.js';
 
 export const raidState = {
   active: false,
@@ -68,29 +67,27 @@ export function startRaid() {
   ) {
     const check = () => {
       if (canSpawn()) {
-        spawnBlob();
+        bus.publish('BLOB_SPAWN');
       } else {
         window.requestAnimationFrame(check);
       }
     };
     window.requestAnimationFrame(check);
   } else {
-    spawnBlob();
+    bus.publish('BLOB_SPAWN');
   }
   raidState.enemy = {
     maxHp: 20,
     currentHp: 20,
     takeDamage(dmg) {
-      damageClosestBlob(dmg);
+      bus.publish('DISCIPLE_ATTACK', { damage: dmg });
       raidState.damageDealt += dmg;
     },
     isDefeated() {
       if (!canSpawn()) return false;
       return raidFinished();
     },
-    tick(dt) {
-      tickBlobRaid(dt);
-    }
+    tick() {}
   };
   setCurrentEnemy(raidState.enemy);
   showOrbAttackBar();
@@ -169,12 +166,27 @@ export function endRaid(victory = false) {
   if (typeof updateSectDisplay === 'function') updateSectDisplay();
 }
 
-export function tickRaid(delta) {
+export function tickRaid() {
   if (!raidState.active || !raidState.enemy) return;
-  raidState.enemy.tick(delta);
   if (sectSystem.orbs.water.current <= 0) {
     endRaid(false);
     return;
   }
   if (raidState.enemy.isDefeated()) endRaid(true);
 }
+
+// Event bus wiring
+bus.subscribe('BLOB_ATTACK_ORB', ({ damage }) => {
+  sectSystem.orbs.water.current = Math.max(0, sectSystem.orbs.water.current - damage);
+  raidState.damageReceived += damage;
+  const orbEl = document.querySelector('#sectOrbs .sect-orb.water');
+  if (orbEl) runAnimation(orbEl, 'orb-hit');
+  addLog('SlowBlob hits the Water Orb for ' + damage + ' damage.', 'damage');
+  if (sectSystem.orbs.water.current <= 0 && raidState.active) {
+    endRaid(false);
+  }
+});
+
+bus.subscribe('RAID_DAMAGE_DEALT', ({ amount }) => {
+  raidState.damageDealt += amount;
+});

--- a/game/sect.js
+++ b/game/sect.js
@@ -1334,7 +1334,7 @@ export function tickSectSystem(delta) {
   tickActiveConstructs(dt);
   tickOrbSpells(dt);
   tickMetamorphosis(dt);
-  tickRaid(delta);
+  tickRaid();
   ins.current = Math.min(ins.max, Math.max(0, ins.current));
   if (hasUI) {
     updateCooldownOverlays();

--- a/script.js
+++ b/script.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-unused-vars, no-undef */
 // Core modules that power combat systems
 import Disciple from "./game/disciple.js";
+import bus from './game/canBus.js';
 import addLog from "./game/log.js"; // helper for appending to the event log
 import Enemy from "./game/enemy.js"; // base enemy class
 import {
@@ -2592,6 +2593,7 @@ function gameLoop(currentTime) {
   const rawDelta = currentTime - lastFrameTime;
   lastFrameTime = currentTime;
   const deltaTime = rawDelta * timeScale;
+  bus.publish('TICK', { delta: deltaTime });
   const startWater = sectSystem.resources.water.current;
   const startFruit = sectState.fruits;
   const startSoftwood = sectState.softwood;


### PR DESCRIPTION
## Summary
- add central CAN bus utility
- publish raid ticks and attacks via event bus
- update blob raid logic to emit events
- handle disciple and orb damage through subscriptions
- document new bus module
- tweak blob attack ranges
- route raid damage updates over the event bus
- halt blob updates unless a raid is active

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68893cb9034c83268570b9f5e6f6137a