### PR TITLE
Add disciple visual customization tasks

### DIFF
--- a/docs/25-disciple-visual-customization.md
+++ b/docs/25-disciple-visual-customization.md
@@ -1,0 +1,14 @@
+# 25 – Disciple Visual Customization
+
+This section outlines tasks for making each disciple sprite visually distinct through scars and special markings.
+
+## Usage
+
+Each disciple sprite supports two new data attributes:
+
+- **`data-scar`** – displays small icons in the upper left corner using the `::before` pseudo-element. Icons are chosen from the `SCAR_ICONS` map and are applied automatically when an injury reaches the `destroyed` tier.
+- **`data-mark`** – applies a special style or emblem based on the disciple’s unique background. Currently `shellwarden` adds a golden outline.
+
+These attributes are managed by `initDiscipleVisual` and `updateDiscipleVisual` which read `d.injuries` and `d.mark` to update the DOM.
+
+Modders can extend `SCAR_ICONS` and `MARK_ICONS` in `game/constants.js` to introduce additional visuals.

--- a/docs/README.md
+++ b/docs/README.md
@@ -70,3 +70,5 @@ Table of Contents
 23. [Raids](23-raids.md)
 24. [Injury System & Health Tab](24-injury-system.md)
 
+
+25. [Disciple Visual Customization](25-disciple-visual-customization.md)

--- a/game/constants.js
+++ b/game/constants.js
@@ -61,6 +61,14 @@ export const TASK_ICONS = {
   Sleep: '💤'
 };
 
+export const SCAR_ICONS = {
+  default: '✖'
+};
+
+export const MARK_ICONS = {
+  shellwarden: '🐚'
+};
+
 export const TASK_GROUPS = {
   'Gather Fruit': 'Gathering',
   'Gather Softwood': 'Logging',

--- a/game/disciplesVisuals.js
+++ b/game/disciplesVisuals.js
@@ -1,4 +1,4 @@
-import { TASK_ICONS } from './constants.js';
+import { TASK_ICONS, SCAR_ICONS, MARK_ICONS } from './constants.js';
 import { sectState } from './state.js';
 
 function scheduleNext(el) {
@@ -10,12 +10,16 @@ export function initDiscipleVisual(d, el) {
   updateItem(el, 'Idle');
   const meta = sectState.discipleMetamorphosis[d.id];
   if (meta) el.dataset.stage = meta.stage + 1;
+  applyMarkAttr(d, el);
+  applyScarAttr(d, el);
 }
 
 export function updateDiscipleVisual(d, el, task) {
   updateItem(el, task);
   const meta = sectState.discipleMetamorphosis[d.id];
   if (meta) el.dataset.stage = meta.stage + 1;
+  applyMarkAttr(d, el);
+  applyScarAttr(d, el);
   const next = parseFloat(el.dataset.nextCroak || '0');
   if (Date.now() >= next) {
     showCroak(el);
@@ -29,6 +33,30 @@ function updateItem(el, task) {
     el.dataset.item = icon;
   } else {
     el.removeAttribute('data-item');
+  }
+}
+
+function applyMarkAttr(d, el) {
+  if (d.mark && MARK_ICONS[d.mark]) {
+    el.dataset.mark = d.mark;
+  } else {
+    el.removeAttribute('data-mark');
+  }
+}
+
+function applyScarAttr(d, el) {
+  if (!d.injuries) return el.removeAttribute('data-scar');
+  const icons = [];
+  Object.entries(d.injuries).forEach(([part, state]) => {
+    if (state.tier === 'destroyed') {
+      const icon = SCAR_ICONS[part] || SCAR_ICONS.default;
+      icons.push(icon);
+    }
+  });
+  if (icons.length) {
+    el.dataset.scar = icons.join('');
+  } else {
+    el.removeAttribute('data-scar');
   }
 }
 

--- a/style.css
+++ b/style.css
@@ -3536,8 +3536,19 @@ body.darkenshift-mode .tabsContainer button.active {
     right: -7.2px;
     font-size: 0.55rem;
 }
+.sect-disciple::before {
+    content: attr(data-scar);
+    position: absolute;
+    top: -7.2px;
+    left: -7.2px;
+    font-size: 0.55rem;
+}
 .sect-disciple.incapacitated {
     filter: grayscale(1) drop-shadow(0 0 2px rgba(255,0,0,0.8));
+}
+
+.sect-disciple[data-mark="shellwarden"] {
+    box-shadow: 0 0 3px 2px rgba(255,215,0,0.6);
 }
 
 /* metamorphosis stage glow effects */

--- a/test/disciple-visuals.test.js
+++ b/test/disciple-visuals.test.js
@@ -1,0 +1,49 @@
+/* global describe, it, before, after, beforeEach */
+import { expect } from 'chai';
+import Disciple from '../game/disciple.js';
+import { initializeDisciple } from '../utils/discipleInit.js';
+import { initDiscipleVisual, updateDiscipleVisual } from '../game/disciplesVisuals.js';
+import { applyInjury } from '../game/injury.js';
+
+describe('disciple visual customization', () => {
+  let el;
+  before(() => {
+    globalThis.document = {
+      createElement: () => ({ remove() {} }),
+      getElementsByClassName: () => [null],
+      getElementById: () => null,
+      addEventListener: () => {},
+      removeEventListener: () => {}
+    };
+  });
+
+  after(() => {
+    delete globalThis.document;
+  });
+
+  beforeEach(() => {
+    el = {
+      dataset: {},
+      appendChild() {},
+      removeChild() {},
+      removeAttribute(attr) { delete this.dataset[attr.replace('data-', '')]; }
+    };
+  });
+
+  it('sets data-scar when a body part is destroyed', () => {
+    const d = new Disciple({ id: 1 });
+    initializeDisciple(d);
+    initDiscipleVisual(d, el);
+    applyInjury(d, 'leftEye', 'destroyed');
+    updateDiscipleVisual(d, el, 'Idle');
+    expect(el.dataset.scar).to.equal('✖');
+  });
+
+  it('applies mark attribute', () => {
+    const d = new Disciple({ id: 2 });
+    initializeDisciple(d);
+    d.mark = 'shellwarden';
+    initDiscipleVisual(d, el);
+    expect(el.dataset.mark).to.equal('shellwarden');
+  });
+});

--- a/utils/discipleInit.js
+++ b/utils/discipleInit.js
@@ -37,6 +37,7 @@ export function initializeDisciple(d) {
   if (d.currentHp === undefined) d.currentHp = d.maxHp;
   if (d.foundationXp === undefined) d.foundationXp = 0;
   if (d.lastTab === undefined) d.lastTab = 'general';
+  if (d.mark === undefined) d.mark = null;
   ensureInjuryState(d);
   if (!sectState.discipleMetamorphosis[d.id]) {
     sectState.discipleMetamorphosis[d.id] = {

--- a/utils/sectInit.js
+++ b/utils/sectInit.js
@@ -7,6 +7,7 @@ export function initializeSect() {
   const disciples = [1, 2, 3].map(id => {
     const d = new Disciple({ id });
     initializeDisciple(d);
+    if (id === 1) d.mark = 'shellwarden';
     d.affinities = generateSkillAffinities();
     initializeStartingSkills(d);
     return d;


### PR DESCRIPTION
## Summary
- document tasks for disciple visual customization
- link the doc in the design docs index
- implement disciple scars and marks via data attributes and CSS
- apply mark to starting disciple
- test scar and mark visuals

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688d2fee7698832689e141245a2680d4