### PR TITLE
style: increase raid disciple spacing

### DIFF
--- a/style.css
+++ b/style.css
@@ -568,6 +568,7 @@ body.darkenshift-mode .tabsContainer button.active {
     justify-content: center;
     align-items: flex-end;
     gap: 8px;
+    padding-bottom: 16px;
 }
 
 .disciple-container {
@@ -575,7 +576,8 @@ body.darkenshift-mode .tabsContainer button.active {
     display: flex;
     justify-content: center;
     align-items: flex-start;
-    gap: 16px;
+    gap: 24px;
+    padding-top: 16px;
 }
 
 .wave-info {


### PR DESCRIPTION
## Summary
- add bottom padding to raid container and top padding to disciple container for more separation from fight line
- widen gap between disciples in raids

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890221180108326acfd669d420d6143