### PR TITLE
Implement simple raid autobattler

### DIFF
--- a/docs/23-raids.md
+++ b/docs/23-raids.md
@@ -1,54 +1,16 @@
-
 # 23 – Raids
 
-**Sunday, July 20, 2025 • 8:15 PM**
+Night raids play out as a horizontal autobattler. Raiders march in waves from the right edge of the screen toward the Water Orb on the left. Disciples line up to meet them at the fight line in the center.
 
-Night raids escalate the longer your sect survives. Each evening hostile frogs or spirits attack from the edge of the sect map and attempt to reach the Water Orb.
-All raid interactions are coordinated through a small event bus so the combat,
-raid and rendering modules remain loosely coupled.
-Damage totals are broadcast via `RAID_DAMAGE_DEALT` and `BLOB_ATTACK_ORB` events
-which update the raid summary.
+Raid behaviour is entirely data‑driven. A raid is started by calling `startRaid(config)` where `config` provides:
 
-- **Enemy scaling** – raid size and enemy stats grow with the current stage and world. Early attacks feature sluggish "SlowBlob" spirits that spawn every few seconds and crawl toward the orb.
-- **Orb damage** – the Water Orb pulses damage in a small radius, harming nearby attackers. Buildings can boost this effect.
-- **Resource theft** – if any enemy touches the orb they steal a portion of stored resources (fruit, timber and ore) before escaping.
-- **Rewards** – defeating a raid grants small loot drops and experience for participating disciples.
+- `orb` – object with `current` and `max` water values
+- `disciples` – array of defender objects
+- `waves` – list describing each wave `{ count, rate, stats }`
+- Optional callbacks `onWaveStart`, `onWaveEnd`, `onSuccess`, and `onFailure`
 
-Disciples may be called upon to defend the sect from occasional raids.
+The module handles spawning raiders, advancing them toward the fight line and resolving combat. Raiders that reach the orb once will damage it and then vanish. If the orb's water reaches zero the raid fails immediately.
 
-* Raids begin automatically during the Night phase.
-* A red alert briefly appears on screen when a raid starts.
-* Raiders attack the Water orb, reducing its stored energy.
-* All disciples rush to intercept raiders as soon as they appear.
-* Raiders continue heading toward the Water orb but halt if a disciple enters a 100&nbsp;px radius, attacking while in range.
-* Blobs stop when within **100&nbsp;px** of the Water orb (`BLOB_ORB_ATTACK_RANGE`) before striking.
-* All disciples immediately pause their current task to join the defense.
-* After the raid ends, disciples automatically resume their previous work assignments, even if they were incapacitated at the start of the raid.
-* Each disciple seeks the nearest enemy and engages in melee when in range.
-* If the orb is depleted the sect loses **half** of its stored fruit and softwood.
-* Early raids send four SlowBlob raiders, one every 10&nbsp;s for 40&nbsp;s.
-* SlowBlob attacks now occur every 10&nbsp;s.
+When a raider crosses the fight line it pairs with the first available disciple. Neither combatant moves while engaged. They attack based on their `attackSpeed` until one is defeated. Victorious disciples may re‑enter the line while surviving raiders continue toward the orb.
 
-* The Water orb lashes out every 5&nbsp;s at blobs within 75&nbsp;px, striking the closest target for 2 damage.
-* Blobs show a small health meter as they crawl across the map.
-* When killed, blobs burst in a brief animation.
-* The Water orb displays a short attack timer bar above it and flashes each time it fires.
-* Disciples briefly grow in size when landing an attack.
-* When raiders are struck several small red circles mark the ground and remain on the sect map.
-*
-* Damage dealt to and by the Water orb is logged during raids.
-* All units traverse the map at a base rate of 10&nbsp;px per second.
-* SlowBlob raiders crawl at half this speed, moving only 5&nbsp;px per second.
-* SlowBlob raiders now sport two glowing red eyes that move with them.
-
-
-
-* Defeating a raid yields **Undead Nectar** in addition to experience. The nectar
-  is added to your resources side panel for later use.
-* The raid ends immediately when the enemy is defeated or the Water orb is drained.
-* A summary overlay appears after victory showing damage dealt, damage received,
-  rewards and how much combat XP each participating disciple earned. Each
-  disciple now displays a small progress bar indicating their level and progress
-  toward the next. Level ups are noted next to the disciple's name.
-* If defeated, a raid end overlay displays the resources lost when the orb was
-  drained.
+The raid ends when all waves are cleared or the orb is destroyed. Callbacks are fired at the start and end of each wave along with a final success or failure signal. Disciples temporarily switch to the "Idle" task during a raid so their badges remain visible in the interface.

