### PR TITLE
feat: show mood modifiers

### DIFF
--- a/docs/11-needs.md
+++ b/docs/11-needs.md
@@ -34,3 +34,4 @@
 - Disciple death: –15 mood to all remaining disciples.
 - Sect integrity is the average mood percentage of all disciples and directly multiplies work speed and metamorph XP. It is displayed beneath the season banner.
 - Mood is shown as a bar in each disciple's Moodlets tab and an emoji on their badge: 😄 above 100, 🙂 at 75–100, 😐 at 50–74, 🙁 at 25–49, and 😭 below 25.
+- The Moodlets tab lists current mood modifiers such as overcrowding, injuries, and recent deaths.

--- a/game/sect.js
+++ b/game/sect.js
@@ -1474,14 +1474,26 @@ function updateDiscipleMood(d, dt) {
   if (!d.incapTimer) d.incapTimer = 0;
   if (!d.healedInjuryTimers) d.healedInjuryTimers = {};
 
+  d.moodModifiers = [];
   let mood = 100;
   const bohio = sectState.buildings.bohio || 0;
   const diff = sectSystem.disciples.length - bohio;
-  if (diff > 0) mood -= 25 * diff;
-  else if (diff < 0) mood += 10 * -diff;
+  if (diff > 0) {
+    const amount = -25 * diff;
+    mood += amount;
+    d.moodModifiers.push({ label: 'Overcrowded housing', value: amount });
+  } else if (diff < 0) {
+    const amount = 10 * -diff;
+    mood += amount;
+    d.moodModifiers.push({ label: 'Spare housing', value: amount });
+  }
 
   const meta = sectState.discipleMetamorphosis[d.id];
-  if (meta?.stage) mood -= 50 * meta.stage;
+  if (meta?.stage) {
+    const amount = -50 * meta.stage;
+    mood += amount;
+    d.moodModifiers.push({ label: `Metamorphosis stage ${meta.stage}`, value: amount });
+  }
 
   let destroyedCount = 0;
   BODY_PARTS.forEach(p => {
@@ -1490,21 +1502,35 @@ function updateDiscipleMood(d, dt) {
     if (state.tier === 'destroyed') {
       destroyedCount++;
     } else if (state.tier) {
-      mood -= 20;
+      const amount = -20;
+      mood += amount;
+      d.moodModifiers.push({ label: `Injured ${p.label}`, value: amount });
       d.healedInjuryTimers[p.key] = 1200;
     } else if (d.healedInjuryTimers[p.key] > 0) {
-      mood -= 20;
+      const amount = -20;
+      mood += amount;
+      d.moodModifiers.push({ label: `Recently injured ${p.label}`, value: amount });
     }
   });
-  if (destroyedCount > 0) mood -= 20 + (destroyedCount - 1) * 10;
+  if (destroyedCount > 0) {
+    const amount = -(20 + (destroyedCount - 1) * 10);
+    mood += amount;
+    d.moodModifiers.push({ label: 'Destroyed limbs', value: amount });
+  }
 
   if (d.incapacitated) d.incapTimer = 1200;
   if (d.incapTimer > 0) {
-    mood -= 20;
+    const amount = -20;
+    mood += amount;
+    d.moodModifiers.push({ label: 'Incapacitated', value: amount });
     d.incapTimer = Math.max(0, d.incapTimer - dt);
   }
 
-  if (sectSystem.deathMoodPenalty) mood -= sectSystem.deathMoodPenalty;
+  if (sectSystem.deathMoodPenalty) {
+    const amount = -sectSystem.deathMoodPenalty;
+    mood += amount;
+    d.moodModifiers.push({ label: 'Fallen comrade', value: amount });
+  }
 
   d.mood = Math.max(0, Math.min(100, mood));
 }

--- a/script.js
+++ b/script.js
@@ -56,7 +56,6 @@ import {
   calculateStaminaRegen
 } from './utils/stamina.js';
 import { BODY_PARTS } from './game/injury.js';
-import { QUIRKS } from './game/quirks.js';
 import {
   calculateMaxWater,
   calculateWaterRegen
@@ -735,6 +734,22 @@ function updateDiscipleMoodDisplay() {
         const text = row.querySelector('.disciple-bar-text');
         if (text) text.textContent = `${Math.round(d.mood)}/100`;
       }
+      const list = discipleOverlay.box.querySelector('.mood-modifiers');
+      if (list) {
+        list.innerHTML = '';
+        if (d.moodModifiers && d.moodModifiers.length > 0) {
+          d.moodModifiers.forEach(m => {
+            const item = document.createElement('li');
+            const sign = m.value >= 0 ? '+' : '';
+            item.textContent = `${m.label} (${sign}${m.value})`;
+            list.appendChild(item);
+          });
+        } else {
+          const none = document.createElement('li');
+          none.textContent = 'No active mood modifiers';
+          list.appendChild(none);
+        }
+      }
     }
   }
 }
@@ -1220,19 +1235,20 @@ function buildDiscipleMoodletsView(d) {
   const moodBar = createLabeledBar(getMoodEmoji(d.mood), d.mood, 100, '#ffcc4d');
   moodBar.classList.add('mood-bar');
   container.appendChild(moodBar);
-  if (!d.quirks || d.quirks.length === 0) {
-    const none = document.createElement('div');
-    none.textContent = 'No active moodlets';
-    container.appendChild(none);
-    return container;
-  }
   const list = document.createElement('ul');
-  d.quirks.forEach(k => {
-    const item = document.createElement('li');
-    const info = QUIRKS[k];
-    item.textContent = info ? `${info.name} – ${info.description}` : k;
-    list.appendChild(item);
-  });
+  list.className = 'mood-modifiers';
+  if (d.moodModifiers && d.moodModifiers.length > 0) {
+    d.moodModifiers.forEach(m => {
+      const item = document.createElement('li');
+      const sign = m.value >= 0 ? '+' : '';
+      item.textContent = `${m.label} (${sign}${m.value})`;
+      list.appendChild(item);
+    });
+  } else {
+    const none = document.createElement('li');
+    none.textContent = 'No active mood modifiers';
+    list.appendChild(none);
+  }
   container.appendChild(list);
   return container;
 }


### PR DESCRIPTION
## Summary
- track mood modifiers when updating disciple mood
- list active mood modifiers in the Moodlets tab
- document mood modifier display

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689015a91d6c83268bc62daf60e53400