### PR TITLE
feat: add water burst raid spell

### DIFF
--- a/docs/15-research.md
+++ b/docs/15-research.md
@@ -84,6 +84,10 @@ Word of Haste
 
 Costs 2 points. Grants an orb spell that spends 15 Water to boost sect work speed for 1 minute. Shares a 1 minute cooldown.
 
+Water Burst
+
+Costs 2 points. Unlocks a raid spell that deals splash damage to raiders for 30 Water.
+
 Orb Spell Strength
 
 Costs 3 points. Unlocks the Orb Spell Strength building. Each level increases orb damage spells by 20%.

--- a/docs/16-water-orb.md
+++ b/docs/16-water-orb.md
@@ -24,5 +24,6 @@
   the remaining time.
 - Orb Revival research grants access to an Orb Management panel for the Water Orb.
 - Word of Haste orb spell speeds up work tasks for one minute at the cost of 15 Water.
+- Water Burst raid spell unleashes splash damage against raiders for 30 Water.
 - Orb Spell Strength buildings raise the Water Orb's attack damage by 20% per level.
 - Orb Reverberation grants a toggled effect that increases disciple attack speed by 30% while draining 1 Water each second.

--- a/game/horizontalRaid.js
+++ b/game/horizontalRaid.js
@@ -143,6 +143,25 @@ export function createHorizontalRaid({
     if (idx >= 0) state.disciples.splice(idx, 1);
   }
 
+  function waterBurst(damage) {
+    state.raiders.slice().forEach(r => {
+      const before = r.hp;
+      r.hp = Math.max(0, r.hp - damage);
+      const dealt = before - r.hp;
+      state.waveHp = Math.max(0, state.waveHp - dealt);
+      showRaidDamageFloat(r.el, dealt, true);
+      if (r.hp === 0) {
+        r.el.remove();
+        const idx = state.raiders.indexOf(r);
+        if (idx >= 0) state.raiders.splice(idx, 1);
+        state.disciples.forEach(s => {
+          if (s.target === r) s.target = null;
+        });
+      }
+    });
+    updateWaveLife();
+  }
+
   function beginWave(index) {
     state.waveIndex = index;
     const wave = state.waves[index];
@@ -341,6 +360,7 @@ export function createHorizontalRaid({
       beginWave(0);
     },
     tick,
-    end
+    end,
+    castWaterBurst: waterBurst
   };
 }

--- a/game/orbSpells.js
+++ b/game/orbSpells.js
@@ -1,5 +1,6 @@
 import { sectSystem } from './sect.js';
 import { sectState } from './state.js';
+import { raidState } from './raids.js';
 import addLog from './log.js';
 
 export function orbDamageMultiplier() {
@@ -25,6 +26,16 @@ export function toggleReverberation() {
   sectSystem.orbReverbActive = true;
   sectSystem.attackSpeedMult = 1.3;
   addLog('Orb Reverberation active', 'info');
+}
+
+export function castWaterBurst() {
+  if (!raidState.active || !raidState.raid) return;
+  const cost = 30;
+  if (sectSystem.orbs.water.current < cost) return;
+  sectSystem.orbs.water.current -= cost;
+  const damage = 20 * orbDamageMultiplier();
+  raidState.raid.castWaterBurst(damage);
+  addLog('Water Burst unleashed!', 'info');
 }
 
 export function tickOrbSpells(dt) {

--- a/style.css
+++ b/style.css
@@ -860,6 +860,13 @@ body.darkenshift-mode .tabsContainer button.active {
     height: 100%;
 }
 
+.raid-spell-bar {
+    display: flex;
+    gap: 8px;
+    justify-content: center;
+    margin-top: 8px;
+}
+
 #battle-container {
     position: relative;
     overflow: hidden;

--- a/ui/colonyOverlays.js
+++ b/ui/colonyOverlays.js
@@ -8,7 +8,8 @@ import { sectSystem, SECT_SCHEDULE, getCurrentSchedule, renderConstructCards, ge
 import { systems, sectState, worldProgress } from '../game/state.js';
 import { createSectDiscipleCard, renderExplorationTab, startExploration, startWorldCombat, discipleGatherPhase } from '../script.js';
 import { BUILDINGS, startBuilding } from '../game/buildings.js';
-import { castWordOfHaste, toggleReverberation } from '../game/orbSpells.js';
+import { castWordOfHaste, toggleReverberation, castWaterBurst } from '../game/orbSpells.js';
+import { raidState } from '../game/raids.js';
 import { TRANSMUTES, performTransmute, canTransmute, getTransmutePower } from '../game/transmutation.js';
 import { TASK_GROUPS } from '../game/constants.js';
 import { getTaskSkillProgress } from '../utils/skills.js';
@@ -339,6 +340,17 @@ export function openOrbOverlay() {
       li.appendChild(document.createTextNode(' - Boost work speed for 1m'));
       list.appendChild(li);
     }
+    if (sectState.completedResearch.includes('waterBurst')) {
+      const li = document.createElement('li');
+      li.className = 'orb-spell dynamic-spell';
+      const btn = document.createElement('button');
+      btn.textContent = 'Cast Water Burst';
+      btn.disabled = sectSystem.orbs.water.current < 30 || !raidState.active;
+      btn.addEventListener('click', () => { castWaterBurst(); render(); });
+      li.appendChild(btn);
+      li.appendChild(document.createTextNode(' - Damages raiders (30 Water)'));
+      list.appendChild(li);
+    }
     if (sectState.completedResearch.includes('orbReverb')) {
       const li = document.createElement('li');
       li.className = 'orb-spell dynamic-spell';
@@ -589,6 +601,13 @@ export function openResearchOverlay() {
       label: 'Word of Haste',
       cost: 2,
       desc: 'Orb spell granting 1m work speed boost (15 Water)',
+      unlock() {}
+    },
+    {
+      key: 'waterBurst',
+      label: 'Water Burst',
+      cost: 2,
+      desc: 'Raid spell dealing splash damage (30 Water)',
       unlock() {}
     },
     {

--- a/ui/raidBattleOverlay.js
+++ b/ui/raidBattleOverlay.js
@@ -1,5 +1,8 @@
 import { createOverlay } from './overlay.js';
 import { createHorizontalRaid } from '../game/horizontalRaid.js';
+import { castWordOfHaste, toggleReverberation, castWaterBurst } from '../game/orbSpells.js';
+import { sectState } from '../game/state.js';
+import { sectSystem } from '../game/sect.js';
 
 export function openRaidBattleOverlay({ config, onSuccess = () => {}, onFailure = () => {}, onDamage = () => {} } = {}) {
   const overlay = createOverlay({ className: 'raid-overlay', boxClass: 'parchment-box', closable: false });
@@ -11,6 +14,9 @@ export function openRaidBattleOverlay({ config, onSuccess = () => {}, onFailure 
   mid.className = 'mid';
   area.appendChild(mid);
   overlay.append(area);
+  const spells = document.createElement('div');
+  spells.className = 'raid-spell-bar';
+  overlay.append(spells);
 
   const raid = createHorizontalRaid({
     ...config,
@@ -25,6 +31,44 @@ export function openRaidBattleOverlay({ config, onSuccess = () => {}, onFailure 
     },
     onDamage
   });
+
+  function renderSpells() {
+    spells.innerHTML = '';
+    if (sectState.completedResearch.includes('wordOfHaste')) {
+      const btn = document.createElement('button');
+      btn.textContent = 'Word of Haste';
+      btn.disabled = sectSystem.wordOfHasteCd > 0 || sectSystem.orbs.water.current < 15;
+      btn.addEventListener('click', () => {
+        castWordOfHaste();
+        renderSpells();
+      });
+      spells.appendChild(btn);
+    }
+    if (sectState.completedResearch.includes('waterBurst')) {
+      const btn = document.createElement('button');
+      btn.textContent = 'Water Burst';
+      btn.disabled = sectSystem.orbs.water.current < 30;
+      btn.addEventListener('click', () => {
+        castWaterBurst();
+        renderSpells();
+      });
+      spells.appendChild(btn);
+    }
+    if (sectState.completedResearch.includes('orbReverb')) {
+      const btn = document.createElement('button');
+      btn.textContent = sectSystem.orbReverbActive ? 'Stop Reverberation' : 'Start Reverberation';
+      btn.disabled = !sectSystem.orbReverbActive && sectSystem.orbs.water.current < 1;
+      btn.addEventListener('click', () => {
+        toggleReverberation();
+        renderSpells();
+      });
+      spells.appendChild(btn);
+    }
+  }
+
+  renderSpells();
+  const interval = setInterval(renderSpells, 1000);
+  overlay.onClose(() => clearInterval(interval));
 
   raid.start();
   return { overlay, raid };


### PR DESCRIPTION
## Summary
- display raid spells beneath battle overlay
- add Water Burst spell unlocked via research
- document new Water Burst ability and research topic

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688dae10c73883268297cf1704f87d75