--- a/game/horizontalRaid.js
+++ b/game/horizontalRaid.js
@@ -1,0 +1,155 @@
+import { createDiscipleBadge } from './badges.js';
+
+export function createHorizontalRaid({ orb, disciples = [], waves = [], onWaveStart = () => {}, onWaveEnd = () => {}, onSuccess = () => {}, onFailure = () => {}, onDamage = () => {}, container = document.body } = {}) {
+  const state = {
+    orb,
+    disciples: disciples.map(d => ({ d, engaged: null, timer: 0 })),
+    waves,
+    onWaveStart,
+    onWaveEnd,
+    onSuccess,
+    onFailure,
+    container,
+    root: null,
+    raiders: [],
+    waveIndex: 0,
+    spawnIndex: 0,
+    spawnTimer: 0,
+    active: false,
+    onDamage
+  };
+
+  function buildUI() {
+    const root = document.createElement('div');
+    root.className = 'raid-container';
+    const line = document.createElement('div');
+    line.className = 'fight-line';
+    root.appendChild(line);
+    state.disciples.forEach((slot, i) => {
+      const badge = createDiscipleBadge(slot.d);
+      badge.style.position = 'absolute';
+      badge.style.left = `${10 + i * 60}px`;
+      badge.style.bottom = '0';
+      root.appendChild(badge);
+      slot.el = badge;
+    });
+    state.container.appendChild(root);
+    state.root = root;
+  }
+
+  function spawnRaider(stats) {
+    const el = document.createElement('div');
+    el.className = 'raider-unit';
+    state.root.appendChild(el);
+    state.raiders.push({
+      hp: stats.hp,
+      damage: stats.damage,
+      attackSpeed: stats.attackSpeed,
+      moveSpeed: stats.moveSpeed,
+      progress: 1,
+      timer: 0,
+      el,
+      engaged: null
+    });
+  }
+
+  function tryEngage(r) {
+    const slot = state.disciples.find(s => !s.engaged && !s.d.incapacitated);
+    if (!slot) return false;
+    r.engaged = slot;
+    slot.engaged = r;
+    r.progress = 0.5;
+    if (slot.el) slot.el.style.left = '45%';
+    if (r.el) r.el.style.left = '55%';
+    return true;
+  }
+
+  function updateRaiders(dt) {
+    state.raiders.forEach(r => {
+      if (r.engaged) {
+        r.timer += dt;
+        const d = r.engaged;
+        d.timer += dt;
+        if (r.timer >= r.attackSpeed) {
+          r.timer -= r.attackSpeed;
+          d.d.currentHp = Math.max(0, d.d.currentHp - r.damage);
+          state.onDamage({ amount: r.damage, source: 'raider' });
+          if (d.d.currentHp === 0) {
+            d.engaged = null;
+            r.engaged = null;
+          }
+        }
+        if (d.timer >= d.d.attackSpeed && r.engaged) {
+          d.timer -= d.d.attackSpeed;
+          r.hp = Math.max(0, r.hp - d.d.damage);
+          state.onDamage({ amount: d.d.damage, source: 'disciple' });
+          if (r.hp === 0) {
+            r.el.remove();
+            const idx = state.raiders.indexOf(r);
+            if (idx >= 0) state.raiders.splice(idx, 1);
+            d.engaged = null;
+          }
+        }
+      } else {
+        r.progress -= r.moveSpeed * dt;
+        if (r.progress <= 0.5) {
+          if (!tryEngage(r)) {
+            r.progress -= r.moveSpeed * dt;
+          }
+        }
+        if (r.progress <= 0) {
+          state.orb.current = Math.max(0, state.orb.current - r.damage);
+          state.onDamage({ amount: r.damage, source: 'raider' });
+          r.el.remove();
+          const idx = state.raiders.indexOf(r);
+          if (idx >= 0) state.raiders.splice(idx, 1);
+          if (state.orb.current <= 0) end(false);
+        }
+        if (r.el) r.el.style.left = `${r.progress * 100}%`;
+      }
+    });
+  }
+
+  function spawnLoop(dt) {
+    const wave = state.waves[state.waveIndex];
+    if (!wave) return;
+    if (state.spawnIndex < wave.count) {
+      state.spawnTimer += dt;
+      if (state.spawnTimer >= wave.rate) {
+        state.spawnTimer -= wave.rate;
+        spawnRaider(wave.stats);
+        state.spawnIndex += 1;
+      }
+    }
+    if (state.spawnIndex >= wave.count && state.raiders.length === 0) {
+      state.onWaveEnd(state.waveIndex);
+      state.waveIndex += 1;
+      state.spawnIndex = 0;
+      state.spawnTimer = 0;
+      if (state.waveIndex >= state.waves.length) {
+        end(true);
+      } else {
+        state.onWaveStart(state.waveIndex);
+      }
+    }
+  }
+
+  function end(success) {
+    if (!state.active) return;
+    state.active = false;
+    state.root?.remove();
+    state.raiders.length = 0;
+    state.onWaveEnd(state.waveIndex);
+    success ? state.onSuccess() : state.onFailure();
+  }
+
+  function tick(dt) {
+    if (!state.active) return;
+    spawnLoop(dt);
+    updateRaiders(dt / 1000);
+  }
+
+  buildUI();
+
+  return { start: () => { state.active = true; state.onWaveStart(0); }, tick, end };
+}

