### PR TITLE
fix: correct hp calc and tooltip behavior

### DIFF
--- a/game/injury.js
+++ b/game/injury.js
@@ -53,10 +53,10 @@ export function ensureInjuryState(d) {
 export function calculateMaxHealth(d) {
   ensureInjuryState(d);
   const base = d.maxHp;
-  let hp = 0;
+  let hp = base;
   BODY_PARTS.forEach(p => {
     const state = d.injuries[p.key];
-    if (state.tier !== 'destroyed') hp += base * p.contribution;
+    if (state.tier === 'destroyed') hp -= base * p.contribution;
   });
   return Math.round(hp);
 }

--- a/game/metamorphosis.js
+++ b/game/metamorphosis.js
@@ -357,6 +357,12 @@ function updateStats() {
       window.showTooltip(tip, e.pageX + 10, e.pageY + 10);
     });
     el.addEventListener('mouseleave', window.hideTooltip);
+    el.addEventListener('touchstart', e => {
+      const t = e.touches[0];
+      window.showTooltip(tip, t.pageX + 10, t.pageY + 10);
+      e.stopPropagation();
+    });
+    el.addEventListener('touchend', window.hideTooltip);
   });
 }
 

--- a/game/tooltip.js
+++ b/game/tooltip.js
@@ -2,6 +2,9 @@ let tooltipEl;
 
 export function initTooltip() {
   tooltipEl = document.getElementById('tooltip');
+  if (typeof document !== 'undefined') {
+    document.addEventListener('touchstart', hideTooltip);
+  }
 }
 
 export function showTooltip(text, x = 0, y = 0) {
@@ -11,8 +14,18 @@ export function showTooltip(text, x = 0, y = 0) {
   }
   tooltipEl.textContent = text;
   tooltipEl.style.display = 'block';
-  tooltipEl.style.left = `${x}px`;
-  tooltipEl.style.top = `${y}px`;
+  const padding = 8;
+  let left = x;
+  let top = y;
+  const width = tooltipEl.offsetWidth;
+  const height = tooltipEl.offsetHeight;
+  const { innerWidth, innerHeight } = window;
+  if (left + width > innerWidth - padding) left = innerWidth - width - padding;
+  if (top + height > innerHeight - padding) top = innerHeight - height - padding;
+  if (left < padding) left = padding;
+  if (top < padding) top = padding;
+  tooltipEl.style.left = `${left}px`;
+  tooltipEl.style.top = `${top}px`;
 }
 
 export function hideTooltip() {

--- a/test/injury-system.test.js
+++ b/test/injury-system.test.js
@@ -37,9 +37,16 @@ it('exposes BODY_PARTS constant', () => {
 });
 
 describe('injury system', () => {
+  it('starts with full health when no injuries', () => {
+    const d = new Disciple({ id: 1 });
+    initializeDisciple(d, { allowInjuries: false, generateQuirks: false });
+    expect(d.health).to.equal(d.maxHp);
+  });
+
   it('applies starvation damage and injuries', () => {
     const d = new Disciple({ id: 1 });
     initializeDisciple(d, { allowInjuries: false, generateQuirks: false });
+    d.resilience = 0;
     d.water = 0;
     sectSystem.disciples.push(d);
     sectState.discipleTasks[d.id] = 'Research';
@@ -47,7 +54,7 @@ describe('injury system', () => {
     Math.random = () => 0; // always hit head and apply bruise
     tickSect(1000);
     Math.random = prev;
-    expect(d.health).to.be.below(10);
+    expect(d.health).to.be.below(d.maxHp);
   });
 
   it('resilience slows injury progress', () => {


### PR DESCRIPTION
## Summary
- ensure full max health by adjusting injury-based hp calculation
- keep tooltips on-screen and dismiss on touch or pointer leave
- cover health initialization and starvation damage in injury tests

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fbf9b274c8326b810313bd2532cac