### PR TITLE
fix: shrink metamorph ring and add orb

### DIFF
--- a/docs/00-wireframes.md
+++ b/docs/00-wireframes.md
@@ -275,9 +275,9 @@ You can adjust button labels, add icons, or tweak layout widths to fit your fina
 │ [Room 1]   [Room 2]   [Room 3]        Room 1 Selected                        │
 │                                                                              │
 │ ┌───────────────────────┐   ┌─────────────────────────┐   ┌─────────────────┐ │
-│ │     Tadpole Figure    │   │     Progress:          │   │ Assigned to     │ │
-│ │   (tadpole silhouette │   │   25 000 / 25 000      │   │   Li Xuan       │ │
-│ │    with fill overlay) │   │   (fill bar here)      │   │                 │ │
+│ │   Metamorphosis Orb   │   │     Progress:          │   │ Assigned to     │ │
+│ │   (orb with fill      │   │   25 000 / 25 000      │   │   Li Xuan       │ │
+│ │    overlay)           │   │   (fill bar here)      │   │                 │ │
 │ └───────────────────────┘   └─────────────────────────┘   └─────────────────┘ │
 │                                                                              │
 │ ┌─────────────────────────────────────────────────────────────────────────┐  │
@@ -293,7 +293,7 @@ You can adjust button labels, add icons, or tweak layout widths to fit your fina
 
 Top: room‐selector tabs & currently selected label.
 
-Center‐left: disciple “tadpole” silhouette with fill overlay showing metamorphosis progress.
+Center‐left: disciple's metamorphosis orb with fill overlay showing progress.
 
 Center‐middle: numeric & bar progress (current/target).
 

--- a/docs/13-metamorphosis-stages-&-methods.md
+++ b/docs/13-metamorphosis-stages-&-methods.md
@@ -8,8 +8,8 @@ Each disciple evolves through frog-like spiritual metamorphosis. Accessible via 
 
 ## 🐚 metamorphosis Overview (Per Disciple)
 
-- **Current Metamorphosis Stage** label above the tadpole diagram
-- **Tadpole silhouette** with animated fill toward next breakthrough
+- **Current Metamorphosis Stage** label above the metamorphosis orb
+- **Glowing orb** with animated fill toward next breakthrough
 - **Progress bar** showing XP and % toward next phase
 - **metamorphosis Stats**: method modifiers, room/building multipliers, season, humidity, and training bonuses
 - **Left panel disciple list** for selecting which coquí's progress to view

--- a/game/metamorphosis.js
+++ b/game/metamorphosis.js
@@ -21,7 +21,7 @@ let statsPanel;
 let statsToggle;
 let selectedDiscipleId = null;
 let breakthroughHandler;
-const RING_RADIUS = 80;
+const RING_RADIUS = 70;
 const RING_CIRCUMFERENCE = 2 * Math.PI * RING_RADIUS;
 const STAGE_NAMES = ['Egg', 'Tadpole', 'Young Coquí', 'Elder Frog', 'Divine Coquí'];
 
@@ -34,14 +34,6 @@ export function initMetamorphosis() {
   statsPanel = document.querySelector('.metamorphosis-stats-panel');
   statsToggle = document.getElementById('metaStatsToggle');
   if (!container) return;
-const bodyPath = `M200 150
-               m -25 0
-               a25 25 0 1 0 50 0
-               a25 25 0 1 0 -50 0
-               m25 20
-               c60 20 90 60 50 110
-               c-30 -40 -70 -70 -100 -80
-               Z`;
   container.innerHTML = `
     <div class="metamorphosis-room">
           <div id="metamorphosisStageLabel" class="metamorphosis-stage"></div>
@@ -59,11 +51,11 @@ const bodyPath = `M200 150
         <div class="metamorphosis-figure">
           <svg id="metamorphosisDiagram" viewBox="0 0 400 400" width="100%" height="100%">
             <defs>
-              <clipPath id="bodyShapeClip"><path d="${bodyPath}" /></clipPath>
+              <clipPath id="bodyShapeClip"><circle cx="200" cy="180" r="60" /></clipPath>
             </defs>
-            <path d="${bodyPath}" fill="rgba(0,0,0,0.3)" stroke="#888" stroke-width="2" />
+            <circle cx="200" cy="180" r="60" fill="rgba(0,0,0,0.3)" stroke="#888" stroke-width="2" />
             <circle id="metamorphosisHalo" cx="200" cy="180" r="70" fill="none" stroke="gold" stroke-width="4" opacity="0" />
-            <rect id="bodyFill" x="170" y="240" width="60" height="0" fill="rgba(255,255,255,0.4)" clip-path="url(#bodyShapeClip)" />
+            <rect id="bodyFill" x="140" y="240" width="120" height="0" fill="rgba(255,255,255,0.4)" clip-path="url(#bodyShapeClip)" />
           </svg>
         </div>
       </div>

--- a/style.css
+++ b/style.css
@@ -2471,8 +2471,8 @@ body.darkenshift-mode .tabsContainer button.active {
     margin-bottom: 8px;
 }
 .metamorphosis-progress {
-    width: 240px;
-    height: 240px;
+    width: 200px;
+    height: 200px;
     overflow: visible;
 }
 #metamorphosisRing {


### PR DESCRIPTION
## Summary
- shrink metamorphosis progress ring to avoid clipping on small screens
- swap tadpole silhouette for a universal filling orb and update docs

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e47ae3d50832683526d5794e35ee0