### PR TITLE
fix: persist orb management unlock

### DIFF
--- a/script.js
+++ b/script.js
@@ -2425,12 +2425,7 @@ if (typeof localStorage === "undefined") return;
     sectSystem,
     sectState,
     sectTabUnlocked,
-    systems: {
-      buildingUnlocked: systems.buildingUnlocked,
-      researchUnlocked: systems.researchUnlocked,
-      chantingHallUnlocked: systems.chantingHallUnlocked,
-      explorationUnlocked: systems.explorationUnlocked
-    }
+    systems: { ...systems }
   };
 
 try {

--- a/test/combat-xp.test.js
+++ b/test/combat-xp.test.js
@@ -9,6 +9,7 @@ let sectModule;
 let raidModule;
 let sectSystem;
 let startRaid;
+let endRaid;
 
 function setupDom() {
   globalThis.document = {
@@ -36,7 +37,7 @@ describe('combat xp gain', () => {
     sectModule = await import(`../game/sect.js?test=${Date.now()}`);
     raidModule = await import(`../game/raids.js?test=${Date.now()}`);
     ({ sectSystem } = sectModule);
-    ({ startRaid } = raidModule);
+    ({ startRaid, endRaid } = raidModule);
   });
 
   after(() => {});
@@ -58,5 +59,6 @@ describe('combat xp gain', () => {
     addSkillXp(d, 'Combat', 1);
     const endXp = sectState.discipleSkills[d.id].Combat || 0;
     expect(endXp).to.be.greaterThan(0);
+    endRaid(true);
   });
 });

--- a/test/research-save.test.js
+++ b/test/research-save.test.js
@@ -1,0 +1,89 @@
+/* global describe, it, before, beforeEach */
+import { expect } from 'chai';
+
+let saveGame;
+let sectState;
+let systems;
+
+describe('research persistence', () => {
+  function stubElement() {
+    return {
+      style: {},
+      classList: { add() {}, remove() {}, toggle() {} },
+      appendChild() {},
+      remove() {},
+      setAttribute() {},
+      getAttribute() { return null; },
+      addEventListener() {},
+      removeEventListener() {},
+      querySelector() { return stubElement(); },
+      querySelectorAll() { return []; },
+      innerHTML: '',
+      textContent: '',
+      value: '',
+      dataset: {}
+    };
+  }
+
+  before(async () => {
+    const docStub = {
+      getElementById: () => stubElement(),
+      getElementsByClassName: () => [stubElement()],
+      querySelector: () => stubElement(),
+      querySelectorAll: () => [],
+      createElement: () => stubElement(),
+      addEventListener() {},
+      removeEventListener() {},
+      documentElement: { style: { setProperty() {} } },
+      body: stubElement()
+    };
+    globalThis.document = docStub;
+    globalThis.window = {
+      addEventListener() {},
+      removeEventListener() {},
+      dispatchEvent() {},
+      location: { reload() {} },
+      CustomEvent: class {},
+    };
+    globalThis.requestAnimationFrame = () => {};
+    const noop = () => 0;
+    globalThis.setInterval = noop;
+    globalThis.clearInterval = () => {};
+    globalThis.setTimeout = noop;
+    globalThis.clearTimeout = () => {};
+    globalThis.localStorage = {
+      _data: {},
+      setItem(k, v) { this._data[k] = String(v); },
+      getItem(k) { return Object.prototype.hasOwnProperty.call(this._data, k) ? this._data[k] : null; },
+      removeItem(k) { delete this._data[k]; },
+      clear() { this._data = {}; }
+    };
+
+    const script = await import('../script.js');
+    saveGame = script.saveGame;
+    const stateModule = await import('../game/state.js');
+    sectState = stateModule.sectState;
+    systems = stateModule.systems;
+  });
+
+  beforeEach(() => {
+    localStorage.clear();
+    sectState.completedResearch.length = 0;
+    systems.researchUnlocked = false;
+    systems.orbManagementUnlocked = false;
+  });
+
+  it('saves completed research and system unlocks', () => {
+    systems.researchUnlocked = true;
+    systems.orbManagementUnlocked = true;
+    sectState.completedResearch.push('wordOfHaste', 'orbRevival');
+    saveGame();
+    const raw = localStorage.getItem('gameSave');
+    const parsed = JSON.parse(raw);
+    expect(parsed.systems.researchUnlocked).to.be.true;
+    expect(parsed.systems.orbManagementUnlocked).to.be.true;
+    expect(parsed.sectState.completedResearch).to.include('wordOfHaste');
+    expect(parsed.sectState.completedResearch).to.include('orbRevival');
+  });
+});
+


### PR DESCRIPTION
## Summary
- save entire systems state during saves so research-unlocked features like orb management persist
- extend regression test to verify orb management unlock and research completions serialize correctly

## Testing
- `npm install`
- `npm run build` *(fails: Missing data in the file; the file is truncated)*
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e42e81af4832689c4198b4baf5e35