### PR TITLE
fix: show metamorphosis stats toggle

### DIFF
--- a/style.css
+++ b/style.css
@@ -2377,7 +2377,7 @@ body.darkenshift-mode .tabsContainer button.active {
     position: absolute;
     top: 50%;
     right: 0;
-    transform: translate(100%, -50%);
+    transform: translateY(-50%);
     background: var(--core-accent);
     color: #000;
     padding: 4px 6px;


### PR DESCRIPTION
## Summary
- keep metamorphosis stats toggle arrow visible so the side panel can be opened

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688dad01976083269e660105e2e3ed51