### PR TITLE
feat: render vertical raid containers

### DIFF
--- a/docs/23-raids.md
+++ b/docs/23-raids.md
@@ -1,6 +1,6 @@
 # 23 – Raids
 
-Night raids play out as a horizontal autobattler. Raiders spawn just right of the fight line and strike from afar. Disciples line up on the left to defend the Water Orb.
+Night raids play out as a vertical autobattler. Raiders gather above the fight line and strike from above while disciples line up below to defend the Water Orb.
 
 Raid behaviour is entirely data‑driven. A raid is started by calling `startRaid(config)` where `config` provides:
 
@@ -15,15 +15,15 @@ The module handles spawning raiders and resolving combat. If the orb's water rea
 
 Raiders randomly target living disciples from their positions. Disciples remain in place and always attack the first raider in line. Several disciples may assault the same target at once, each dealing damage whenever their personal attack timer completes. Each defender strikes once every 5 seconds for 1 damage before any combat or metamorphosis bonuses are applied. Attacking disciples grow slightly larger and a dark overlay shrinks to indicate progress toward their next strike. Whenever a disciple or raider lands an attack, their sprite briefly flashes white twice.
 
-The raid ends when all waves are cleared or the orb is destroyed. Callbacks are fired at the start and end of each wave along with a final success or failure signal. When night falls the game automatically opens a dedicated raid overlay and begins a raid. Disciples temporarily switch to the "Idle" task so their badges remain visible in the interface.
+The raid ends when all waves are cleared or the orb is destroyed. Callbacks are fired at the start and end of each wave along with a final success or failure signal. When night falls the game automatically opens a dedicated raid overlay and begins a raid. Disciples temporarily switch to the "Idle" task so they remain visible in the interface.
 
-The overlay fills the entire screen. Disciple badges line the top while their sprites stand near the Water Orb at the bottom left. Damage numbers briefly float above disciples, raiders and the orb whenever they are hit.
+The overlay fills the entire screen. Raiders occupy a dedicated top container with the current wave life bar. Disciples stand in a row across the bottom container and show their HP, Water and attack progress bars underneath each sprite. Damage numbers briefly float above disciples, raiders and the orb whenever they are hit.
 Damage floats use red text when disciples take damage and white when raiders are struck. Raiders are drawn with a thin black border so each unit is clearly visible.
 
 
-A bar just below the disciple badges shows the remaining life of the current wave in red. The label displays the exact HP left along with the current wave number so players can track their progress.
+A life bar at the top shows the remaining life of the current wave in red. The label displays the exact HP left along with the current wave number so players can track their progress.
 
-During raids you can click a disciple's badge to open their detailed overlay.
+During raids you can click a disciple to open their detailed overlay.
 Any disciple reduced to **0 HP** or incapacitated by destroyed body parts is
 immediately removed from the lineup and no longer fights in that raid.
 

--- a/docs/module-structure.md
+++ b/docs/module-structure.md
@@ -9,7 +9,7 @@ The project organizes game logic under the `game/` directory.
 - **game/ui.js** – renders combat UI elements such as bars and disciple cards.
 - **game/rendering.js** – raid rendering helpers such as `showRaidDamageFloat`.
 - **game/combat.js** – provides generic damage helpers used by raid modules.
-- **game/raids.js** and **game/horizontalRaid.js** – implement raid encounters and the
+- **game/raids.js** and **game/verticalRaid.js** – implement raid encounters and the
   defensive combat loop.
 - **game/canBus.js** – lightweight event bus used for in-game modules to
   communicate without direct imports.

--- a/game/verticalRaid.js
+++ b/game/verticalRaid.js
@@ -1,9 +1,11 @@
-import { createDiscipleBadge } from './badges.js';
 import { showRaidDamageFloat } from './rendering.js';
 import { applyDamage } from './combat.js';
 import { runAnimation } from '../utils/animation.js';
+import { makeBar } from './ui.js';
+import { sectState } from './state.js';
+import { getMaxWater } from './metamorphosisBonuses.js';
 
