### PR TITLE
feat: show sect integrity below season banner

### DIFF
--- a/docs/11-needs.md
+++ b/docs/11-needs.md
@@ -32,5 +32,5 @@
 - Injuries: every injured limb gives –20 mood while injured and for 20 minutes after healing (stacks). Destroyed limbs give –20 mood for the first and –10 for each additional.
 - Incapacitation: –20 mood while incapacitated and for 20 minutes after recovery (stacks).
 - Disciple death: –15 mood to all remaining disciples.
-- Sect integrity is the average mood percentage of all disciples and directly multiplies work speed and metamorph XP.
+- Sect integrity is the average mood percentage of all disciples and directly multiplies work speed and metamorph XP. It is displayed beneath the season banner.
 - Mood is shown as a bar in each disciple's Moodlets tab and an emoji on their badge: 😄 above 100, 🙂 at 75–100, 😐 at 50–74, 🙁 at 25–49, and 😭 below 25.

--- a/game/sect.js
+++ b/game/sect.js
@@ -1035,6 +1035,7 @@ function renderSeasonBanner() {
   if (!banner) return;
   const textEl = banner.querySelector('.season-text');
   const weatherEl = banner.querySelector('.weather-icon');
+  const integrityEl = document.getElementById('sectIntegrityDisplay');
   const idx = sectSystem.seasonIndex;
   const season = seasons[idx];
   setSeasonBackdrop(season.name);
@@ -1043,6 +1044,7 @@ function renderSeasonBanner() {
   const temp = seasonTemps[idx];
   if (textEl) textEl.textContent = `${season.name} Day ${day} (${daysLeft}d) ${temp}°C`;
   if (weatherEl) weatherEl.textContent = sectSystem.weather ? sectSystem.weather.icon : '';
+  if (integrityEl) integrityEl.textContent = `Integrity ${Math.round(sectIntegrity * 100)}%`;
   banner.className = `season-banner ${seasonClasses[idx]}`;
   if (container) {
     seasonClasses.forEach(cls => container.classList.remove(cls));

--- a/index.html
+++ b/index.html
@@ -55,9 +55,12 @@
       <div class="colony-main">
         <div id="colonyMap" class="colony-map">
           <div class="sect-header">
-            <div id="seasonBanner" class="season-banner">
-              <span class="season-text"></span>
-              <span class="weather-icon"></span>
+            <div class="season-info">
+              <div id="seasonBanner" class="season-banner">
+                <span class="season-text"></span>
+                <span class="weather-icon"></span>
+              </div>
+              <div id="sectIntegrityDisplay" class="sect-integrity"></div>
             </div>
             <div id="sectDiscipleList" class="sect-disciple-list"></div>
           </div>

--- a/style.css
+++ b/style.css
@@ -3759,6 +3759,18 @@ body.darkenshift-mode .tabsContainer button.active {
 .season-banner.winter { background: #3399ff; }
 .season-banner .weather-icon { margin-left: 4px; }
 
+.season-info {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+}
+
+.sect-integrity {
+    font-weight: bold;
+    font-size: 0.65rem;
+    color: #fff;
+}
+
 /* Mobile adjustments */
 @media (max-width: 600px) {
   .sect-orb { width: 60px; height: 60px; }


### PR DESCRIPTION
## Summary
- show sect integrity percentage beneath the season banner
- style the new integrity text
- document sect integrity display

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fedcec5a083268491e3fc0e3d6bfe