### PR TITLE
Enable raid badge interactions

### DIFF
--- a/docs/23-raids.md
+++ b/docs/23-raids.md
@@ -19,4 +19,6 @@ When a raider reaches the fight line it stops and targets the rightmost living d
 The raid ends when all waves are cleared or the orb is destroyed. Callbacks are fired at the start and end of each wave along with a final success or failure signal. When night falls the game automatically opens a dedicated raid overlay and begins a raid. Disciples temporarily switch to the "Idle" task so their badges remain visible in the interface.
 
 The overlay fills the entire screen. Disciple badges line the top while their sprites stand near the Water Orb at the bottom left. Raiders advance from the right toward a fight line in the center where battles take place. Damage numbers briefly float above disciples, raiders and the orb whenever they are hit.
-Damage floats use red text when disciples take damage and white when raiders are struck. Raiders are drawn with a thin black border so each unit is clearly visible.
+ Damage floats use red text when disciples take damage and white when raiders are struck. Raiders are drawn with a thin black border so each unit is clearly visible.
+
+During raids you can click a disciple's badge to open their detailed overlay.

--- a/game/horizontalRaid.js
+++ b/game/horizontalRaid.js
@@ -26,7 +26,8 @@ export function createHorizontalRaid({ orb, disciples = [], waves = [], onWaveSt
     active: false,
     onDamage,
     orbFill: null,
-    orbEl: null
+    orbEl: null,
+    selectedBadge: null
   };
 
   function buildUI() {
@@ -51,6 +52,14 @@ export function createHorizontalRaid({ orb, disciples = [], waves = [], onWaveSt
       badge.style.position = 'absolute';
       badge.style.left = `${10 + i * 80}px`;
       badge.style.top = '4px';
+      badge.addEventListener('click', () => {
+        if (state.selectedBadge) state.selectedBadge.classList.remove('selected');
+        state.selectedBadge = badge;
+        badge.classList.add('selected');
+        window.dispatchEvent(
+          new CustomEvent('open-disciple-overlay', { detail: slot.d })
+        );
+      });
       root.appendChild(badge);
       const sprite = document.createElement('div');
       sprite.className = 'raid-disciple';
@@ -202,6 +211,10 @@ export function createHorizontalRaid({ orb, disciples = [], waves = [], onWaveSt
     if (!state.active) return;
     state.active = false;
     state.root?.remove();
+    if (state.selectedBadge) {
+      state.selectedBadge.classList.remove('selected');
+      state.selectedBadge = null;
+    }
     state.raiders.length = 0;
     state.disciples.forEach(slot => {
       slot.target = null;

--- a/script.js
+++ b/script.js
@@ -1301,7 +1301,7 @@ function renderSectDiscipleList() {
 let discipleOverlay = null;
 let discipleOverlayData = { disciple: null };
 let discipleOverlayActiveTab = 'general';
-function openDiscipleOverlay(d) {
+export function openDiscipleOverlay(d) {
   if (discipleOverlay) {
     discipleOverlay.close();
   } else {
@@ -1381,7 +1381,12 @@ function openDiscipleOverlay(d) {
     }
     discipleOverlayData.disciple = null;
   });
+  return discipleOverlay;
 }
+
+window.addEventListener('open-disciple-overlay', e =>
+  openDiscipleOverlay(e.detail)
+);
 
  export function renderExplorationTab() {
   if (!explorationListContainer) return;

--- a/style.css
+++ b/style.css
@@ -549,6 +549,9 @@ body.darkenshift-mode .tabsContainer button.active {
     top: 0;
     pointer-events: none;
 }
+.raid-container .disciple-badge {
+    pointer-events: auto;
+}
 
 .raid-container .fight-line {
     position: absolute;

--- a/test/incapacitation.test.js
+++ b/test/incapacitation.test.js
@@ -13,15 +13,18 @@ before(async () => {
   globalThis.document = {
     getElementsByClassName: () => [null],
     getElementById: () => null,
+    querySelector: () => null,
     addEventListener: () => {},
     removeEventListener: () => {}
   };
+  globalThis.window = { addEventListener() {} };
   sectModule = await import('../game/sect.js');
   ({ sectSystem, tickSect } = sectModule);
 });
 
 after(() => {
   delete globalThis.document;
+  delete globalThis.window;
 });
 
 beforeEach(() => {


### PR DESCRIPTION
## Summary
- allow clicks on raid badges by re-enabling pointer events
- keep raid badge selection highlight until the raid ends
- open the disciple overlay when clicking a badge
- document the new badge overlay behavior

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688be43d51c083268e735b2d5c3d517f