### PR TITLE
fix: update combat stats on level

### DIFF
--- a/game/ui.js
+++ b/game/ui.js
@@ -66,8 +66,20 @@ export function updateRaidLifeBar(enemy) {
 }
 
 export function updateDiscipleStatsDisplay(d) {
-  if (!d.statsElement) return;
-  d.statsElement.innerHTML = '';
+  const elems = d.combatStatElems;
+  if (!elems) return;
+
+  elems.level.textContent = `Level ${d.combatLevel}`;
+  const pct = Math.min(1, d.combatXp / d.xpForNextLevel());
+  elems.xpFill.style.width = `${Math.floor(pct * 100)}%`;
+  elems.xpLabel.textContent = `${Math.floor(d.combatXp)}/${d.xpForNextLevel()}`;
+
+  const atkPerSec = (1000 / d.attackSpeed).toFixed(2);
+  const defense = Math.round(d.defense ?? 0);
+  elems.stats.innerHTML =
+    `Damage ${Math.round(d.damage)}<br>` +
+    `Attack/s ${atkPerSec}<br>` +
+    `Defense ${defense}`;
 }
 
 export function renderCombatDisciples() {}

--- a/script.js
+++ b/script.js
@@ -1029,6 +1029,15 @@ function buildDiscipleCombatStatsView(d) {
     `Defense ${defense}`;
   body.appendChild(stats);
 
+  // store references for later updates
+  d.statsElement = body;
+  d.combatStatElems = {
+    level: levelRow,
+    xpFill: fill,
+    xpLabel: label,
+    stats
+  };
+
   return body;
 }
 

--- a/test/combat-stats.test.js
+++ b/test/combat-stats.test.js
@@ -1,0 +1,51 @@
+/* global describe, it, before */
+import { expect } from 'chai';
+import Disciple from '../game/disciple.js';
+import { initializeDisciple } from '../utils/discipleInit.js';
+
+let updateDiscipleStatsDisplay;
+
+before(async () => {
+  globalThis.document = {
+    getElementById: () => null,
+    getElementsByClassName: () => [null],
+    querySelector: () => null,
+    createElement: () => ({
+      appendChild() {},
+      style: {},
+      classList: { add() {}, toggle() {} }
+    }),
+    addEventListener() {},
+    removeEventListener() {},
+    body: { appendChild() {} }
+  };
+  globalThis.window = {};
+  ({ updateDiscipleStatsDisplay } = await import('../game/ui.js'));
+});
+
+describe('combat stat updates', () => {
+  it('increases and updates combat stats on level up', () => {
+    const d = new Disciple({ id: 1 });
+    initializeDisciple(d);
+
+    // stub elements for display
+    const levelRow = { textContent: '' };
+    const xpFill = { style: { width: '' } };
+    const xpLabel = { textContent: '' };
+    const stats = { innerHTML: '' };
+    d.combatStatElems = { level: levelRow, xpFill, xpLabel, stats };
+
+    // initial render
+    updateDiscipleStatsDisplay(d);
+    const before = stats.innerHTML;
+
+    // level up
+    d.gainCombatXp(d.xpForNextLevel());
+    updateDiscipleStatsDisplay(d);
+
+    expect(levelRow.textContent).to.equal(`Level ${d.combatLevel}`);
+    expect(stats.innerHTML).to.not.equal(before);
+    expect(stats.innerHTML).to.include(`Damage ${Math.round(d.damage)}`);
+    expect(stats.innerHTML).to.include(`Defense ${Math.round(d.defense)}`);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure disciple combat stats display updates on level up
- track combat stat DOM elements for dynamic updates
- test combat stats refresh when leveling

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e439d44808326b037c837789c944f