### PR TITLE
fix: center raid water orb

### DIFF
--- a/style.css
+++ b/style.css
@@ -678,7 +678,8 @@ body.darkenshift-mode .tabsContainer button.active {
 .raid-orb {
     position: absolute;
     bottom: 8px;
-    left: 8px;
+    left: 50%;
+    transform: translateX(-50%);
     width: 48px;
     height: 48px;
     overflow: hidden;


### PR DESCRIPTION
## Summary
- center water orb in raid overlay

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689022256d508326b1c6cc07bbad47da