### PR TITLE
fix: guard player stats ui elements

### DIFF
--- a/game/ui.js
+++ b/game/ui.js
@@ -27,9 +27,14 @@ export function init(elements = {}) {
   explorationTabButton = elements.explorationTabButton;
 }
 
-export const handContainer = document.getElementsByClassName('handContainer')[0];
+export const handContainer =
+  typeof document !== 'undefined'
+    ? document.getElementsByClassName('handContainer')[0]
+    : null;
 export const dealerLifeDisplay =
-  document.getElementsByClassName('dealerLifeDisplay')[0] || null;
+  typeof document !== 'undefined'
+    ? document.getElementsByClassName('dealerLifeDisplay')[0] || null
+    : null;
 
 export function showPlayerAttackBar() {
   const bar = document.getElementById('playerAttackBar');
@@ -68,6 +73,21 @@ export function updateRaidLifeBar(enemy) {
 export function updateDiscipleStatsDisplay(d) {
   if (!d.statsElement) return;
   d.statsElement.innerHTML = '';
+}
+
+export function updatePlayerStatsUI(elems = {}, data = {}) {
+  if (elems.level) {
+    elems.level.textContent = String(data.level ?? '');
+  }
+  if (elems.xpFill) {
+    elems.xpFill.style.width = `${data.xpPercent ?? 0}%`;
+  }
+  if (elems.xpLabel) {
+    elems.xpLabel.textContent = data.xpLabel ?? '';
+  }
+  if (elems.stats) {
+    elems.stats.textContent = data.stats ?? '';
+  }
 }
 
 export function renderCombatDisciples() {}

--- a/test/ui-null-check.test.js
+++ b/test/ui-null-check.test.js
@@ -1,0 +1,24 @@
+/* global describe, it */
+import { expect } from 'chai';
+import { updatePlayerStatsUI } from '../game/ui.js';
+
+describe('updatePlayerStatsUI', () => {
+  it('exits cleanly when some elements are undefined', () => {
+    const elems = {
+      level: { textContent: '' },
+      xpLabel: { textContent: '' },
+      // xpFill and stats intentionally omitted
+    };
+
+    const data = {
+      level: 3,
+      xpPercent: 40,
+      xpLabel: '40/100',
+      stats: 'HP: 10'
+    };
+
+    expect(() => updatePlayerStatsUI(elems, data)).to.not.throw();
+    expect(elems.level.textContent).to.equal('3');
+    expect(elems.xpLabel.textContent).to.equal('40/100');
+  });
+});


### PR DESCRIPTION
## Summary
- guard DOM lookups in `game/ui.js` for non-browser contexts
- add `updatePlayerStatsUI` with null checks for optional UI elements
- test behavior when player stat elements are missing

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f71e6193c83268ce02e7f2855f057