### PR TITLE
Add raid damage numbers

### DIFF
--- a/docs/23-raids.md
+++ b/docs/23-raids.md
@@ -15,4 +15,4 @@ When a raider crosses the fight line it pairs with the first available disciple.
 
 The raid ends when all waves are cleared or the orb is destroyed. Callbacks are fired at the start and end of each wave along with a final success or failure signal. When night falls the game automatically opens a dedicated raid overlay and begins a raid. Disciples temporarily switch to the "Idle" task so their badges remain visible in the interface.
 
-The overlay fills the entire screen. Disciple badges line the top while their sprites stand near the Water Orb at the bottom left. Raiders advance from the right toward a fight line in the center where battles take place.
+The overlay fills the entire screen. Disciple badges line the top while their sprites stand near the Water Orb at the bottom left. Raiders advance from the right toward a fight line in the center where battles take place. Damage numbers briefly float above disciples, raiders and the orb whenever they are hit.

--- a/game/horizontalRaid.js
+++ b/game/horizontalRaid.js
@@ -1,4 +1,5 @@
 import { createDiscipleBadge } from './badges.js';
+import { showRaidDamageFloat } from './rendering.js';
 
 export function createHorizontalRaid({ orb, disciples = [], waves = [], onWaveStart = () => {}, onWaveEnd = () => {}, onSuccess = () => {}, onFailure = () => {}, onDamage = () => {}, container = document.body } = {}) {
   const state = {
@@ -17,7 +18,8 @@ export function createHorizontalRaid({ orb, disciples = [], waves = [], onWaveSt
     spawnTimer: 0,
     active: false,
     onDamage,
-    orbFill: null
+    orbFill: null,
+    orbEl: null
   };
 
   function buildUI() {
@@ -35,6 +37,7 @@ export function createHorizontalRaid({ orb, disciples = [], waves = [], onWaveSt
     orbEl.appendChild(fill);
     root.appendChild(orbEl);
     state.orbFill = fill;
+    state.orbEl = orbEl;
 
     state.disciples.forEach((slot, i) => {
       const badge = createDiscipleBadge(slot.d);
@@ -92,6 +95,7 @@ export function createHorizontalRaid({ orb, disciples = [], waves = [], onWaveSt
           r.timer -= r.attackSpeed;
           d.d.currentHp = Math.max(0, d.d.currentHp - r.damage);
           state.onDamage({ amount: r.damage, source: 'raider' });
+          showRaidDamageFloat(d.sprite, r.damage);
           if (d.d.currentHp === 0) {
             d.engaged = null;
             r.engaged = null;
@@ -102,6 +106,7 @@ export function createHorizontalRaid({ orb, disciples = [], waves = [], onWaveSt
           d.timer -= d.d.attackSpeed;
           r.hp = Math.max(0, r.hp - d.d.damage);
           state.onDamage({ amount: d.d.damage, source: 'disciple' });
+          showRaidDamageFloat(r.el, d.d.damage);
           if (r.hp === 0) {
             r.el.remove();
             const idx = state.raiders.indexOf(r);
@@ -123,6 +128,7 @@ export function createHorizontalRaid({ orb, disciples = [], waves = [], onWaveSt
             state.orbFill.style.height = `${(state.orb.current / state.orb.max) * 100}%`;
           }
           state.onDamage({ amount: r.damage, source: 'raider' });
+          showRaidDamageFloat(state.orbEl, r.damage);
           r.el.remove();
           const idx = state.raiders.indexOf(r);
           if (idx >= 0) state.raiders.splice(idx, 1);

--- a/game/rendering.js
+++ b/game/rendering.js
@@ -176,6 +176,22 @@ export function showDamageFloat(card, amount) {
   setTimeout(() => dmg.remove(), 3000);
 }
 
+export function showRaidDamageFloat(el, amount) {
+  if (!el) return;
+  const dmg = document.createElement('div');
+  dmg.classList.add('damage-float');
+  dmg.textContent = `-${amount}`;
+  el.appendChild(dmg);
+  dmg.addEventListener(
+    'animationend',
+    () => dmg.remove(),
+    {
+      once: true
+    }
+  );
+  setTimeout(() => dmg.remove(), 3000);
+}
+
 export function animateDiscipleDeath(card, callback) {
   const w = card.wrapperElement;
   if (!w) {


### PR DESCRIPTION
## Summary
- display floating damage numbers during raids
- document raid damage floats

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688b761f5498832699ceb49ba6b2fbdc