### PR TITLE
Fix raid damage display

### DIFF
--- a/docs/23-raids.md
+++ b/docs/23-raids.md
@@ -16,3 +16,4 @@ When a raider crosses the fight line it pairs with the first available disciple.
 The raid ends when all waves are cleared or the orb is destroyed. Callbacks are fired at the start and end of each wave along with a final success or failure signal. When night falls the game automatically opens a dedicated raid overlay and begins a raid. Disciples temporarily switch to the "Idle" task so their badges remain visible in the interface.
 
 The overlay fills the entire screen. Disciple badges line the top while their sprites stand near the Water Orb at the bottom left. Raiders advance from the right toward a fight line in the center where battles take place. Damage numbers briefly float above disciples, raiders and the orb whenever they are hit.
+Damage floats use red text when disciples take damage and white when raiders are struck. Raiders are drawn with a thin black border so each unit is clearly visible.

--- a/game/horizontalRaid.js
+++ b/game/horizontalRaid.js
@@ -109,7 +109,7 @@ export function createHorizontalRaid({ orb, disciples = [], waves = [], onWaveSt
           d.timer -= d.d.attackSpeed;
           r.hp = Math.max(0, r.hp - d.d.damage);
           state.onDamage({ amount: d.d.damage, source: 'disciple' });
-          showRaidDamageFloat(r.el, d.d.damage);
+          showRaidDamageFloat(r.el, d.d.damage, true);
           if (r.hp === 0) {
             r.el.remove();
             const idx = state.raiders.indexOf(r);
@@ -182,7 +182,8 @@ export function createHorizontalRaid({ orb, disciples = [], waves = [], onWaveSt
   function tick(dt) {
     if (!state.active) return;
     spawnLoop(dt);
-    updateRaiders(dt / 1000);
+    // dt is in milliseconds; use same unit for attack timers
+    updateRaiders(dt);
   }
 
   buildUI();

--- a/game/rendering.js
+++ b/game/rendering.js
@@ -176,10 +176,11 @@ export function showDamageFloat(card, amount) {
   setTimeout(() => dmg.remove(), 3000);
 }
 
-export function showRaidDamageFloat(el, amount) {
+export function showRaidDamageFloat(el, amount, isRaider = false) {
   if (!el) return;
   const dmg = document.createElement('div');
   dmg.classList.add('damage-float');
+  if (isRaider) dmg.classList.add('raider-damage');
   dmg.textContent = `-${amount}`;
   el.appendChild(dmg);
   dmg.addEventListener(

--- a/style.css
+++ b/style.css
@@ -566,6 +566,7 @@ body.darkenshift-mode .tabsContainer button.active {
     height: 16px;
     background: purple;
     border-radius: 4px;
+    border: 1px solid #000;
     pointer-events: none;
 }
 
@@ -1723,6 +1724,9 @@ body.darkenshift-mode .tabsContainer button.active {
     text-shadow: 0 0 2px #000;
     font-size: 1.4em;
     animation: damage-float 3s ease-out forwards;
+}
+.raider-damage {
+    color: white;
 }
 
 @keyframes damage-float {


### PR DESCRIPTION
## Summary
- adjust raid attack timer calculations
- color raider damage text white
- outline raider units
- document raid damage colors

## Testing
- `npm run build`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b7a54299083268648d6e32e0583e4