### PR TITLE
style: remove bamboo border from disciple badges

### DIFF
--- a/docs/00-wireframes.md
+++ b/docs/00-wireframes.md
@@ -85,10 +85,9 @@ Footer
 
 “Gate” button to open the full map/exploration/tasks overlay.
 * Exploration and sect disciple lists now use a unified badge styled purely via CSS.
-  Each badge displays a parchment background inside a bamboo border along with the disciple's name,
+  Each badge displays a parchment background along with the disciple's name,
   mood, HP bar, Water bar and current task.
-* Disciples on the sect map appear as slightly larger side-facing coquí sprites (about 20% bigger). The bamboo frame is drawn using
-  the CSS `border-image` property so the texture tiles cleanly around the badge. Every 10–20 seconds they emit a small croak bubble, and when assigned work they display a task icon such as a pickaxe or scroll.
+* Disciples on the sect map appear as slightly larger side-facing coquí sprites (about 20% bigger). Every 10–20 seconds they emit a small croak bubble, and when assigned work they display a task icon such as a pickaxe or scroll.
 * HP and Water bars animate in real time on both the badge and within the disciple overlay.
 
 * All overlays now use the same parchment-style box for a consistent look.

--- a/style.css
+++ b/style.css
@@ -4216,11 +4216,8 @@ body.darkenshift-mode .tabsContainer button.active {
 }
 
 .disciple-badge {
-  background-image: url('img/bamboo.png');
-  background-size: 100% 100%;
-  background-repeat: no-repeat;
-  border-radius: 12px;
-  padding: 8px;
+  border-radius: 8px;
+  padding: 0;
   position: relative;
   z-index: 1;
   display: flex;


### PR DESCRIPTION
## Summary
- drop bamboo border styling from disciple badges
- update wireframe docs to reflect new badge appearance

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f70219f9c8326bcd0b3bc78f8048b