### PR TITLE
fix: load raid parallax images

### DIFF
--- a/style.css
+++ b/style.css
@@ -866,6 +866,10 @@ body.darkenshift-mode .tabsContainer button.active {
     --reeds-offset: 0;
     --water-offset: 0;
     --lily-offset: 0;
+    /* default background image URLs for parallax layers */
+    --reeds-bg: url('/img/reeds-back.png');
+    --water-bg: url('/img/water-mid.png');
+    --lily-bg: url('/img/lily-pads.png');
 }
 #battle-container::before,
 #battle-container::after,
@@ -882,17 +886,17 @@ body.darkenshift-mode .tabsContainer button.active {
     pointer-events: none;
 }
 #battle-container::before {
-    background-image: url('img/reeds-back.png');
+    background-image: var(--reeds-bg);
     z-index: 1;
     transform: translateX(var(--reeds-offset));
 }
 #battle-container .mid {
-    background-image: url('img/water-mid.png');
+    background-image: var(--water-bg);
     z-index: 2;
     transform: translateX(var(--water-offset));
 }
 #battle-container::after {
-    background-image: url('img/lily-pads.png');
+    background-image: var(--lily-bg);
     z-index: 3;
     transform: translateX(var(--lily-offset));
 }

--- a/ui/raidBattleOverlay.js
+++ b/ui/raidBattleOverlay.js
@@ -1,6 +1,11 @@
 import { createOverlay } from './overlay.js';
 import { createHorizontalRaid } from '../game/horizontalRaid.js';
 
+// Resolve parallax layer image URLs relative to this module
+const reedsUrl = new URL('../img/reeds-back.png', import.meta.url).href;
+const waterUrl = new URL('../img/water-mid.png', import.meta.url).href;
+const lilyUrl = new URL('../img/lily-pads.png', import.meta.url).href;
+
 export function openRaidBattleOverlay({ config, onSuccess = () => {}, onFailure = () => {}, onDamage = () => {} } = {}) {
   const overlay = createOverlay({ className: 'raid-overlay', boxClass: 'parchment-box', closable: false });
   overlay.box.classList.add('parchment-box');
@@ -10,6 +15,14 @@ export function openRaidBattleOverlay({ config, onSuccess = () => {}, onFailure 
   const mid = document.createElement('div');
   mid.className = 'mid';
   area.appendChild(mid);
+
+  // set background image variables so bundlers include assets
+  if (area.style?.setProperty) {
+    area.style.setProperty('--reeds-bg', `url(${reedsUrl})`);
+    area.style.setProperty('--water-bg', `url(${waterUrl})`);
+    area.style.setProperty('--lily-bg', `url(${lilyUrl})`);
+  }
+
   overlay.append(area);
 
   const raid = createHorizontalRaid({


### PR DESCRIPTION
## Summary
- ensure parallax background images are referenced and loaded for raid battles
- inject image URLs when opening a raid so bundlers include assets

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688d75eccf008326ad8210ff043213b2