### PR TITLE
Enable multi-target raid combat

### DIFF
--- a/docs/23-raids.md
+++ b/docs/23-raids.md
@@ -14,7 +14,7 @@ and there is a five‑second pause before the next wave begins.
 
 The module handles spawning raiders, advancing them toward the fight line and resolving combat. Raiders that reach the orb once will damage it and then vanish. If the orb's water reaches zero the raid fails immediately.
 
-When a raider crosses the fight line it pairs with the first available disciple. Neither combatant moves while engaged. They attack based on their `attackSpeed` until one is defeated. Victorious disciples may re‑enter the line while surviving raiders continue toward the orb.
+When a raider reaches the fight line it stops and targets the rightmost living disciple. Disciples remain in place and always attack the leftmost raider. Several disciples may assault the same target at once, each dealing damage whenever their personal attack timer completes. Attacking disciples grow slightly larger and a dark overlay shrinks to indicate progress toward their next strike.
 
 The raid ends when all waves are cleared or the orb is destroyed. Callbacks are fired at the start and end of each wave along with a final success or failure signal. When night falls the game automatically opens a dedicated raid overlay and begins a raid. Disciples temporarily switch to the "Idle" task so their badges remain visible in the interface.
 

--- a/game/horizontalRaid.js
+++ b/game/horizontalRaid.js
@@ -9,7 +9,7 @@ const WAVE_DELAY = 5000;
 export function createHorizontalRaid({ orb, disciples = [], waves = [], onWaveStart = () => {}, onWaveEnd = () => {}, onSuccess = () => {}, onFailure = () => {}, onDamage = () => {}, container = document.body } = {}) {
   const state = {
     orb,
-    disciples: disciples.map(d => ({ d, engaged: null, timer: 0, badge: null, sprite: null, startLeft: 0 })),
+    disciples: disciples.map(d => ({ d, timer: 0, badge: null, sprite: null, startLeft: 0, target: null, overlay: null })),
     waves,
     onWaveStart,
     onWaveEnd,
@@ -55,9 +55,13 @@ export function createHorizontalRaid({ orb, disciples = [], waves = [], onWaveSt
       const sprite = document.createElement('div');
       sprite.className = 'raid-disciple';
       sprite.style.left = `${50 + i * 30}px`;
+      const overlay = document.createElement('div');
+      overlay.className = 'raid-attack-shadow';
+      sprite.appendChild(overlay);
       root.appendChild(sprite);
       slot.badge = badge;
       slot.sprite = sprite;
+      slot.overlay = overlay;
       slot.startLeft = 50 + i * 30;
     });
     state.container.appendChild(root);
@@ -76,72 +80,87 @@ export function createHorizontalRaid({ orb, disciples = [], waves = [], onWaveSt
       moveSpeed: stats.moveSpeed,
       progress: 1,
       timer: 0,
-      el,
-      engaged: null
+      el
     });
   }
 
-  function tryEngage(r) {
-    const slot = state.disciples.find(s => !s.engaged && !s.d.incapacitated);
-    if (!slot) return false;
-    r.engaged = slot;
-    slot.engaged = r;
-    r.progress = 0.5;
-    if (slot.sprite) slot.sprite.style.left = '45%';
-    if (r.el) r.el.style.left = '55%';
-    return true;
-  }
 
   function updateRaiders(dt) {
     state.raiders.forEach(r => {
-      if (r.engaged) {
-        r.timer += dt;
-        const d = r.engaged;
-        d.timer += dt;
-        if (r.timer >= r.attackSpeed) {
-          r.timer -= r.attackSpeed;
-          applyDamage(d.d, r.damage);
-          state.onDamage({ amount: r.damage, source: 'raider' });
-          showRaidDamageFloat(d.sprite, r.damage);
-          if (d.d.currentHp === 0) {
-            d.engaged = null;
-            r.engaged = null;
-            if (d.sprite) d.sprite.style.left = `${d.startLeft}px`;
-          }
-        }
-        if (d.timer >= d.d.attackSpeed && r.engaged) {
-          d.timer -= d.d.attackSpeed;
-          r.hp = Math.max(0, r.hp - d.d.damage);
-          state.onDamage({ amount: d.d.damage, source: 'disciple' });
-          showRaidDamageFloat(r.el, d.d.damage, true);
-          if (r.hp === 0) {
-            r.el.remove();
-            const idx = state.raiders.indexOf(r);
-            if (idx >= 0) state.raiders.splice(idx, 1);
-            d.engaged = null;
-            if (d.sprite) d.sprite.style.left = `${d.startLeft}px`;
-          }
-        }
-      } else {
+      if (r.progress > 0.5) {
         r.progress -= r.moveSpeed * dt;
-        if (r.progress <= 0.5) {
-          if (!tryEngage(r)) {
-            r.progress -= r.moveSpeed * dt;
-          }
-        }
+        if (r.el) r.el.style.left = `${r.progress * 100}%`;
+        return;
+      }
+
+      const living = state.disciples.filter(s => !s.d.incapacitated);
+      if (living.length === 0) {
+        r.progress -= r.moveSpeed * dt;
         if (r.progress <= 0) {
           state.orb.current = Math.max(0, state.orb.current - r.damage);
+          state.onDamage({ amount: r.damage, source: 'raider' });
           if (state.orbFill) {
             state.orbFill.style.height = `${(state.orb.current / state.orb.max) * 100}%`;
           }
-          state.onDamage({ amount: r.damage, source: 'raider' });
           showRaidDamageFloat(state.orbEl, r.damage);
           r.el.remove();
           const idx = state.raiders.indexOf(r);
           if (idx >= 0) state.raiders.splice(idx, 1);
           if (state.orb.current <= 0) end(false);
+          return;
         }
         if (r.el) r.el.style.left = `${r.progress * 100}%`;
+        return;
+      }
+
+      const target = living.sort((a, b) => b.startLeft - a.startLeft)[0];
+      r.timer += dt;
+      if (r.timer >= r.attackSpeed) {
+        r.timer -= r.attackSpeed;
+        applyDamage(target.d, r.damage);
+        state.onDamage({ amount: r.damage, source: 'raider' });
+        showRaidDamageFloat(target.sprite, r.damage);
+      }
+    });
+  }
+
+  function updateDisciples(dt) {
+    const livingRaiders = state.raiders;
+    state.disciples.forEach(slot => {
+      if (slot.d.incapacitated) return;
+
+      if (!slot.target || slot.target.hp <= 0 || !livingRaiders.includes(slot.target)) {
+        slot.target = null;
+        if (livingRaiders.length > 0) {
+          slot.target = livingRaiders.slice().sort((a, b) => a.progress - b.progress)[0];
+        }
+        if (!slot.target) {
+          slot.timer = 0;
+          slot.sprite?.classList.remove('attacking');
+          if (slot.overlay) slot.overlay.style.height = '0%';
+          return;
+        }
+      }
+
+      slot.sprite?.classList.add('attacking');
+      slot.timer += dt;
+      const ratio = Math.min(1, slot.timer / slot.d.attackSpeed);
+      if (slot.overlay) slot.overlay.style.height = `${(1 - ratio) * 100}%`;
+      if (slot.timer >= slot.d.attackSpeed) {
+        slot.timer -= slot.d.attackSpeed;
+        const r = slot.target;
+        r.hp = Math.max(0, r.hp - slot.d.damage);
+        state.onDamage({ amount: slot.d.damage, source: 'disciple' });
+        showRaidDamageFloat(r.el, slot.d.damage, true);
+        if (slot.overlay) slot.overlay.style.height = '100%';
+        if (r.hp === 0) {
+          r.el.remove();
+          const idx = state.raiders.indexOf(r);
+          if (idx >= 0) state.raiders.splice(idx, 1);
+          state.disciples.forEach(s => {
+            if (s.target === r) s.target = null;
+          });
+        }
       }
     });
   }
@@ -185,8 +204,9 @@ export function createHorizontalRaid({ orb, disciples = [], waves = [], onWaveSt
     state.root?.remove();
     state.raiders.length = 0;
     state.disciples.forEach(slot => {
-      slot.engaged = null;
-      if (slot.sprite) slot.sprite.style.left = `${slot.startLeft}px`;
+      slot.target = null;
+      if (slot.sprite) slot.sprite.classList.remove('attacking');
+      if (slot.overlay) slot.overlay.style.height = '0%';
     });
     state.onWaveEnd(state.waveIndex);
     success ? state.onSuccess() : state.onFailure();
@@ -197,6 +217,7 @@ export function createHorizontalRaid({ orb, disciples = [], waves = [], onWaveSt
     spawnLoop(dt);
     // dt is in milliseconds; use same unit for attack timers
     updateRaiders(dt);
+    updateDisciples(dt);
   }
 
   buildUI();

--- a/style.css
+++ b/style.css
@@ -582,6 +582,21 @@ body.darkenshift-mode .tabsContainer button.active {
     filter: drop-shadow(0 0 2px rgba(0,0,0,0.8));
 }
 
+.raid-disciple.attacking {
+    transform: scale(1.3);
+    z-index: 2;
+}
+
+.raid-attack-shadow {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: 0%;
+    background: rgba(0,0,0,0.5);
+    pointer-events: none;
+}
+
 .raid-orb {
     position: absolute;
     bottom: 8px;


### PR DESCRIPTION
## Summary
- allow multiple disciples to attack the same raider
- keep disciples in place and show attack progress via overlay
- raiders now strike the rightmost disciple while disciples focus the leftmost raider
- document updated raid flow

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688bcb4815008326b1fb564d255d74bd