### PR TITLE
fix: hide sect map during raids

### DIFF
--- a/docs/23-raids.md
+++ b/docs/23-raids.md
@@ -21,6 +21,8 @@ The raid ends when all waves are cleared or the orb is destroyed. Callbacks are 
 The overlay fills the entire screen. Disciple badges line the top while their sprites stand near the Water Orb at the bottom left. Raiders advance from the right toward a fight line in the center where battles take place. Damage numbers briefly float above disciples, raiders and the orb whenever they are hit.
 Damage floats use red text when disciples take damage and white when raiders are struck. Raiders are drawn with a thin black border so each unit is clearly visible.
 
+While a raid is active the sect map and other tabs are hidden so the battle runs in its own view.
+
 A bar just below the disciple badges shows the remaining life of the current wave in red. The label displays the exact HP left along with the current wave number so players can track their progress.
 
 During raids you can click a disciple's badge to open their detailed overlay.

--- a/game/blobRaids.js
+++ b/game/blobRaids.js
@@ -352,10 +352,13 @@ bus.subscribe('TICK', ({ delta }) => {
 // Track raid activity
 if (typeof document !== 'undefined' && typeof document.addEventListener === 'function') {
   document.addEventListener('raid-start', () => {
-    activeRaid = true;
+    clearBlobs();
+    const map = document.getElementById('colonyMap');
+    activeRaid = !!(map && map.offsetParent !== null);
   });
 
   document.addEventListener('raid-end', () => {
     activeRaid = false;
+    clearBlobs();
   });
 }

--- a/game/ui.js
+++ b/game/ui.js
@@ -184,3 +184,14 @@ export function addDiscoveredLocation(name, locationListContainer, LOCATION_DEFS
     explorationTabButton.style.display = '';
   }
 }
+
+// Hide existing tabs during raids so the sect map isn't visible beneath the battle
+if (typeof document !== 'undefined' && typeof document.addEventListener === 'function') {
+  document.addEventListener('raid-start', () => {
+    hideTab();
+  });
+
+  document.addEventListener('raid-end', () => {
+    showTab(sectTab);
+  });
+}


### PR DESCRIPTION
## Summary
- stop leftover raiders when the sect map isn't visible
- treat raids as their own tab by hiding other panels
- document that raids run without the sect map in view

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688dadb9f72083269c62be0d41a1fefd