### PR TITLE
Add attack flash and embed disciple cooldown

### DIFF
--- a/docs/23-raids.md
+++ b/docs/23-raids.md
@@ -14,7 +14,7 @@ and there is a five‑second pause before the next wave begins.
 
 The module handles spawning raiders, advancing them toward the fight line and resolving combat. Raiders that reach the orb once will damage it and then vanish. If the orb's water reaches zero the raid fails immediately.
 
-When a raider reaches the fight line it stops and targets the rightmost living disciple. Disciples remain in place and always attack the leftmost raider. Several disciples may assault the same target at once, each dealing damage whenever their personal attack timer completes. Attacking disciples grow slightly larger and a dark overlay shrinks to indicate progress toward their next strike.
+When a raider reaches the fight line it stops and targets the rightmost living disciple. Disciples remain in place and always attack the leftmost raider. Several disciples may assault the same target at once, each dealing damage whenever their personal attack timer completes. Attacking disciples grow slightly larger and a dark overlay shrinks to indicate progress toward their next strike. Whenever a disciple or raider lands an attack, their sprite briefly flashes white twice.
 
 The raid ends when all waves are cleared or the orb is destroyed. Callbacks are fired at the start and end of each wave along with a final success or failure signal. When night falls the game automatically opens a dedicated raid overlay and begins a raid. Disciples temporarily switch to the "Idle" task so their badges remain visible in the interface.
 

--- a/game/combat.js
+++ b/game/combat.js
@@ -18,6 +18,7 @@ import { raidState } from './raids.js';
 
 import addLog from './log.js';
 import bus from './canBus.js';
+import { runAnimation } from '../utils/animation.js';
 
 export function applyDamage(target, amount) {
   let remaining = Math.round(amount);
@@ -66,6 +67,7 @@ export function applyDiscipleAttacks(
       onHit?.(d.damage, d);
       timers[d.id] = 0;
       if (updateFill) updateFill(d, 0);
+      if (d.cardElement) runAnimation(d.cardElement, 'attack-flash');
     }
   });
 }
@@ -81,7 +83,7 @@ export function attack(deltaTime = 0) {
     deltaTime,
     null,
     (disc, ratio) => {
-      if (disc.attackFill) disc.attackFill.style.width = `${ratio * 100}%`;
+      if (disc.attackOverlay) disc.attackOverlay.style.height = `${(1 - ratio) * 100}%`;
     }
   );
 

--- a/game/horizontalRaid.js
+++ b/game/horizontalRaid.js
@@ -1,6 +1,7 @@
 import { createDiscipleBadge } from './badges.js';
 import { showRaidDamageFloat } from './rendering.js';
 import { applyDamage } from './combat.js';
+import { runAnimation } from '../utils/animation.js';
 
 // Delay between waves in milliseconds
 const WAVE_DELAY = 5000;
@@ -103,6 +104,7 @@ export function createHorizontalRaid({ orb, disciples = [], waves = [], onWaveSt
             state.orbFill.style.height = `${(state.orb.current / state.orb.max) * 100}%`;
           }
           showRaidDamageFloat(state.orbEl, r.damage);
+          runAnimation(r.el, 'attack-flash');
           r.el.remove();
           const idx = state.raiders.indexOf(r);
           if (idx >= 0) state.raiders.splice(idx, 1);
@@ -120,6 +122,7 @@ export function createHorizontalRaid({ orb, disciples = [], waves = [], onWaveSt
         applyDamage(target.d, r.damage);
         state.onDamage({ amount: r.damage, source: 'raider' });
         showRaidDamageFloat(target.sprite, r.damage);
+        runAnimation(r.el, 'attack-flash');
       }
     });
   }
@@ -152,6 +155,7 @@ export function createHorizontalRaid({ orb, disciples = [], waves = [], onWaveSt
         r.hp = Math.max(0, r.hp - slot.d.damage);
         state.onDamage({ amount: slot.d.damage, source: 'disciple' });
         showRaidDamageFloat(r.el, slot.d.damage, true);
+        runAnimation(slot.sprite, 'attack-flash');
         if (slot.overlay) slot.overlay.style.height = '100%';
         if (r.hp === 0) {
           r.el.remove();

--- a/game/ui.js
+++ b/game/ui.js
@@ -86,13 +86,10 @@ export function renderCombatDisciples() {
   handContainer.innerHTML = '';
   activeDisciples.forEach(d => {
     renderDiscipleCard(d, handContainer);
-    const bar = document.createElement('div');
-    bar.className = 'disciple-attack-bar';
-    const fill = document.createElement('div');
-    fill.className = 'disciple-attack-fill';
-    bar.appendChild(fill);
-    d.wrapperElement.insertBefore(bar, d.xpBar);
-    d.attackFill = fill;
+    const overlay = document.createElement('div');
+    overlay.className = 'disciple-attack-shadow';
+    d.cardElement.appendChild(overlay);
+    d.attackOverlay = overlay;
     updateDiscipleStatsDisplay(d);
   });
 }

--- a/style.css
+++ b/style.css
@@ -568,6 +568,7 @@ body.darkenshift-mode .tabsContainer button.active {
     border-radius: 4px;
     border: 1px solid #000;
     pointer-events: none;
+    overflow: hidden;
 }
 
 .raid-disciple {
@@ -580,6 +581,7 @@ body.darkenshift-mode .tabsContainer button.active {
     background-repeat: no-repeat;
     pointer-events: none;
     filter: drop-shadow(0 0 2px rgba(0,0,0,0.8));
+    overflow: hidden;
 }
 
 .raid-disciple.attacking {
@@ -597,12 +599,23 @@ body.darkenshift-mode .tabsContainer button.active {
     pointer-events: none;
 }
 
+.disciple-attack-shadow {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: 0%;
+    background: rgba(0,0,0,0.5);
+    pointer-events: none;
+}
+
 .raid-orb {
     position: absolute;
     bottom: 8px;
     left: 8px;
     width: 48px;
     height: 48px;
+    overflow: hidden;
 }
 
 .water-burst {
@@ -1485,6 +1498,7 @@ body.darkenshift-mode .tabsContainer button.active {
     font-size: 2vmin;
     box-sizing: border-box;
     position: relative;
+    overflow: hidden;
     box-shadow: 0 2px 4px rgba(0,0,0,0.2);
 }
 
@@ -2647,6 +2661,17 @@ body.darkenshift-mode .tabsContainer button.active {
 
 .disciple-strike {
     animation: disciple-strike 0.3s ease;
+}
+
+@keyframes attack-flash {
+    0%, 100% { filter: brightness(1); }
+    25% { filter: brightness(2); }
+    50% { filter: brightness(1); }
+    75% { filter: brightness(2); }
+}
+
+.attack-flash {
+    animation: attack-flash 0.3s ease;
 }
 
 .construct-orb .orb-fill {


### PR DESCRIPTION
## Summary
- embed disciple attack cooldown inside the card sprite
- flash attacking raiders and disciples twice in white
- keep raid sprites visible by constraining overlay elements
- document raid attack flashes

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688be3c5b37c83268bcb095d48367ffb