### PR TITLE
fix: restore disciple healing

### DIFF
--- a/game/sect.js
+++ b/game/sect.js
@@ -1479,7 +1479,21 @@ export function tickSect(delta) {
     }
     const task = sectState.discipleTasks[d.id];
     if (!task || task === 'Idle' || task === 'Resting') {
-      if (!raidState.active) return;
+      if (!raidState.active) {
+        if (!d.starveTimer) d.starveTimer = 0;
+        if (d.water <= 0) {
+          d.starveTimer += dt;
+          while (d.starveTimer >= 1) {
+            applyStarvationHit(d);
+            d.starveTimer -= 1;
+          }
+        } else {
+          d.starveTimer = 0;
+        }
+        tickInjuries(d, dt, d.resilience, task);
+        d.currentHp = d.health;
+        return;
+      }
     }
     ensureDiscipleSkills(d.id);
     let group = TASK_GROUPS[task];
@@ -1546,6 +1560,7 @@ export function tickSect(delta) {
       d.starveTimer = 0;
     }
     tickInjuries(d, dt, d.resilience, task);
+    d.currentHp = d.health;
   });
 
 }

--- a/test/hp-recovery.test.js
+++ b/test/hp-recovery.test.js
@@ -1,0 +1,49 @@
+/* global describe, it, before, after, beforeEach */
+import { expect } from 'chai';
+import Disciple from '../game/disciple.js';
+import { initializeDisciple } from '../utils/discipleInit.js';
+import { sectState } from '../game/state.js';
+
+let sectModule;
+let sectSystem;
+let tickSect;
+
+before(async () => {
+  globalThis.document = {
+    getElementsByClassName: () => [null],
+    getElementById: () => null,
+    querySelector: () => null,
+    addEventListener: () => {},
+    removeEventListener: () => {}
+  };
+  globalThis.window = { addEventListener() {} };
+  sectModule = await import('../game/sect.js');
+  ({ sectSystem, tickSect } = sectModule);
+});
+
+after(() => {
+  delete globalThis.document;
+  delete globalThis.window;
+});
+
+beforeEach(() => {
+  sectSystem.disciples.length = 0;
+  Object.keys(sectState.discipleTasks).forEach(k => delete sectState.discipleTasks[k]);
+  sectState.fruits = 10;
+});
+
+describe('disciple health regeneration', () => {
+  it('updates currentHp when healing', () => {
+    const d = new Disciple({ id: 1 });
+    initializeDisciple(d);
+    d.health = 5;
+    d.currentHp = 5;
+    d.water = 10;
+    sectSystem.disciples.push(d);
+
+    tickSect(1000);
+
+    expect(d.health).to.be.closeTo(6, 0.1);
+    expect(d.currentHp).to.equal(d.health);
+  });
+});


### PR DESCRIPTION
## Summary
- heal idle disciples and sync current HP
- add regression test for disciple healing

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e4251b72883269c49c4439a031b84