### PR TITLE
feat: remove raid movement and parallax

### DIFF
--- a/docs/23-raids.md
+++ b/docs/23-raids.md
@@ -1,6 +1,6 @@
 # 23 – Raids
 
-Night raids play out as a horizontal autobattler. Raiders march in waves from the right edge of the screen toward the Water Orb on the left. Disciples line up to meet them at the fight line in the center.
+Night raids play out as a horizontal autobattler. Raiders spawn just right of the fight line and strike from afar. Disciples line up on the left to defend the Water Orb.
 
 Raid behaviour is entirely data‑driven. A raid is started by calling `startRaid(config)` where `config` provides:
 
@@ -9,19 +9,17 @@ Raid behaviour is entirely data‑driven. A raid is started by calling `startRai
 - `waves` – list describing each wave `{ count, rate, stats }`
 - Optional callbacks `onWaveStart`, `onWaveEnd`, `onSuccess`, and `onFailure`
 
-A typical raid now consists of **five** waves. Each wave spawns a single raider
-and there is a five‑second pause before the next wave begins.
+A typical raid now consists of **five** waves. Each wave spawns a single raider and the next wave begins immediately once the previous is cleared.
 
-The module handles spawning raiders, advancing them toward the fight line and resolving combat. Raiders that reach the orb once will damage it and then vanish. If the orb's water reaches zero the raid fails immediately.
+The module handles spawning raiders and resolving combat. If the orb's water reaches zero the raid fails immediately.
 
-When a raider reaches the fight line it stops and targets the rightmost living disciple. Disciples remain in place and always attack the leftmost raider. Several disciples may assault the same target at once, each dealing damage whenever their personal attack timer completes. Attacking disciples grow slightly larger and a dark overlay shrinks to indicate progress toward their next strike. Whenever a disciple or raider lands an attack, their sprite briefly flashes white twice.
+Raiders randomly target living disciples from their positions. Disciples remain in place and always attack the first raider in line. Several disciples may assault the same target at once, each dealing damage whenever their personal attack timer completes. Attacking disciples grow slightly larger and a dark overlay shrinks to indicate progress toward their next strike. Whenever a disciple or raider lands an attack, their sprite briefly flashes white twice.
 
 The raid ends when all waves are cleared or the orb is destroyed. Callbacks are fired at the start and end of each wave along with a final success or failure signal. When night falls the game automatically opens a dedicated raid overlay and begins a raid. Disciples temporarily switch to the "Idle" task so their badges remain visible in the interface.
 
-The overlay fills the entire screen. Disciple badges line the top while their sprites stand near the Water Orb at the bottom left. Raiders advance from the right toward a fight line in the center where battles take place. Damage numbers briefly float above disciples, raiders and the orb whenever they are hit.
+The overlay fills the entire screen. Disciple badges line the top while their sprites stand near the Water Orb at the bottom left. Damage numbers briefly float above disciples, raiders and the orb whenever they are hit.
 Damage floats use red text when disciples take damage and white when raiders are struck. Raiders are drawn with a thin black border so each unit is clearly visible.
 
-Three parallax background layers—reeds, water and lily pads—scroll left at different speeds and loop seamlessly to maintain motion.
 
 A bar just below the disciple badges shows the remaining life of the current wave in red. The label displays the exact HP left along with the current wave number so players can track their progress.
 

--- a/game/horizontalRaid.js
+++ b/game/horizontalRaid.js
@@ -3,27 +3,6 @@ import { showRaidDamageFloat } from './rendering.js';
 import { applyDamage } from './combat.js';
 import { runAnimation } from '../utils/animation.js';
 
-// Delay between waves in milliseconds
-const WAVE_DELAY = 5000;
-
-// Parallax layer configuration
-const PARALLAX_LAYERS = {
-  reeds: { speed: 10, cssVar: '--reeds-offset', img: 'img/reeds-back.png', width: 0 },
-  water: { speed: 30, cssVar: '--water-offset', img: 'img/water-mid.png', width: 0 },
-  lily: { speed: 60, cssVar: '--lily-offset', img: 'img/lily-pads.png', width: 0 }
-};
-
-// populate image widths without hard-coding values
-if (typeof Image !== 'undefined') {
-  Object.values(PARALLAX_LAYERS).forEach(layer => {
-    const img = new Image();
-    img.src = layer.img;
-    img.onload = () => {
-      layer.width = img.width;
-    };
-  });
-}
-
 export function createHorizontalRaid({
   orb,
   disciples = [],
@@ -49,8 +28,6 @@ export function createHorizontalRaid({
     waveIndex: 0,
     spawnIndex: 0,
     spawnTimer: 0,
-    waveTimer: 0,
-    waiting: false,
     active: false,
     onDamage,
     orbFill: null,
@@ -60,8 +37,7 @@ export function createHorizontalRaid({
     waveLifeFill: null,
     waveLifeLabel: null,
     waveLabel: null,
-    selectedBadge: null,
-    bgOffsets: Object.fromEntries(Object.keys(PARALLAX_LAYERS).map(k => [k, 0]))
+    selectedBadge: null
   };
 
   function buildUI() {
@@ -130,17 +106,6 @@ export function createHorizontalRaid({
     state.root = root;
   }
 
-  function updateBackground(dt) {
-    const offs = state.bgOffsets;
-    for (const [name, cfg] of Object.entries(PARALLAX_LAYERS)) {
-      offs[name] -= (dt * cfg.speed) / 1000;
-      if (cfg.width) offs[name] %= cfg.width;
-      if (state.container) {
-        state.container.style.setProperty(cfg.cssVar, `${offs[name]}px`);
-      }
-    }
-  }
-  
   function updateWaveLife() {
     if (!state.waveLifeFill) return;
     const pct = state.waveTotal > 0 ? (state.waveHp / state.waveTotal) * 100 : 0;
@@ -192,14 +157,12 @@ export function createHorizontalRaid({
   function spawnRaider(stats) {
     const el = document.createElement('div');
     el.className = 'raider-unit';
-    el.style.left = '100%';
+    el.style.left = '60%';
     state.root.appendChild(el);
     state.raiders.push({
       hp: stats.hp,
       damage: stats.damage,
       attackSpeed: stats.attackSpeed,
-      moveSpeed: stats.moveSpeed,
-      progress: 1,
       timer: 0,
       el
     });
@@ -212,23 +175,11 @@ export function createHorizontalRaid({
         s => !s.d.incapacitated && s.d.currentHp > 0
       );
 
-      // Determine the progress point the raider should move toward. If there
-      // are disciples alive we target the rightmost one; otherwise we head for
-      // the sect orb at progress 0.
-      const rootWidth = state.root?.offsetWidth || 1;
-      const target =
-        living.length > 0 ? living.sort((a, b) => b.startLeft - a.startLeft)[0] : null;
-      const targetProgress = target ? target.startLeft / rootWidth : 0;
-
-      if (r.progress > targetProgress) {
-        // Move toward the target and clamp so we don't pass through.
-        r.progress = Math.max(targetProgress, r.progress - r.moveSpeed * dt);
-        if (r.el) r.el.style.left = `${r.progress * 100}%`;
-      } else if (target) {
-        // At disciple – attack
-        r.timer += dt;
-        if (r.timer >= r.attackSpeed) {
-          r.timer -= r.attackSpeed;
+      r.timer += dt;
+      if (r.timer >= r.attackSpeed) {
+        r.timer -= r.attackSpeed;
+        if (living.length > 0) {
+          const target = living[Math.floor(Math.random() * living.length)];
           applyDamage(target.d, r.damage);
           state.onDamage({ amount: r.damage, source: 'raider' });
           showRaidDamageFloat(target.sprite, r.damage);
@@ -236,26 +187,15 @@ export function createHorizontalRaid({
           if (target.d.currentHp <= 0 || target.d.incapacitated) {
             removeDisciple(target);
           }
-        }
-      } else {
-        // No disciples remain; continue toward the orb
-        if (r.progress <= 0) {
+        } else {
           state.orb.current = Math.max(0, state.orb.current - r.damage);
           state.onDamage({ amount: r.damage, source: 'raider' });
           if (state.orbFill) {
             state.orbFill.style.height = `${(state.orb.current / state.orb.max) * 100}%`;
           }
           showRaidDamageFloat(state.orbEl, r.damage);
-          state.waveHp = Math.max(0, state.waveHp - r.hp);
           runAnimation(r.el, 'attack-flash');
-          r.el.remove();
-          const idx = state.raiders.indexOf(r);
-          if (idx >= 0) state.raiders.splice(idx, 1);
-          updateWaveLife();
           if (state.orb.current <= 0) end(false);
-        } else {
-          r.progress -= r.moveSpeed * dt;
-          if (r.el) r.el.style.left = `${r.progress * 100}%`;
         }
       }
     });
@@ -270,10 +210,7 @@ export function createHorizontalRaid({
       }
 
       if (!slot.target || slot.target.hp <= 0 || !livingRaiders.includes(slot.target)) {
-        slot.target = null;
-        if (livingRaiders.length > 0) {
-          slot.target = livingRaiders.slice().sort((a, b) => a.progress - b.progress)[0];
-        }
+        slot.target = livingRaiders[0] || null;
         if (!slot.target) {
           slot.timer = 0;
           slot.sprite?.classList.remove('attacking');
@@ -313,15 +250,7 @@ export function createHorizontalRaid({
   function spawnLoop(dt) {
     const wave = state.waves[state.waveIndex];
     if (!wave) return;
-    if (state.waiting) {
-      state.waveTimer += dt;
-      if (state.waveTimer >= WAVE_DELAY) {
-        state.waiting = false;
-        state.waveTimer = 0;
-        beginWave(state.waveIndex);
-      }
-      return;
-    }
+
     if (state.spawnIndex < wave.count) {
       state.spawnTimer += dt;
       if (state.spawnTimer >= wave.rate) {
@@ -339,7 +268,7 @@ export function createHorizontalRaid({
         end(true);
       } else {
         state.waveIndex = next;
-        state.waiting = true;
+        beginWave(state.waveIndex);
       }
     }
   }
@@ -364,7 +293,6 @@ export function createHorizontalRaid({
 
   function tick(dt) {
     if (!state.active) return;
-    updateBackground(dt);
     spawnLoop(dt);
     // dt is in milliseconds; use same unit for attack timers
     updateRaiders(dt);
@@ -376,8 +304,6 @@ export function createHorizontalRaid({
   return {
     start: () => {
       state.active = true;
-      state.waiting = false;
-      state.waveTimer = 0;
       beginWave(0);
     },
     tick,

--- a/style.css
+++ b/style.css
@@ -870,38 +870,6 @@ body.darkenshift-mode .tabsContainer button.active {
 #battle-container {
     position: relative;
     overflow: hidden;
-    --reeds-offset: 0;
-    --water-offset: 0;
-    --lily-offset: 0;
-}
-#battle-container::before,
-#battle-container::after,
-#battle-container .mid {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background-repeat: repeat-x;
-    background-position: 0 0;
-    will-change: background-position;
-    pointer-events: none;
-}
-#battle-container::before {
-    background-image: url('img/reeds-back.png');
-    z-index: 1;
-    background-position: var(--reeds-offset) 0;
-}
-#battle-container .mid {
-    background-image: url('img/water-mid.png');
-    z-index: 2;
-    background-position: var(--water-offset) 0;
-}
-#battle-container::after {
-    background-image: url('img/lily-pads.png');
-    z-index: 3;
-    background-position: var(--lily-offset) 0;
 }
 
 .work-content {

--- a/ui/raidBattleOverlay.js
+++ b/ui/raidBattleOverlay.js
@@ -10,9 +10,6 @@ export function openRaidBattleOverlay({ config, onSuccess = () => {}, onFailure 
   const area = document.createElement('div');
   area.className = 'raid-battle-area';
   area.id = 'battle-container';
-  const mid = document.createElement('div');
-  mid.className = 'mid';
-  area.appendChild(mid);
   overlay.append(area);
   const spells = document.createElement('div');
   spells.className = 'raid-spell-bar';


### PR DESCRIPTION
## Summary
- strip parallax backgrounds and overlay mid layer from raids
- spawn raiders on right side, remove movement, and target disciples randomly
- start new raid waves immediately after the previous clears

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f6b1241808326a17ca84467b710fa