### PR TITLE
Remove incapacitated disciples from raids

### DIFF
--- a/docs/23-raids.md
+++ b/docs/23-raids.md
@@ -24,4 +24,6 @@ Damage floats use red text when disciples take damage and white when raiders are
 A bar just below the disciple badges shows the remaining life of the current wave in red. The label displays the exact HP left along with the current wave number so players can track their progress.
 
 During raids you can click a disciple's badge to open their detailed overlay.
+Any disciple reduced to **0 HP** or incapacitated by destroyed body parts is
+immediately removed from the lineup and no longer fights in that raid.
 

--- a/game/horizontalRaid.js
+++ b/game/horizontalRaid.js
@@ -121,6 +121,13 @@ export function createHorizontalRaid({
     }
   }
 
+  function removeDisciple(slot) {
+    slot.sprite?.remove();
+    slot.badge?.remove();
+    const idx = state.disciples.indexOf(slot);
+    if (idx >= 0) state.disciples.splice(idx, 1);
+  }
+
   function beginWave(index) {
     state.waveIndex = index;
     const wave = state.waves[index];
@@ -159,7 +166,9 @@ export function createHorizontalRaid({
         return;
       }
 
-      const living = state.disciples.filter(s => !s.d.incapacitated);
+      const living = state.disciples.filter(
+        s => !s.d.incapacitated && s.d.currentHp > 0
+      );
       if (living.length === 0) {
         r.progress -= r.moveSpeed * dt;
         if (r.progress <= 0) {
@@ -190,14 +199,20 @@ export function createHorizontalRaid({
         state.onDamage({ amount: r.damage, source: 'raider' });
         showRaidDamageFloat(target.sprite, r.damage);
         runAnimation(r.el, 'attack-flash');
+        if (target.d.currentHp <= 0 || target.d.incapacitated) {
+          removeDisciple(target);
+        }
       }
     });
   }
 
   function updateDisciples(dt) {
     const livingRaiders = state.raiders;
-    state.disciples.forEach(slot => {
-      if (slot.d.incapacitated) return;
+    state.disciples.slice().forEach(slot => {
+      if (slot.d.currentHp <= 0 || slot.d.incapacitated) {
+        removeDisciple(slot);
+        return;
+      }
 
       if (!slot.target || slot.target.hp <= 0 || !livingRaiders.includes(slot.target)) {
         slot.target = null;


### PR DESCRIPTION
## Summary
- remove disciples from the raid when defeated or incapacitated
- document that incapacitated disciples leave the raid

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688bf7607ce48326b076d6b0e19fbd55