-export function createHorizontalRaid({
+export function createVerticalRaid({
   orb,
   disciples = [],
   waves = [],
@@ -16,7 +18,16 @@ export function createHorizontalRaid({
 } = {}) {
   const state = {
     orb,
-    disciples: disciples.map(d => ({ d, timer: 0, badge: null, sprite: null, startLeft: 0, target: null, overlay: null })),
+    disciples: disciples.map(d => ({
+      d,
+      timer: 0,
+      sprite: null,
+      wrapper: null,
+      hpFill: null,
+      waterFill: null,
+      attackFill: null,
+      target: null
+    })),
     waves,
     onWaveStart,
     onWaveEnd,
@@ -25,6 +36,8 @@ export function createHorizontalRaid({
     container,
     root: null,
     raiders: [],
+    raiderBox: null,
+    discipleBox: null,
     waveIndex: 0,
     spawnIndex: 0,
     spawnTimer: 0,
@@ -36,13 +49,21 @@ export function createHorizontalRaid({
     waveHp: 0,
     waveLifeFill: null,
     waveLifeLabel: null,
-    waveLabel: null,
-    selectedBadge: null
+    waveLabel: null
   };
 
   function buildUI() {
     const root = document.createElement('div');
     root.className = 'raid-container';
+
+    const raiderBox = document.createElement('div');
+    raiderBox.className = 'raider-container';
+    root.appendChild(raiderBox);
+
+    const discipleBox = document.createElement('div');
+    discipleBox.className = 'disciple-container';
+    root.appendChild(discipleBox);
+
     const line = document.createElement('div');
     line.className = 'fight-line';
     root.appendChild(line);
@@ -61,7 +82,7 @@ export function createHorizontalRaid({
     lifeBar.appendChild(lifeFill);
     lifeBar.appendChild(lifeLabel);
     info.appendChild(lifeBar);
-    root.appendChild(info);
+    raiderBox.appendChild(info);
     state.waveLifeFill = lifeFill;
     state.waveLifeLabel = lifeLabel;
     state.waveLabel = waveLabel;
@@ -76,34 +97,52 @@ export function createHorizontalRaid({
     state.orbFill = fill;
     state.orbEl = orbEl;
 
-    state.disciples.forEach((slot, i) => {
-      const badge = createDiscipleBadge(slot.d);
-      badge.style.position = 'absolute';
-      badge.style.left = `${10 + i * 80}px`;
-      badge.style.top = '4px';
-      badge.addEventListener('click', () => {
-        if (state.selectedBadge) state.selectedBadge.classList.remove('selected');
-        state.selectedBadge = badge;
-        badge.classList.add('selected');
+    state.disciples.forEach(slot => {
+      const wrapper = document.createElement('div');
+      wrapper.className = 'raid-disciple-wrapper';
+      wrapper.addEventListener('click', () => {
         window.dispatchEvent(
           new CustomEvent('open-disciple-overlay', { detail: slot.d })
         );
       });
-      root.appendChild(badge);
       const sprite = document.createElement('div');
       sprite.className = 'raid-disciple';
-      sprite.style.left = `${50 + i * 30}px`;
-      const overlay = document.createElement('div');
-      overlay.className = 'raid-attack-shadow';
-      sprite.appendChild(overlay);
-      root.appendChild(sprite);
-      slot.badge = badge;
+      wrapper.appendChild(sprite);
+
+      const bars = document.createElement('div');
+      bars.className = 'raid-disciple-bars';
+
+      const hpBar = makeBar(slot.d.currentHp, slot.d.maxHp, '#a33');
+      hpBar.classList.add('hp-bar');
+      bars.appendChild(hpBar);
+
+      const waterLvl = sectState.discipleSkills[slot.d.id]?.WaterSense || 0;
+      const waterBar = makeBar(
+        slot.d.water || 0,
+        getMaxWater(slot.d, waterLvl),
+        '#7fd9ff'
+      );
+      waterBar.classList.add('water-bar');
+      bars.appendChild(waterBar);
+
+      const attackBar = makeBar(0, slot.d.attackSpeed, '#ccc');
+      attackBar.classList.add('attack-bar');
+      bars.appendChild(attackBar);
+
+      wrapper.appendChild(bars);
+      discipleBox.appendChild(wrapper);
+
+      slot.wrapper = wrapper;
       slot.sprite = sprite;
-      slot.overlay = overlay;
-      slot.startLeft = 50 + i * 30;
+      slot.hpFill = hpBar.querySelector('.bar-fill');
+      slot.waterFill = waterBar.querySelector('.bar-fill');
+      slot.attackFill = attackBar.querySelector('.bar-fill');
     });
+
     state.container.appendChild(root);
     state.root = root;
+    state.raiderBox = raiderBox;
+    state.discipleBox = discipleBox;
   }
 
   function updateWaveLife() {
@@ -111,13 +150,14 @@ export function createHorizontalRaid({
     const pct = state.waveTotal > 0 ? (state.waveHp / state.waveTotal) * 100 : 0;
     state.waveLifeFill.style.width = `${pct}%`;
     if (state.waveLifeLabel) {
-      state.waveLifeLabel.textContent = `${Math.round(state.waveHp)}/${Math.round(state.waveTotal)}`;
+      state.waveLifeLabel.textContent = `${Math.round(state.waveHp)}/${Math.round(
+        state.waveTotal
+      )}`;
     }
   }
 
   function removeDisciple(slot) {
-    slot.sprite?.remove();
-    slot.badge?.remove();
+    slot.wrapper?.remove();
     const idx = state.disciples.indexOf(slot);
     if (idx >= 0) state.disciples.splice(idx, 1);
   }
@@ -157,8 +197,7 @@ export function createHorizontalRaid({
   function spawnRaider(stats) {
     const el = document.createElement('div');
     el.className = 'raider-unit';
-    el.style.left = '60%';
-    state.root.appendChild(el);
+    state.raiderBox.appendChild(el);
     state.raiders.push({
       hp: stats.hp,
       damage: stats.damage,
@@ -167,7 +206,6 @@ export function createHorizontalRaid({
       el
     });
   }
-
 
   function updateRaiders(dt) {
     state.raiders.forEach(r => {
@@ -183,6 +221,10 @@ export function createHorizontalRaid({
           applyDamage(target.d, r.damage);
           state.onDamage({ amount: r.damage, source: 'raider' });
           showRaidDamageFloat(target.sprite, r.damage);
+          if (target.hpFill) {
+            const ratio = target.d.currentHp / target.d.maxHp;
+            target.hpFill.style.width = `${Math.max(0, ratio) * 100}%`;
+          }
           runAnimation(r.el, 'attack-flash');
           if (target.d.currentHp <= 0 || target.d.incapacitated) {
             removeDisciple(target);
@@ -214,7 +256,7 @@ export function createHorizontalRaid({
         if (!slot.target) {
           slot.timer = 0;
           slot.sprite?.classList.remove('attacking');
-          if (slot.overlay) slot.overlay.style.height = '0%';
+          if (slot.attackFill) slot.attackFill.style.width = '0%';
           return;
         }
       }
@@ -222,7 +264,7 @@ export function createHorizontalRaid({
       slot.sprite?.classList.add('attacking');
       slot.timer += dt;
       const ratio = Math.min(1, slot.timer / slot.d.attackSpeed);
-      if (slot.overlay) slot.overlay.style.height = `${(1 - ratio) * 100}%`;
+      if (slot.attackFill) slot.attackFill.style.width = `${ratio * 100}%`;
       if (slot.timer >= slot.d.attackSpeed) {
         slot.timer -= slot.d.attackSpeed;
         const r = slot.target;
@@ -233,7 +275,7 @@ export function createHorizontalRaid({
         state.onDamage({ amount: slot.d.damage, source: 'disciple' });
         showRaidDamageFloat(r.el, slot.d.damage, true);
         runAnimation(slot.sprite, 'attack-flash');
-        if (slot.overlay) slot.overlay.style.height = '100%';
+        if (slot.attackFill) slot.attackFill.style.width = '0%';
         if (r.hp === 0) {
           r.el.remove();
           const idx = state.raiders.indexOf(r);
@@ -277,15 +319,11 @@ export function createHorizontalRaid({
     if (!state.active) return;
     state.active = false;
     state.root?.remove();
-    if (state.selectedBadge) {
-      state.selectedBadge.classList.remove('selected');
-      state.selectedBadge = null;
-    }
     state.raiders.length = 0;
     state.disciples.forEach(slot => {
       slot.target = null;
       if (slot.sprite) slot.sprite.classList.remove('attacking');
-      if (slot.overlay) slot.overlay.style.height = '0%';
+      if (slot.attackFill) slot.attackFill.style.width = '0%';
     });
     state.onWaveEnd(state.waveIndex);
     success ? state.onSuccess() : state.onFailure();
@@ -294,7 +332,6 @@ export function createHorizontalRaid({
   function tick(dt) {
     if (!state.active) return;
     spawnLoop(dt);
-    // dt is in milliseconds; use same unit for attack timers
     updateRaiders(dt);
     updateDisciples(dt);
   }
@@ -311,3 +348,4 @@ export function createHorizontalRaid({
     castWaterBurst: waterBurst
   };
 }
+

--- a/style.css
+++ b/style.css
@@ -549,24 +549,38 @@ body.darkenshift-mode .tabsContainer button.active {
     top: 0;
     z-index: 4;
     pointer-events: none;
-}
-.raid-container .disciple-badge {
-    pointer-events: auto;
+    display: flex;
+    flex-direction: column;
 }
 
-.raid-container .fight-line {
+.fight-line {
     position: absolute;
-    left: 50%;
-    top: 0;
-    bottom: 0;
-    width: 2px;
+    left: 0;
+    right: 0;
+    top: 50%;
+    height: 2px;
     background: rgba(255,255,255,0.2);
+}
+
+.raider-container {
+    flex: 1;
+    display: flex;
+    justify-content: center;
+    align-items: flex-end;
+    gap: 8px;
+}
+
+.disciple-container {
+    flex: 1;
+    display: flex;
+    justify-content: center;
+    align-items: flex-start;
+    gap: 16px;
 }
 
 .wave-info {
     position: absolute;
-    /* Leave room for disciple badges */
-    top: 56px;
+    top: 4px;
     left: 50%;
     transform: translateX(-50%);
     display: flex;
@@ -614,8 +628,6 @@ body.darkenshift-mode .tabsContainer button.active {
 }
 
 .raider-unit {
-    position: absolute;
-    bottom: 8px;
     width: 16px;
     height: 16px;
     background: purple;
@@ -626,8 +638,6 @@ body.darkenshift-mode .tabsContainer button.active {
 }
 
 .raid-disciple {
-    position: absolute;
-    bottom: 8px;
     width: 24px;
     height: 24px;
     background-image: url('img/coqui.png');
@@ -643,24 +653,26 @@ body.darkenshift-mode .tabsContainer button.active {
     z-index: 2;
 }
 
-.raid-attack-shadow {
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    width: 100%;
-    height: 0%;
-    background: rgba(0,0,0,0.5);
-    pointer-events: none;
+.raid-attack-shadow,
+.disciple-attack-shadow {
+    display: none;
 }
 
-.disciple-attack-shadow {
-    position: absolute;
-    bottom: 0;
-    left: 0;
+.raid-disciple-wrapper {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    pointer-events: auto;
+}
+
+.raid-disciple-bars {
+    width: 32px;
+}
+
+.raid-disciple-bars .bar {
     width: 100%;
-    height: 0%;
-    background: rgba(0,0,0,0.5);
-    pointer-events: none;
+    height: 4px;
+    margin-top: 2px;
 }
 
 .raid-orb {

--- a/ui/raidBattleOverlay.js
+++ b/ui/raidBattleOverlay.js
@@ -1,5 +1,5 @@
 import { createOverlay } from './overlay.js';
-import { createHorizontalRaid } from '../game/horizontalRaid.js';
+import { createVerticalRaid } from '../game/verticalRaid.js';
 import { castWordOfHaste, toggleReverberation, castWaterBurst } from '../game/orbSpells.js';
 import { sectState } from '../game/state.js';
 import { sectSystem } from '../game/sect.js';
@@ -15,7 +15,7 @@ export function openRaidBattleOverlay({ config, onSuccess = () => {}, onFailure 
   spells.className = 'raid-spell-bar';
   overlay.append(spells);
 
-  const raid = createHorizontalRaid({
+  const raid = createVerticalRaid({
     ...config,
     container: area,
     onSuccess: () => {


### PR DESCRIPTION
## Summary
- display raids vertically with raider and disciple containers
- add HP, Water, and attack progress bars below each disciple
- document vertical raid layout

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fee04cd648326957f5699894a6e3c