### PR TITLE
fix: update combat overlay stats

### DIFF
--- a/docs/00-wireframes.md
+++ b/docs/00-wireframes.md
@@ -94,7 +94,7 @@ Footer
 
 #dicsiple overlay card on pressing disciple
 
-Here’s the updated **Disciple Overlay UI wireframe** with the added `Cultivation` tab and clean layout for all six tabs:
+Here’s the updated **Disciple Overlay UI wireframe** with the added `Cultivation` and `Combat` tabs and clean layout for all seven tabs:
 
 ---
 
@@ -102,7 +102,7 @@ Here’s the updated **Disciple Overlay UI wireframe** with the added `Cultivati
 
 ```plaintext
 ┌────────────────────────────────────────────────────────────────────────────┐
-│ ○ General  ○ Proficiency  ○ Constructs  ○ Moodlets  ○ Stats  ○ Cultivation │
+│ ○ General  ○ Proficiency  ○ Constructs  ○ Moodlets  ○ Stats  ○ Combat  ○ Cultivation │
 ├────────────────────────────────────────────────────────────────────────────┤
 
 [Content based on selected tab shown below]

--- a/script.js
+++ b/script.js
@@ -750,6 +750,33 @@ function updateDiscipleHealthDisplay() {
   }
 }
 
+function updateDiscipleCombatStatsDisplay() {
+  if (discipleOverlay && discipleOverlayActiveTab === 'combat') {
+    const d = discipleOverlayData.disciple;
+    if (!d) return;
+    const section = discipleOverlay.box.querySelector('.disciple-stats-combat');
+    if (!section) return;
+    const levelRow = section.querySelector('.combat-level');
+    if (levelRow) levelRow.textContent = `Level ${d.combatLevel}`;
+    const fill = section.querySelector('.disciple-progress-fill');
+    if (fill) {
+      const pct = Math.min(1, d.combatXp / d.xpForNextLevel());
+      fill.style.width = `${Math.floor(pct * 100)}%`;
+    }
+    const label = section.querySelector('.disciple-progress-label');
+    if (label) label.textContent = `${Math.floor(d.combatXp)}/${d.xpForNextLevel()}`;
+    const stats = section.querySelector('.combat-stats');
+    if (stats) {
+      const atkPerSec = (1000 / d.attackSpeed).toFixed(2);
+      const defense = Math.round(d.defense ?? 0);
+      stats.innerHTML =
+        `Damage ${Math.round(d.damage)}<br>` +
+        `Attack/s ${atkPerSec}<br>` +
+        `Defense ${defense}`;
+    }
+  }
+}
+
 function updateSectDisplay() {
   checkBuildingUnlock();
   if (sectNavBuildBtn) {
@@ -1003,10 +1030,12 @@ function startDiscipleMovement() {
 
 function buildDiscipleCombatStatsView(d) {
   const body = document.createElement('div');
+  body.className = 'disciple-combat';
   const atkPerSec = (1000 / d.attackSpeed).toFixed(2);
   const defense = Math.round(d.defense ?? 0);
 
   const levelRow = document.createElement('div');
+  levelRow.className = 'combat-level';
   levelRow.textContent = `Level ${d.combatLevel}`;
   body.appendChild(levelRow);
 
@@ -1023,6 +1052,7 @@ function buildDiscipleCombatStatsView(d) {
   body.appendChild(bar);
 
   const stats = document.createElement('div');
+  stats.className = 'combat-stats';
   stats.innerHTML =
     `Damage ${Math.round(d.damage)}<br>` +
     `Attack/s ${atkPerSec}<br>` +
@@ -1304,7 +1334,8 @@ export function openDiscipleOverlay(d) {
     { key: 'health', label: 'Health' },
     { key: 'proficiency', label: 'Proficiency' },
     { key: 'moodlets', label: 'Moodlets' },
-    { key: 'stats', label: 'Stats' }
+    { key: 'stats', label: 'Stats' },
+    { key: 'combat', label: 'Combat' }
   ];
   let active = discipleOverlayActiveTab;
   function render() {
@@ -1319,22 +1350,21 @@ export function openDiscipleOverlay(d) {
     } else if (active === 'moodlets') {
       content.appendChild(buildDiscipleMoodletsView(d));
     } else if (active === 'stats') {
-      const c = document.createElement('div');
-      const genSection = document.createElement('div');
-      genSection.className = 'disciple-stats-general';
-      const genTitle = document.createElement('h3');
-      genTitle.textContent = 'General Stats';
-      genSection.appendChild(genTitle);
-      genSection.appendChild(buildDiscipleStatsView(d));
-      const combatSection = document.createElement('div');
-      combatSection.className = 'disciple-stats-combat';
-      const comTitle = document.createElement('h3');
-      comTitle.textContent = 'Combat Stats';
-      combatSection.appendChild(comTitle);
-      combatSection.appendChild(buildDiscipleCombatStatsView(d));
-      c.appendChild(genSection);
-      c.appendChild(combatSection);
-      content.appendChild(c);
+      const section = document.createElement('div');
+      section.className = 'disciple-stats-general';
+      const title = document.createElement('h3');
+      title.textContent = 'General Stats';
+      section.appendChild(title);
+      section.appendChild(buildDiscipleStatsView(d));
+      content.appendChild(section);
+    } else if (active === 'combat') {
+      const section = document.createElement('div');
+      section.className = 'disciple-stats-combat';
+      const title = document.createElement('h3');
+      title.textContent = 'Combat Stats';
+      section.appendChild(title);
+      section.appendChild(buildDiscipleCombatStatsView(d));
+      content.appendChild(section);
     }
     if (window.lucide) lucide.createIcons({ icons: lucide.icons });
   }
@@ -2634,6 +2664,7 @@ function gameLoop(currentTime) {
   updateTaskProgressDisplay();
   updateDiscipleHealthDisplay();
   updateDiscipleWaterDisplay();
+  updateDiscipleCombatStatsDisplay();
   updateOrbGlow(deltaTime);
   requestAnimationFrame(gameLoop);
 }


### PR DESCRIPTION
## Summary
- ensure disciple combat overlay shows live combat level and stats
- refresh combat stat view each frame
- add dedicated Combat tab to disciple overlays

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f7446cdfc832685040f8fef0ccf17