### PR TITLE
fix: sync combat xp overlay

### DIFF
--- a/test/combat-xp.test.js
+++ b/test/combat-xp.test.js
@@ -59,6 +59,7 @@ describe('combat xp gain', () => {
     addSkillXp(d, 'Combat', 1);
     const endXp = sectState.discipleSkills[d.id].Combat || 0;
     expect(endXp).to.be.greaterThan(0);
+    expect(d.combatXp).to.be.greaterThan(0);
     endRaid(true);
   });
 });

--- a/test/water-orb.test.js
+++ b/test/water-orb.test.js
@@ -1,4 +1,4 @@
-/* global describe, it, before, after, global */
+/* global describe, it, before, after */
 import { expect } from 'chai';
 import { sectState } from '../game/state.js';
 

--- a/utils/skills.js
+++ b/utils/skills.js
@@ -51,6 +51,9 @@ export function addSkillXp(d, group, amount) {
   const newXp = prevXp + amount;
   sectState.discipleSkills[d.id][group] = newXp;
   const newLevel = getTaskSkillProgress(newXp).level;
+  if (group === 'Combat') {
+    d.gainCombatXp(amount);
+  }
   if (group === 'Combat') addMasteryXp(d.id, amount);
   else addMasteryXp(d.id, amount / 4);
   if (newLevel > oldLevel) {


### PR DESCRIPTION
## Summary
- update combat skill xp handler to update disciple combat xp for overlay syncing
- verify combat xp growth after raids

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f8bda689083269be0fe58d38e9d96