### PR TITLE
Fix raid attack overlay clipping

### DIFF
--- a/docs/23-raids.md
+++ b/docs/23-raids.md
@@ -14,7 +14,7 @@ and there is a five‑second pause before the next wave begins.
 
 The module handles spawning raiders, advancing them toward the fight line and resolving combat. Raiders that reach the orb once will damage it and then vanish. If the orb's water reaches zero the raid fails immediately.
 
-When a raider reaches the fight line it stops and targets the rightmost living disciple. Disciples remain in place and always attack the leftmost raider. Several disciples may assault the same target at once, each dealing damage whenever their personal attack timer completes. Attacking disciples grow slightly larger and a dark overlay shrinks to indicate progress toward their next strike. Whenever a disciple or raider lands an attack, their sprite briefly flashes white twice.
+When a raider reaches the fight line it stops and targets the rightmost living disciple. Disciples remain in place and always attack the leftmost raider. Several disciples may assault the same target at once, each dealing damage whenever their personal attack timer completes. Attacking disciples grow slightly larger and a dark overlay inside each sprite shrinks to indicate progress toward their next strike. Whenever a disciple or raider lands an attack, their sprite briefly flashes white twice.
 
 The raid ends when all waves are cleared or the orb is destroyed. Callbacks are fired at the start and end of each wave along with a final success or failure signal. When night falls the game automatically opens a dedicated raid overlay and begins a raid. Disciples temporarily switch to the "Idle" task so their badges remain visible in the interface.
 

--- a/game/ui.js
+++ b/game/ui.js
@@ -88,7 +88,9 @@ export function renderCombatDisciples() {
     renderDiscipleCard(d, handContainer);
     const overlay = document.createElement('div');
     overlay.className = 'disciple-attack-shadow';
-    d.cardElement.appendChild(overlay);
+    const suit = d.cardElement.querySelector('.card-suit');
+    if (suit) suit.appendChild(overlay);
+    else d.cardElement.appendChild(overlay);
     d.attackOverlay = overlay;
     updateDiscipleStatsDisplay(d);
   });

--- a/style.css
+++ b/style.css
@@ -1580,6 +1580,8 @@ body.darkenshift-mode .tabsContainer button.active {
     align-items: center;
     font-size: 3em; /* adjust as needed */
     line-height: 1;
+    position: relative;
+    overflow: hidden;
 }
 
 .card-hp {


### PR DESCRIPTION
## Summary
- keep the disciple attack cooldown overlay within the card's sprite
- ensure card-suit container clips overlay
- document the overlay behavior in raid docs

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688d2fb4a3a0832698a8a418b3a9cbaa