### PR TITLE
fix: display undead nectar resource

### DIFF
--- a/docs/00-wireframes.md
+++ b/docs/00-wireframes.md
@@ -51,7 +51,7 @@ This row appears above the sect map. The previous row of disciple cards beneath 
 
 Left panel (Resource / Items)
 
-Shows stackable resources (fruit, wood, stone, etc.).
+Shows stackable resources like fruit, wood, and undead nectar.
 Selecting the Resources nav opens an overlay showing daily gains and losses.
 Softwood production appears once a disciple is assigned to gather it.
 The numbers update automatically as tasks and production change.

--- a/game/raids.js
+++ b/game/raids.js
@@ -45,6 +45,7 @@ function finalize(victory) {
     if (sectSystem.resources.undeadNectar) {
       const res = sectSystem.resources.undeadNectar;
       res.current = Math.min(res.max, res.current + RAID_NECTAR_REWARD);
+      res.unlocked = true;
     }
   }
 

--- a/game/sect.js
+++ b/game/sect.js
@@ -103,7 +103,8 @@ export const sectSystem = {
   gains: {
     water: 0,
     fruits: 0,
-    softwood: 0
+    softwood: 0,
+    undeadNectar: 0
   },
   skills: {
     mind: { xp: 0, level: 0 },

--- a/script.js
+++ b/script.js
@@ -745,10 +745,15 @@ function updateSectDisplay() {
        };
     const fruitRate = formatRate(sectSystem.gains?.fruits);
     const woodRate = formatRate(sectSystem.gains?.softwood);
+    const nectarRate = formatRate(sectSystem.gains?.undeadNectar);
+    const nectarLine = sectSystem.resources?.undeadNectar?.unlocked
+      ? `<span>💀 ${sectState.undeadNectar.toFixed(2)}/${sectSystem.resources.undeadNectar.max} (${nectarRate}/s)</span>`
+      : '';
     sectSummaryDisplay.innerHTML = `
       <span>👥 ${total}/${sectState.maxDisciples} (Idle: ${idle})</span>
       <span>${sectState.fruits.toFixed(2)}/${sectState.fruitCap} (${fruitRate}/s)</span>
-      <span>🪵 ${sectState.softwood.toFixed(2)}/${sectState.softwoodCap} (${woodRate}/s)</span>`;
+      <span>🪵 ${sectState.softwood.toFixed(2)}/${sectState.softwoodCap} (${woodRate}/s)</span>
+      ${nectarLine}`;
     const timer = document.getElementById('resourceTimer');
     if (timer) {
       timer.textContent = `${mm}:${ss}`;
@@ -2445,11 +2450,12 @@ Object.assign(playerStats, state.playerStats || {});
       }
 
       if (!sectSystem.gains) {
-        sectSystem.gains = { water: 0, fruits: 0, softwood: 0 };
+        sectSystem.gains = { water: 0, fruits: 0, softwood: 0, undeadNectar: 0 };
       } else {
         if (typeof sectSystem.gains.water !== 'number') sectSystem.gains.water = 0;
         if (typeof sectSystem.gains.fruits !== 'number') sectSystem.gains.fruits = 0;
         if (typeof sectSystem.gains.softwood !== 'number') sectSystem.gains.softwood = 0;
+        if (typeof sectSystem.gains.undeadNectar !== 'number') sectSystem.gains.undeadNectar = 0;
       }
 
     if (!Array.isArray(sectSystem.savedConstructs)) {
@@ -2538,6 +2544,7 @@ function gameLoop(currentTime) {
   const startWater = sectSystem.resources.water.current;
   const startFruit = sectState.fruits;
   const startSoftwood = sectState.softwood;
+  const startNectar = sectState.undeadNectar;
 
 
   if (currentEnemy) {
@@ -2584,10 +2591,13 @@ function gameLoop(currentTime) {
     sectSystem.gains.fruits = (sectState.fruits - startFruit) / dtSeconds;
     sectSystem.gains.softwood =
       (sectState.softwood - startSoftwood) / dtSeconds;
+    sectSystem.gains.undeadNectar =
+      (sectState.undeadNectar - startNectar) / dtSeconds;
   } else {
     sectSystem.gains.water = 0;
     sectSystem.gains.fruits = 0;
     sectSystem.gains.softwood = 0;
+    sectSystem.gains.undeadNectar = 0;
   }
   // refresh sect resource UI every tick for real-time updates
   if (typeof updateSectDisplay === 'function') updateSectDisplay();

--- a/test/raid-nectar-unlock.test.js
+++ b/test/raid-nectar-unlock.test.js
@@ -1,0 +1,61 @@
+/* global describe, it, before, after, beforeEach */
+import { expect } from 'chai';
+import { sectState } from '../game/state.js';
+
+let sectModule;
+let raidModule;
+let sectSystem;
+let endRaid;
+let raidState;
+
+function setupDom() {
+  globalThis.document = {
+    getElementById: () => null,
+    getElementsByClassName: () => [{ textContent: '', style: {}, appendChild() {} }],
+    createElement: () => ({
+      appendChild() {},
+      style: {},
+      addEventListener() {},
+      remove() {},
+      classList: { add() {}, remove() {}, toggle() {} }
+    }),
+    querySelector: () => null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    body: { appendChild() {}, classList: { add() {}, remove() {} } },
+    dispatchEvent: () => {}
+  };
+  globalThis.window = { dispatchEvent() {} };
+}
+
+describe('undead nectar rewards', () => {
+  before(async () => {
+    setupDom();
+    sectModule = await import('../game/sect.js');
+    raidModule = await import('../game/raids.js');
+    ({ sectSystem } = sectModule);
+    ({ endRaid, raidState } = raidModule);
+  });
+
+  after(() => {
+    delete globalThis.document;
+    delete globalThis.window;
+  });
+
+  beforeEach(() => {
+    sectState.undeadNectar = 0;
+    const res = sectSystem.resources.undeadNectar;
+    res.current = 0;
+    res.unlocked = false;
+    raidState.active = true;
+    raidState.raid = { end() {} };
+    raidState.overlay = { close() {} };
+    raidState.prevTasks = {};
+    raidState.xpStart = {};
+  });
+
+  it('unlocks undead nectar resource after a raid victory', () => {
+    endRaid(true);
+    expect(sectSystem.resources.undeadNectar.unlocked).to.be.true;
+  });
+});

--- a/test/water-orb.test.js
+++ b/test/water-orb.test.js
@@ -1,4 +1,4 @@
-/* global describe, it, before, after */
+/* global describe, it, before, after, global */
 import { expect } from 'chai';
 import { sectState } from '../game/state.js';
 


### PR DESCRIPTION
## Summary
- show undead nectar in the sect resource panel when unlocked
- track undead nectar gains alongside other resources
- mention undead nectar in UI wireframe docs
- unlock undead nectar resource after raid rewards so it actually displays

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f7c8e89788326ad5d63d0e288e538