### PR TITLE
Update combat damage to cause injuries

### DIFF
--- a/docs/24-injury-system.md
+++ b/docs/24-injury-system.md
@@ -2,7 +2,7 @@
 
 This module introduces a granular injury system for disciples. Each body part contributes a portion of the disciple's maximum health. Injuries progress from **Bruise** → **Wound** → **Destroyed** and reduce available HP.
 
-When a disciple's Water reaches 0 they start taking damage each second. Every hit randomly targets a body part using the following chances:
+When a disciple's Water reaches 0 they start taking damage each second. Any damage suffered while Water is depleted also targets a random body part. Every hit randomly chooses among the following chances:
 
 | Body Part | Chance |
 |-----------|-------|

--- a/game/combat.js
+++ b/game/combat.js
@@ -18,6 +18,7 @@ import { raidState } from './raids.js';
 
 import addLog from './log.js';
 import bus from './canBus.js';
+import { randomBodyPart, applyInjury } from './injury.js';
 
 export function applyDamage(target, amount) {
   let remaining = Math.round(amount);
@@ -25,6 +26,13 @@ export function applyDamage(target, amount) {
     const absorbed = Math.min(target.water, remaining);
     target.water -= absorbed;
     remaining -= absorbed;
+  }
+  if (remaining > 0 && target.water <= 0 && Object.hasOwn(target, 'injuries')) {
+    const part = randomBodyPart();
+    if (part !== 'general') {
+      const tier = Math.random() < 0.5 ? 'bruise' : 'wound';
+      applyInjury(target, part, tier);
+    }
   }
   target.currentHp = Math.max(0, target.currentHp - remaining);
   if (Object.hasOwn(target, 'health')) {

--- a/test/combat-injury.test.js
+++ b/test/combat-injury.test.js
@@ -1,0 +1,49 @@
+/* global describe, it, before, after */
+import { expect } from 'chai';
+import Disciple from '../game/disciple.js';
+import { initializeDisciple } from '../utils/discipleInit.js';
+
+let combatModule;
+let applyDamage;
+
+before(async () => {
+  globalThis.document = {
+    getElementById: () => null,
+    getElementsByClassName: () => [null],
+    querySelector: () => null,
+    createElement: () => ({
+      appendChild() {},
+      addEventListener() {},
+      remove() {},
+      style: {},
+      classList: { add() {}, remove() {} },
+      getContext: () => ({ clearRect() {}, beginPath() {}, arc() {}, fill() {} }),
+      getBoundingClientRect: () => ({ width: 0, height: 0 })
+    }),
+    body: { appendChild() {} },
+    addEventListener() {},
+    removeEventListener() {}
+  };
+  globalThis.window = { dispatchEvent() {} };
+  combatModule = await import('../game/combat.js');
+  ({ applyDamage } = combatModule);
+});
+
+after(() => {
+  delete globalThis.document;
+  delete globalThis.window;
+});
+
+describe('combat injuries', () => {
+  it('applies an injury when taking damage without water', () => {
+    const d = new Disciple({ id: 1 });
+    initializeDisciple(d);
+    d.water = 0;
+    const prev = Math.random;
+    Math.random = () => 0;
+    applyDamage(d, 1);
+    Math.random = prev;
+    expect(d.injuries.head.tier).to.equal('bruise');
+  });
+});
+


### PR DESCRIPTION
## Summary
- apply random injuries when a disciple with no Water takes damage
- document how depleted Water makes all damage target body parts
- add regression test for combat injuries

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688be3fad5948326a2b87626c60f3fd5