### PR TITLE
Initialize game with zones hidden on load

### DIFF
--- a/docs/module-structure.md
+++ b/docs/module-structure.md
@@ -15,7 +15,7 @@ The project organizes game logic under the `game/` directory.
 - **game/debug.js** – wiring for optional debug controls.
 - **debugTools.js** – development helpers lazily loaded when a debug
   button is clicked.
-- **game/zones.js** – toggles visibility of sect map zone elements.
+- **game/zones.js** – toggles visibility of sect map zone elements; hidden by default on load.
 - **game/constants.js** – collection of shared gameplay constants used across systems.
 - **game/tooltip.js** – simple helpers for showing and hiding the UI tooltip.
 - **game/sect.js** – implements the sect management system including constructs and colony helpers.

--- a/game/zones.js
+++ b/game/zones.js
@@ -1,10 +1,10 @@
-export let zonesVisible = true;
+export let zonesVisible = false;
 
 export function toggleZones() {
   const container = document.getElementById('sectDisciplesContainer');
   if (!container) return;
   zonesVisible = !zonesVisible;
   container.querySelectorAll('.zone, .zone-path').forEach(z => {
-    z.style.display = zonesVisible ? '' : 'none';
+    z.style.display = zonesVisible ? 'block' : 'none';
   });
 }

--- a/style.css
+++ b/style.css
@@ -3200,6 +3200,7 @@ body.darkenshift-mode .tabsContainer button.active {
     position: absolute;
     width: var(--zone-size);
     height: var(--zone-size);
+    display: none;
     pointer-events: none;
     border: 2px solid rgba(0,0,0,0.2);
     border-radius: 4px;


### PR DESCRIPTION
## Summary
- Start zones view hidden and allow toggling it on
- Document that zones are hidden by default

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f7151f7388326b4fd64a2a80aa010