### PR TITLE
Tune raider base speed

### DIFF
--- a/game/horizontalRaid.js
+++ b/game/horizontalRaid.js
@@ -2,10 +2,7 @@ import { createDiscipleBadge } from './badges.js';
 import { showRaidDamageFloat } from './rendering.js';
 
 // Multiply raider movement speed by this factor
-const RAIDER_SPEED_MULTIPLIER = 3;
-
-// Multiply raider movement speed by this factor
-const RAIDER_SPEED_MULTIPLIER = 3;
+const RAIDER_SPEED_MULTIPLIER = 1.5;
 
 export function createHorizontalRaid({ orb, disciples = [], waves = [], onWaveStart = () => {}, onWaveEnd = () => {}, onSuccess = () => {}, onFailure = () => {}, onDamage = () => {}, container = document.body } = {}) {
   const state = {

--- a/game/raids.js
+++ b/game/raids.js
@@ -23,7 +23,7 @@ function buildDefaultConfig() {
       {
         count: 4,
         rate: 1000,
-        stats: { hp: 10, damage: 1, attackSpeed: 1000, moveSpeed: 0.002 }
+        stats: { hp: 10, damage: 1, attackSpeed: 1000, moveSpeed: 0.004 }
       }
     ]
   };


### PR DESCRIPTION
## Summary
- slow down horizontal raids by lowering the multiplier
- raise the base raider speed in the default config

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688b811a887c8326abf502dce79c61b2