### PR TITLE
Fix raider attack speed

### DIFF
--- a/game/raids.js
+++ b/game/raids.js
@@ -22,7 +22,7 @@ function buildDefaultConfig() {
     waves: Array.from({ length: 5 }, () => ({
       count: 1,
       rate: 1000,
-      stats: { hp: 10, damage: 1, attackSpeed: 1000, moveSpeed: 0.004 }
+      stats: { hp: 10, damage: 1, attackSpeed: 10000, moveSpeed: 0.004 }
     }))
   };
 }


### PR DESCRIPTION
## Summary
- slow down raider attacks so they match disciple attack timing

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688be417348083268e2c638eca73fe9c