### PR TITLE
feat: add raid row highlights

### DIFF
--- a/docs/23-raids.md
+++ b/docs/23-raids.md
@@ -18,6 +18,7 @@ Raiders randomly target living disciples from their positions. Disciples remain 
 The raid ends when all waves are cleared or the orb is destroyed. Callbacks are fired at the start and end of each wave along with a final success or failure signal. When night falls the game automatically opens a dedicated raid overlay and begins a raid. Disciples temporarily switch to the "Idle" task so they remain visible in the interface.
 
 The overlay fills the entire screen. Raiders occupy a dedicated top container with the current wave life bar. Disciples stand in a row across the bottom container and show their HP, Water and attack progress bars underneath each sprite. Damage numbers briefly float above disciples, raiders and the orb whenever they are hit.
+Faint horizontal bands behind each row make the raider and disciple lines easier to see against the dark field.
 Bars beneath disciples have been thickened and outlined so their colors remain visible even against busy backgrounds.
 
 

--- a/style.css
+++ b/style.css
@@ -569,6 +569,7 @@ body.darkenshift-mode .tabsContainer button.active {
     align-items: center;
     gap: 8px;
     padding-bottom: 16px;
+    background: rgba(255, 255, 255, 0.1);
 }
 
 .disciple-container {
@@ -578,6 +579,7 @@ body.darkenshift-mode .tabsContainer button.active {
     align-items: flex-start;
     gap: 24px;
     padding-top: 16px;
+    background: rgba(255, 255, 255, 0.1);
 }
 
 .wave-info {


### PR DESCRIPTION
## Summary
- add subtle background bands behind raider and disciple rows in raid overlay
- document raid overlay row highlighting

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689025a375048326b6a41528789e19b5