--- a/game/raids.js
+++ b/game/raids.js
@@ -1,45 +1,69 @@
-/* global updateSectDisplay */
 import { sectSystem } from './sect.js';
-import {
-  sectState,
-  setCurrentEnemy
-} from './state.js';
-import { updateDealerLifeDisplay } from './ui.js';
-import { showRaidSummaryOverlay } from '../ui/raidSummaryOverlay.js';
-import { runAnimation } from '../utils/animation.js';
-
-import addLog from './log.js';
-import { showRaidAlert } from './alerts.js';
+import { sectState } from './state.js';
 import { ensureDiscipleSkills, getTaskSkillProgress } from '../utils/skills.js';
-import {
-  clearBlobs,
-  canSpawn,
-  raidFinished,
-  showOrbAttackBar,
-  hideOrbAttackBar
-} from './blobRaids.js';
-import bus from './canBus.js';
+import { showRaidAlert } from './alerts.js';
+import { showRaidSummaryOverlay } from '../ui/raidSummaryOverlay.js';
+import { createHorizontalRaid } from './horizontalRaid.js';
 
 export const raidState = {
   active: false,
-  enemy: null,
-  attackTimers: {},
-  orbTimer: 0,
+  raid: null,
   damageDealt: 0,
   damageReceived: 0,
   xpStart: {},
   prevTasks: {}
 };
 
+function buildDefaultConfig() {
+  return {
+    orb: sectSystem.orbs.water,
+    disciples: sectSystem.disciples.filter(d => !d.incapacitated),
+    waves: [
+      {
+        count: 4,
+        rate: 1000,
+        stats: { hp: 10, damage: 1, attackSpeed: 1000, moveSpeed: 0.002 }
+      }
+    ]
+  };
+}
 
