### PR TITLE
Fix raid enemy reference

### DIFF
--- a/script.js
+++ b/script.js
@@ -1547,7 +1547,8 @@ function init() {
     setInCombat(true);
     removeDealerLifeBar();
     const detail = e.detail || {};
-    const enemy = detail.enemy ?? detail;
+    const enemy =
+      typeof detail.enemy !== 'undefined' ? detail.enemy : detail;
     const useCard = detail.useCard !== false;
     setCurrentEnemy(enemy);
     if (useCard) {


### PR DESCRIPTION
## Summary
- prevent `raid-start` listener from setting a dummy enemy object when `enemy` is null

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688b6c1763c083268ffba9a09ac468ff