### PR TITLE
Add raid victory rewards

### DIFF
--- a/docs/23-raids.md
+++ b/docs/23-raids.md
@@ -27,3 +27,8 @@ During raids you can click a disciple's badge to open their detailed overlay.
 Any disciple reduced to **0 HP** or incapacitated by destroyed body parts is
 immediately removed from the lineup and no longer fights in that raid.
 
+### Rewards
+
+Successfully clearing all waves awards the sect **1 Undead Nectar** and each
+participating disciple gains **30 Combat XP**.
+

--- a/game/constants.js
+++ b/game/constants.js
@@ -94,3 +94,7 @@ export const LOCATION_DEFS = [
 ];
 
 export const METAMORPHOSIS_STAGE_REQ = 25000;
+
+// Rewards granted on successful raid completion
+export const RAID_NECTAR_REWARD = 1;
+export const RAID_COMBAT_XP_REWARD = 30;

--- a/game/raids.js
+++ b/game/raids.js
@@ -1,9 +1,14 @@
 import { sectSystem } from './sect.js';
 import { sectState } from './state.js';
-import { ensureDiscipleSkills, getTaskSkillProgress } from '../utils/skills.js';
+import {
+  ensureDiscipleSkills,
+  getTaskSkillProgress,
+  addSkillXp
+} from '../utils/skills.js';
 import { showRaidAlert } from './alerts.js';
 import { showRaidSummaryOverlay } from '../ui/raidSummaryOverlay.js';
 import { openRaidBattleOverlay } from '../ui/raidBattleOverlay.js';
+import { RAID_NECTAR_REWARD, RAID_COMBAT_XP_REWARD } from './constants.js';
 
 export const raidState = {
   active: false,
@@ -30,6 +35,19 @@ function buildDefaultConfig() {
 function finalize(victory) {
   const xpStart = raidState.xpStart;
   raidState.xpStart = {};
+
+  if (victory) {
+    Object.keys(xpStart).forEach(id => {
+      const disc = sectSystem.disciples.find(d => d.id === Number(id));
+      if (disc) addSkillXp(disc, 'Combat', RAID_COMBAT_XP_REWARD);
+    });
+    sectState.undeadNectar += RAID_NECTAR_REWARD;
+    if (sectSystem.resources.undeadNectar) {
+      const res = sectSystem.resources.undeadNectar;
+      res.current = Math.min(res.max, res.current + RAID_NECTAR_REWARD);
+    }
+  }
+
   Object.keys(raidState.prevTasks).forEach(id => {
     sectState.discipleTasks[id] = raidState.prevTasks[id] || 'Idle';
   });
@@ -52,11 +70,14 @@ function finalize(victory) {
     };
   });
 
+  const rewards = victory ? { undeadNectar: RAID_NECTAR_REWARD } : {};
+
   showRaidSummaryOverlay({
     victory,
     damageDealt: raidState.damageDealt,
     damageReceived: raidState.damageReceived,
-    fighters
+    fighters,
+    rewards
   });
 }
 


### PR DESCRIPTION
## Summary
- grant Undead Nectar and bonus combat XP when raids succeed
- expose reward constants in `constants.js`
- document new raid rewards

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688d32e69a6483269757b419bc8c890c