-// blob raids handle their own visuals and timing
+function finalize(victory) {
+  const xpStart = raidState.xpStart;
+  raidState.xpStart = {};
+  Object.keys(raidState.prevTasks).forEach(id => {
+    sectState.discipleTasks[id] = raidState.prevTasks[id] || 'Idle';
+  });
+  raidState.prevTasks = {};
+  raidState.active = false;
+  raidState.raid = null;
 
+  const fighters = Object.keys(xpStart).map(id => {
+    const start = xpStart[id];
+    const xp = sectState.discipleSkills[id]?.Combat || 0;
+    const diff = xp - start.xp;
+    const prog = getTaskSkillProgress(xp);
+    return {
+      name: start.name,
+      xp: diff,
+      level: prog.level,
+      progress: prog.progress,
+      leveled: prog.level > start.level
+    };
+  });
 
-export function startRaid() {
+  showRaidSummaryOverlay({
+    victory,
+    damageDealt: raidState.damageDealt,
+    damageReceived: raidState.damageReceived,
+    fighters
+  });
+}
+
+export function startRaid(config = buildDefaultConfig()) {
   if (raidState.active) return;
   raidState.damageDealt = 0;
   raidState.damageReceived = 0;
-  raidState.xpStart = {};
   raidState.prevTasks = {};
   sectSystem.disciples.forEach(d => {
     raidState.prevTasks[d.id] = sectState.discipleTasks[d.id];
@@ -52,141 +76,38 @@ export function startRaid() {
       ensureDiscipleSkills(d.id);
       raidState.xpStart[d.id] = {
         xp: sectState.discipleSkills[d.id].Combat || 0,
-        level: getTaskSkillProgress(
-          sectState.discipleSkills[d.id].Combat || 0
-        ).level,
+        level: getTaskSkillProgress(sectState.discipleSkills[d.id].Combat || 0).level,
         name: d.name
       };
     }
   });
-  clearBlobs();
-  if (
-    typeof window !== 'undefined' &&
-    window.requestAnimationFrame &&
-    !canSpawn()
-  ) {
-    const check = () => {
-      if (canSpawn()) {
-        bus.publish('BLOB_SPAWN');
-      } else {
-        window.requestAnimationFrame(check);
-      }
-    };
-    window.requestAnimationFrame(check);
-  } else {
-    bus.publish('BLOB_SPAWN');
-  }
-  raidState.enemy = {
-    maxHp: 20,
-    currentHp: 20,
-    takeDamage(dmg) {
-      bus.publish('DISCIPLE_ATTACK', { damage: dmg });
-      raidState.damageDealt += dmg;
-    },
-    isDefeated() {
-      if (!canSpawn()) return false;
-      return raidFinished();
-    },
-    tick() {}
-  };
-  setCurrentEnemy(raidState.enemy);
-  showOrbAttackBar();
 
+  raidState.raid = createHorizontalRaid({
+    orb: config.orb,
+    disciples: config.disciples,
+    waves: config.waves,
+    container: document.querySelector('.raidCardContainer') || document.body,
+    onSuccess: () => endRaid(true),
+    onFailure: () => endRaid(false),
+    onDamage: ({ amount, source }) => {
+      if (source === 'disciple') raidState.damageDealt += amount;
+      else raidState.damageReceived += amount;
+    }
+  });
+  raidState.raid.start();
   raidState.active = true;
-  raidState.attackTimers = {};
-  raidState.orbTimer = 0;
-  addLog('Raiders have attacked!', 'info');
   showRaidAlert('Raiders incoming!');
-  document.dispatchEvent(
-    new CustomEvent('raid-start', { detail: { enemy: raidState.enemy, useCard: false } })
-  );
-  if (typeof updateSectDisplay === 'function') updateSectDisplay();
+  document.dispatchEvent(new CustomEvent('raid-start', { detail: {} }));
+}
+
+export function tickRaid(delta) {
+  if (!raidState.active || !raidState.raid) return;
+  raidState.raid.tick(delta);
 }
 
 export function endRaid(victory = false) {
   if (!raidState.active) return;
-  const enemy = raidState.enemy;
-  raidState.active = false;
-  setCurrentEnemy(null);
-  raidState.enemy = null;
-  raidState.attackTimers = {};
-  raidState.orbTimer = 0;
-  const xpStart = raidState.xpStart;
-  raidState.xpStart = {};
-  Object.keys(raidState.prevTasks).forEach(id => {
-    sectState.discipleTasks[id] = raidState.prevTasks[id] || 'Idle';
-  });
-  raidState.prevTasks = {};
-  clearBlobs();
-  hideOrbAttackBar();
-  addLog('The raid has ended.', 'info');
-  updateDealerLifeDisplay(null);
-  if (victory && enemy) {
-    const fighters = Object.keys(xpStart).map(id => {
-      const start = xpStart[id];
-      const xp =
-        sectState.discipleSkills[id]?.Combat || 0;
-      const diff = xp - start.xp;
-      const prog = getTaskSkillProgress(xp);
-      return {
-        name: start.name,
-        xp: diff,
-        level: prog.level,
-        progress: prog.progress,
-        leveled: prog.level > start.level
-      };
-    });
-    sectState.undeadNectar = (sectState.undeadNectar || 0) + 1;
-    if (sectSystem.resources.undeadNectar) {
-      const res = sectSystem.resources.undeadNectar;
-      res.current = Math.min(res.max, (res.current || 0) + 1);
-      res.unlocked = true;
-    }
-    showRaidSummaryOverlay({
-      damageDealt: raidState.damageDealt,
-      damageReceived: raidState.damageReceived,
-      rewards: { undeadNectar: 1 },
-      fighters
-    });
-  } else if (!victory) {
-    const lost = {
-      fruits: Math.floor(sectState.fruits / 2),
-      softwood: Math.floor(sectState.softwood / 2)
-    };
-    sectState.fruits -= lost.fruits;
-    sectState.softwood -= lost.softwood;
-    showRaidSummaryOverlay({
-      victory: false,
-      damageDealt: raidState.damageDealt,
-      damageReceived: raidState.damageReceived,
-      lost
-    });
-  }
+  raidState.raid.end(victory);
+  finalize(victory);
   document.dispatchEvent(new CustomEvent('raid-end', { detail: { victory } }));
-  if (typeof updateSectDisplay === 'function') updateSectDisplay();
 }
-
-export function tickRaid() {
-  if (!raidState.active || !raidState.enemy) return;
-  if (sectSystem.orbs.water.current <= 0) {
-    endRaid(false);
-    return;
-  }
-  if (raidState.enemy.isDefeated()) endRaid(true);
-}
-
-// Event bus wiring
-bus.subscribe('BLOB_ATTACK_ORB', ({ damage }) => {
-  sectSystem.orbs.water.current = Math.max(0, sectSystem.orbs.water.current - damage);
-  raidState.damageReceived += damage;
-  const orbEl = document.querySelector('#sectOrbs .sect-orb.water');
-  if (orbEl) runAnimation(orbEl, 'orb-hit');
-  addLog('SlowBlob hits the Water Orb for ' + damage + ' damage.', 'damage');
-  if (sectSystem.orbs.water.current <= 0 && raidState.active) {
-    endRaid(false);
-  }
-});
-
-bus.subscribe('RAID_DAMAGE_DEALT', ({ amount }) => {
-  raidState.damageDealt += amount;
-});

--- a/style.css
+++ b/style.css
@@ -541,6 +541,34 @@ body.darkenshift-mode .tabsContainer button.active {
     transition: width 0.3s;
 }
 
+.raid-container {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 40px;
+    height: 60px;
+    pointer-events: none;
+}
+
+.raid-container .fight-line {
+    position: absolute;
+    left: 50%;
+    top: 0;
+    bottom: 0;
+    width: 2px;
+    background: rgba(255,255,255,0.2);
+}
+
+.raider-unit {
+    position: absolute;
+    bottom: 0;
+    width: 16px;
+    height: 16px;
+    background: purple;
+    border-radius: 4px;
+    pointer-events: none;
+}
+
 .water-burst {
     position: absolute;
     width: 12px;


### PR DESCRIPTION
## Summary
- replace blob raids with horizontal autobattler logic
- document new raid API and behaviour
- style raid container and enemy units

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688aa050b3d08326b5a68388d890d79b