### PR TITLE
Adjust raid pacing

### DIFF
--- a/docs/23-raids.md
+++ b/docs/23-raids.md
@@ -9,6 +9,9 @@ Raid behaviour is entirely data‑driven. A raid is started by calling `startRai
 - `waves` – list describing each wave `{ count, rate, stats }`
 - Optional callbacks `onWaveStart`, `onWaveEnd`, `onSuccess`, and `onFailure`
 
+A typical raid now consists of **five** waves. Each wave spawns a single raider
+and there is a five‑second pause before the next wave begins.
+
 The module handles spawning raiders, advancing them toward the fight line and resolving combat. Raiders that reach the orb once will damage it and then vanish. If the orb's water reaches zero the raid fails immediately.
 
 When a raider crosses the fight line it pairs with the first available disciple. Neither combatant moves while engaged. They attack based on their `attackSpeed` until one is defeated. Victorious disciples may re‑enter the line while surviving raiders continue toward the orb.

--- a/game/horizontalRaid.js
+++ b/game/horizontalRaid.js
@@ -2,8 +2,8 @@ import { createDiscipleBadge } from './badges.js';
 import { showRaidDamageFloat } from './rendering.js';
 import { applyDamage } from './combat.js';
 
-// Multiply raider movement speed by this factor
-const RAIDER_SPEED_MULTIPLIER = 1.5;
+// Delay between waves in milliseconds
+const WAVE_DELAY = 5000;
 
 
 export function createHorizontalRaid({ orb, disciples = [], waves = [], onWaveStart = () => {}, onWaveEnd = () => {}, onSuccess = () => {}, onFailure = () => {}, onDamage = () => {}, container = document.body } = {}) {
@@ -21,6 +21,8 @@ export function createHorizontalRaid({ orb, disciples = [], waves = [], onWaveSt
     waveIndex: 0,
     spawnIndex: 0,
     spawnTimer: 0,
+    waveTimer: 0,
+    waiting: false,
     active: false,
     onDamage,
     orbFill: null,
@@ -71,7 +73,7 @@ export function createHorizontalRaid({ orb, disciples = [], waves = [], onWaveSt
       hp: stats.hp,
       damage: stats.damage,
       attackSpeed: stats.attackSpeed,
-      moveSpeed: stats.moveSpeed * RAIDER_SPEED_MULTIPLIER,
+      moveSpeed: stats.moveSpeed,
       progress: 1,
       timer: 0,
       el,
@@ -147,6 +149,15 @@ export function createHorizontalRaid({ orb, disciples = [], waves = [], onWaveSt
   function spawnLoop(dt) {
     const wave = state.waves[state.waveIndex];
     if (!wave) return;
+    if (state.waiting) {
+      state.waveTimer += dt;
+      if (state.waveTimer >= WAVE_DELAY) {
+        state.waiting = false;
+        state.waveTimer = 0;
+        state.onWaveStart(state.waveIndex);
+      }
+      return;
+    }
     if (state.spawnIndex < wave.count) {
       state.spawnTimer += dt;
       if (state.spawnTimer >= wave.rate) {
@@ -163,7 +174,7 @@ export function createHorizontalRaid({ orb, disciples = [], waves = [], onWaveSt
       if (state.waveIndex >= state.waves.length) {
         end(true);
       } else {
-        state.onWaveStart(state.waveIndex);
+        state.waiting = true;
       }
     }
   }
@@ -190,5 +201,14 @@ export function createHorizontalRaid({ orb, disciples = [], waves = [], onWaveSt
 
   buildUI();
 
-  return { start: () => { state.active = true; state.onWaveStart(0); }, tick, end };
+  return {
+    start: () => {
+      state.active = true;
+      state.waiting = false;
+      state.waveTimer = 0;
+      state.onWaveStart(0);
+    },
+    tick,
+    end
+  };
 }

--- a/game/raids.js
+++ b/game/raids.js
@@ -19,13 +19,11 @@ function buildDefaultConfig() {
   return {
     orb: sectSystem.orbs.water,
     disciples: sectSystem.disciples.filter(d => !d.incapacitated),
-    waves: [
-      {
-        count: 4,
-        rate: 1000,
-        stats: { hp: 10, damage: 1, attackSpeed: 1000, moveSpeed: 0.004 }
-      }
-    ]
+    waves: Array.from({ length: 5 }, () => ({
+      count: 1,
+      rate: 1000,
+      stats: { hp: 10, damage: 1, attackSpeed: 1000, moveSpeed: 0.004 }
+    }))
   };
 }
 


### PR DESCRIPTION
## Summary
- remove raider speed multiplier
- support a 5 second delay between waves
- update default raid config to use 5 single-raider waves
- document updated raid flow

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688bb907e5748326b15d3c895e87b966