### PR TITLE
Clarify raid overlay clipping

### DIFF
--- a/docs/23-raids.md
+++ b/docs/23-raids.md
@@ -14,7 +14,7 @@ and there is a five‑second pause before the next wave begins.
 
 The module handles spawning raiders, advancing them toward the fight line and resolving combat. Raiders that reach the orb once will damage it and then vanish. If the orb's water reaches zero the raid fails immediately.
 
-When a raider reaches the fight line it stops and targets the rightmost living disciple. Disciples remain in place and always attack the leftmost raider. Several disciples may assault the same target at once, each dealing damage whenever their personal attack timer completes. Attacking disciples grow slightly larger and a dark overlay shrinks to indicate progress toward their next strike. Whenever a disciple or raider lands an attack, their sprite briefly flashes white twice.
+When a raider reaches the fight line it stops and targets the rightmost living disciple. Disciples remain in place and always attack the leftmost raider. Several disciples may assault the same target at once, each dealing damage whenever their personal attack timer completes. Attacking disciples grow slightly larger and a dark overlay within each sprite shrinks to indicate progress toward the next strike. The overlay stays clipped inside the disciple sprite so it never spills outside. Whenever a disciple or raider lands an attack, their sprite briefly flashes white twice.
 
 The raid ends when all waves are cleared or the orb is destroyed. Callbacks are fired at the start and end of each wave along with a final success or failure signal. When night falls the game automatically opens a dedicated raid overlay and begins a raid. Disciples temporarily switch to the "Idle" task so their badges remain visible in the interface.
 

--- a/game/horizontalRaid.js
+++ b/game/horizontalRaid.js
@@ -99,6 +99,7 @@ export function createHorizontalRaid({
       const sprite = document.createElement('div');
       sprite.className = 'raid-disciple';
       sprite.style.left = `${50 + i * 30}px`;
+      sprite.style.overflow = 'hidden';
       const overlay = document.createElement('div');
       overlay.className = 'raid-attack-shadow';
       sprite.appendChild(overlay);

--- a/style.css
+++ b/style.css
@@ -635,6 +635,7 @@ body.darkenshift-mode .tabsContainer button.active {
     pointer-events: none;
     filter: drop-shadow(0 0 2px rgba(0,0,0,0.8));
     overflow: hidden;
+    /* ensure attack overlay anchors inside the sprite */
 }
 
 .raid-disciple.attacking {


### PR DESCRIPTION
## Summary
- explain in docs that the raid attack overlay stays clipped inside each disciple sprite
- keep overlay hidden by default during raids

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688d2fb4a3a0832698a8a418b3a9cbaa