### PR TITLE
fix: sync incapacitated healing

### DIFF
--- a/game/sect.js
+++ b/game/sect.js
@@ -1461,10 +1461,6 @@ export function tickSect(delta) {
   sectSystem.disciples.forEach(d => {
     if (d.incapacitated) {
       tickInjuries(d, dt, d.resilience, 'Resting');
-      d.currentHp = d.health;
-      if (d.health >= DISCIPLE_MAX_HEALTH / 2) {
-        d.incapacitated = false;
-      }
       if (!d.starveTimer) d.starveTimer = 0;
       if (d.water <= 0) {
         d.starveTimer += dt;
@@ -1474,6 +1470,10 @@ export function tickSect(delta) {
         }
       } else {
         d.starveTimer = 0;
+      }
+      d.currentHp = d.health;
+      if (d.health >= DISCIPLE_MAX_HEALTH / 2) {
+        d.incapacitated = false;
       }
       return;
     }


### PR DESCRIPTION
## Summary
- keep incapacitated disciple hp in sync with starvation damage

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f74e93b7c8326a71dfebea85fe8ad