### PR TITLE
fix: loop raid parallax backgrounds

### DIFF
--- a/docs/23-raids.md
+++ b/docs/23-raids.md
@@ -21,6 +21,8 @@ The raid ends when all waves are cleared or the orb is destroyed. Callbacks are 
 The overlay fills the entire screen. Disciple badges line the top while their sprites stand near the Water Orb at the bottom left. Raiders advance from the right toward a fight line in the center where battles take place. Damage numbers briefly float above disciples, raiders and the orb whenever they are hit.
 Damage floats use red text when disciples take damage and white when raiders are struck. Raiders are drawn with a thin black border so each unit is clearly visible.
 
+Three parallax background layers—reeds, water and lily pads—scroll left at different speeds and loop seamlessly to maintain motion.
+
 A bar just below the disciple badges shows the remaining life of the current wave in red. The label displays the exact HP left along with the current wave number so players can track their progress.
 
 During raids you can click a disciple's badge to open their detailed overlay.

--- a/game/horizontalRaid.js
+++ b/game/horizontalRaid.js
@@ -6,8 +6,23 @@ import { runAnimation } from '../utils/animation.js';
 // Delay between waves in milliseconds
 const WAVE_DELAY = 5000;
 
-// Parallax speeds in pixels per second
-const PARALLAX_SPEEDS = { reeds: 10, water: 30, lily: 60 };
+// Parallax layer configuration
+const PARALLAX_LAYERS = {
+  reeds: { speed: 10, cssVar: '--reeds-offset', img: 'img/reeds-back.png', width: 0 },
+  water: { speed: 30, cssVar: '--water-offset', img: 'img/water-mid.png', width: 0 },
+  lily: { speed: 60, cssVar: '--lily-offset', img: 'img/lily-pads.png', width: 0 }
+};
+
+// populate image widths without hard-coding values
+if (typeof Image !== 'undefined') {
+  Object.values(PARALLAX_LAYERS).forEach(layer => {
+    const img = new Image();
+    img.src = layer.img;
+    img.onload = () => {
+      layer.width = img.width;
+    };
+  });
+}
 
 export function createHorizontalRaid({
   orb,
@@ -46,7 +61,7 @@ export function createHorizontalRaid({
     waveLifeLabel: null,
     waveLabel: null,
     selectedBadge: null,
-    bgOffsets: { reeds: 0, water: 0, lily: 0 }
+    bgOffsets: Object.fromEntries(Object.keys(PARALLAX_LAYERS).map(k => [k, 0]))
   };
 
   function buildUI() {
@@ -115,15 +130,14 @@ export function createHorizontalRaid({
     state.root = root;
   }
 
-   function updateBackground(dt) {
+  function updateBackground(dt) {
     const offs = state.bgOffsets;
-    offs.reeds -= (dt * PARALLAX_SPEEDS.reeds) / 1000;
-    offs.water -= (dt * PARALLAX_SPEEDS.water) / 1000;
-    offs.lily -= (dt * PARALLAX_SPEEDS.lily) / 1000;
-    if (state.container) {
-      state.container.style.setProperty('--reeds-offset', `${offs.reeds}px`);
-      state.container.style.setProperty('--water-offset', `${offs.water}px`);
-      state.container.style.setProperty('--lily-offset', `${offs.lily}px`);
+    for (const [name, cfg] of Object.entries(PARALLAX_LAYERS)) {
+      offs[name] -= (dt * cfg.speed) / 1000;
+      if (cfg.width) offs[name] %= cfg.width;
+      if (state.container) {
+        state.container.style.setProperty(cfg.cssVar, `${offs[name]}px`);
+      }
     }
   }
   

--- a/style.css
+++ b/style.css
@@ -878,23 +878,23 @@ body.darkenshift-mode .tabsContainer button.active {
     bottom: 0;
     background-repeat: repeat-x;
     background-position: 0 0;
-    will-change: transform;
+    will-change: background-position;
     pointer-events: none;
 }
 #battle-container::before {
     background-image: url('img/reeds-back.png');
     z-index: 1;
-    transform: translateX(var(--reeds-offset));
+    background-position: var(--reeds-offset) 0;
 }
 #battle-container .mid {
     background-image: url('img/water-mid.png');
     z-index: 2;
-    transform: translateX(var(--water-offset));
+    background-position: var(--water-offset) 0;
 }
 #battle-container::after {
     background-image: url('img/lily-pads.png');
     z-index: 3;
-    transform: translateX(var(--lily-offset));
+    background-position: var(--lily-offset) 0;
 }
 
 .work-content {


### PR DESCRIPTION
## Summary
- use config-driven parallax settings and wrap offsets for infinite scroll
- drive CSS parallax layers via background-position instead of transforms
- document raid overlay parallax motion

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e178bcb048326be57e2070242d0f7