### PR TITLE
feat: enlarge raider sprite with red eyes

### DIFF
--- a/docs/23-raids.md
+++ b/docs/23-raids.md
@@ -18,7 +18,7 @@ Raiders randomly target living disciples from their positions. Disciples remain 
 The raid ends when all waves are cleared or the orb is destroyed. Callbacks are fired at the start and end of each wave along with a final success or failure signal. When night falls the game automatically opens a dedicated raid overlay and begins a raid. Disciples temporarily switch to the "Idle" task so they remain visible in the interface.
 
 The overlay fills the entire screen. Raiders occupy a dedicated top container with the current wave life bar. Disciples stand in a row across the bottom container and show their HP, Water and attack progress bars underneath each sprite. Damage numbers briefly float above disciples, raiders and the orb whenever they are hit.
-Damage floats use red text when disciples take damage and white when raiders are struck. Raiders are drawn with a thin black border so each unit is clearly visible.
+Damage floats use red text when disciples take damage and white when raiders are struck. Raiders appear as round purple orbs with menacing red eyes and a thin black border so each unit is clearly visible.
 
 
 A life bar at the top shows the remaining life of the current wave in red. The label displays the exact HP left along with the current wave number so players can track their progress.

--- a/style.css
+++ b/style.css
@@ -566,7 +566,7 @@ body.darkenshift-mode .tabsContainer button.active {
     flex: 1;
     display: flex;
     justify-content: center;
-    align-items: flex-end;
+    align-items: center;
     gap: 8px;
 }
 
@@ -628,13 +628,33 @@ body.darkenshift-mode .tabsContainer button.active {
 }
 
 .raider-unit {
-    width: 16px;
-    height: 16px;
+    width: 32px;
+    height: 32px;
     background: purple;
-    border-radius: 4px;
+    border-radius: 50%;
     border: 1px solid #000;
     pointer-events: none;
     overflow: hidden;
+    position: relative;
+}
+
+.raider-unit::before,
+.raider-unit::after {
+    content: '';
+    position: absolute;
+    top: 10px;
+    width: 6px;
+    height: 6px;
+    background: red;
+    border-radius: 50%;
+}
+
+.raider-unit::before {
+    left: 8px;
+}
+
+.raider-unit::after {
+    right: 8px;
 }
 
 .raid-disciple {


### PR DESCRIPTION
## Summary
- Center raider units within their container
- Double raider size, make sprite circular, and add glowing red eyes
- Document new raider appearance

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689021c474dc83269f704edd10622028