### PR TITLE
Increase raider speed

### DIFF
--- a/game/horizontalRaid.js
+++ b/game/horizontalRaid.js
@@ -1,5 +1,8 @@
 import { createDiscipleBadge } from './badges.js';
 
+// Multiply raider movement speed by this factor
+const RAIDER_SPEED_MULTIPLIER = 3;
+
 export function createHorizontalRaid({ orb, disciples = [], waves = [], onWaveStart = () => {}, onWaveEnd = () => {}, onSuccess = () => {}, onFailure = () => {}, onDamage = () => {}, container = document.body } = {}) {
   const state = {
     orb,
@@ -63,7 +66,7 @@ export function createHorizontalRaid({ orb, disciples = [], waves = [], onWaveSt
       hp: stats.hp,
       damage: stats.damage,
       attackSpeed: stats.attackSpeed,
-      moveSpeed: stats.moveSpeed,
+      moveSpeed: stats.moveSpeed * RAIDER_SPEED_MULTIPLIER,
       progress: 1,
       timer: 0,
       el,


### PR DESCRIPTION
## Summary
- add a `RAIDER_SPEED_MULTIPLIER` constant
- apply speed multiplier when spawning raiders

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688b76118f5c8326956a1d35959ffc1a