### PR TITLE
Fix sect logic running during raids

### DIFF
--- a/game/sect.js
+++ b/game/sect.js
@@ -27,7 +27,7 @@ import {
   HUNT_CYCLE_SECONDS,
   EXPLORATION_CYCLE_SECONDS
 } from './constants.js';
-import { startRaid, tickRaid, raidState } from './raids.js';
+import { startRaid, raidState } from './raids.js';
 import { tickOrbSpells } from './orbSpells.js';
 import { applyStarvationHit, tickInjuries } from './injury.js';
 
@@ -1331,7 +1331,6 @@ export function tickSectSystem(delta) {
   tickActiveConstructs(dt);
   tickOrbSpells(dt);
   tickMetamorphosis(dt);
-  tickRaid(delta);
   ins.current = Math.min(ins.max, Math.max(0, ins.current));
   if (hasUI) {
     updateCooldownOverlays();

--- a/script.js
+++ b/script.js
@@ -123,7 +123,7 @@ import {
   deselectDisciple,
   clearActiveDisciples
 } from "./game/disciples.js";
-import { raidState } from './game/raids.js';
+import { raidState, tickRaid } from './game/raids.js';
 // developer debug tools
 import { init as initDebug } from "./game/debug.js";
 import { attachOrbGlow, enableOrbGlow, disableOrbGlow, updateOrbGlow, flashOrbGlow } from './game/orbGlow.js';
@@ -2593,6 +2593,8 @@ addLog("Game loaded!",
 
 
 let lastFrameTime = performance.now();
+let pendingSectTime = 0;
+let lastRaidState = false;
 
 // Main animation loop; handles ticking the enemy and player actions
 function gameLoop(currentTime) {
@@ -2628,10 +2630,22 @@ function gameLoop(currentTime) {
 
 
 
-  tickSectSystem(deltaTime);
-  tickSect(deltaTime);
-  tickBuilding(deltaTime / 1000);
-  const dtSeconds = deltaTime / 1000;
+  let processedDelta = deltaTime;
+  if (raidState.active) {
+    pendingSectTime += deltaTime;
+    processedDelta = 0;
+    tickRaid(deltaTime);
+  } else {
+    if (lastRaidState && pendingSectTime > 0) {
+      processedDelta += pendingSectTime;
+      pendingSectTime = 0;
+    }
+    tickSectSystem(processedDelta);
+    tickSect(processedDelta);
+    tickBuilding(processedDelta / 1000);
+  }
+  lastRaidState = raidState.active;
+  const dtSeconds = processedDelta / 1000;
   if (dtSeconds > 0) {
     sectSystem.gains.water =
       (sectSystem.resources.water.current - startWater) / dtSeconds;


### PR DESCRIPTION
## Summary
- avoid running colony systems during raids to improve performance
- track elapsed time while a raid is active and apply it when the raid ends

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688d6e42cf5c83268951835c865c4efa