### PR TITLE
Fix disciple badge HP updates

### DIFF
--- a/game/combat.js
+++ b/game/combat.js
@@ -27,6 +27,9 @@ export function applyDamage(target, amount) {
     remaining -= absorbed;
   }
   target.currentHp = Math.max(0, target.currentHp - remaining);
+  if (Object.hasOwn(target, 'health')) {
+    target.health = target.currentHp;
+  }
   return remaining;
 }
 

--- a/game/disciple.js
+++ b/game/disciple.js
@@ -59,6 +59,9 @@ export default class Disciple {
 
   takeDamage(amount) {
     this.currentHp = Math.round(Math.max(0, this.currentHp - amount));
+    if (Object.hasOwn(this, 'health')) {
+      this.health = this.currentHp;
+    }
   }
 
   isDefeated() {

--- a/game/horizontalRaid.js
+++ b/game/horizontalRaid.js
@@ -1,5 +1,6 @@
 import { createDiscipleBadge } from './badges.js';
 import { showRaidDamageFloat } from './rendering.js';
+import { applyDamage } from './combat.js';
 
 // Multiply raider movement speed by this factor
 const RAIDER_SPEED_MULTIPLIER = 1.5;
@@ -97,7 +98,7 @@ export function createHorizontalRaid({ orb, disciples = [], waves = [], onWaveSt
         d.timer += dt;
         if (r.timer >= r.attackSpeed) {
           r.timer -= r.attackSpeed;
-          d.d.currentHp = Math.max(0, d.d.currentHp - r.damage);
+          applyDamage(d.d, r.damage);
           state.onDamage({ amount: r.damage, source: 'raider' });
           showRaidDamageFloat(d.sprite, r.damage);
           if (d.d.currentHp === 0) {


### PR DESCRIPTION
## Summary
- use `applyDamage` in horizontal raids so water absorbs damage

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688b9234efb0832685683792f0f0f8a4