### PR TITLE
feat: add damage ranges

### DIFF
--- a/docs/23-raids.md
+++ b/docs/23-raids.md
@@ -13,7 +13,7 @@ A typical raid now consists of **five** waves. Each wave spawns a single raider 
 
 The module handles spawning raiders and resolving combat. If the orb's water reaches zero the raid fails immediately.
 
-Raiders randomly target living disciples from their positions. Disciples remain in place and always attack the first raider in line. Several disciples may assault the same target at once, each dealing damage whenever their personal attack timer completes. Each defender strikes once every 5 seconds for 1 damage before any combat or metamorphosis bonuses are applied. Attacking disciples grow slightly larger and a dark overlay shrinks to indicate progress toward their next strike. Whenever a disciple or raider lands an attack, their sprite briefly flashes white twice.
+Raiders randomly target living disciples from their positions. Disciples remain in place and always attack the first raider in line. Several disciples may assault the same target at once, each dealing damage whenever their personal attack timer completes. Each defender strikes once every 5 seconds, dealing a random amount between 50% and 150% of their base damage before any combat or metamorphosis bonuses are applied. Attacking disciples grow slightly larger and a dark overlay shrinks to indicate progress toward their next strike. Whenever a disciple or raider lands an attack, their sprite briefly flashes white twice.
 
 The raid ends when all waves are cleared or the orb is destroyed. Callbacks are fired at the start and end of each wave along with a final success or failure signal. When night falls the game automatically opens a dedicated raid overlay and begins a raid. Disciples temporarily switch to the "Idle" task so they remain visible in the interface.
 

--- a/game/disciple.js
+++ b/game/disciple.js
@@ -57,6 +57,8 @@ export default class Disciple {
     const stage = sectState.discipleMetamorphosis[this.id]?.stage || 0;
     const stageBonus = stage * STAGE_BONUS.attack;
     this.damage = this.combatLevel + stageBonus;
+    this.minDamage = Math.max(1, Math.floor(this.damage * 0.5));
+    this.maxDamage = Math.ceil(this.damage * 1.5);
     this.attackSpeed = 5000;
     this.defense = this.combatLevel;
   }

--- a/game/enemy.js
+++ b/game/enemy.js
@@ -10,7 +10,10 @@ class Enemy  {
     // We expect the caller to supply these values
     this.maxHp = config.maxHp;
     this.currentHp = this.maxHp;
-    this.damage = config.damage;
+    this.damage = config.damage || 1;
+    // establish a damage range around the base amount
+    this.minDamage = config.minDamage ?? Math.max(1, Math.floor(this.damage * 0.5));
+    this.maxDamage = config.maxDamage ?? Math.ceil(this.damage * 1.5);
     this.xp = config.xp;
     this.attackInterval = config.attackInterval || 10000;
     this.abilities = config.abilities || [];

--- a/game/enemySpawning.js
+++ b/game/enemySpawning.js
@@ -13,8 +13,9 @@ export function calculateEnemyHp(stage, world, isBoss = false) {
 
 export function calculateEnemyBasicDamage(stage, world, opts = {}) {
   const { damage } = calculateRelativeEnemyStats(stage, world, opts);
-  const maxDamage = Math.max(damage, 1);
-  const minDamage = Math.floor(0.5 * maxDamage) + 1;
+  const base = Math.max(damage, 1);
+  const minDamage = Math.max(1, Math.floor(base * 0.5));
+  const maxDamage = Math.max(minDamage, Math.ceil(base * 1.5));
   return { minDamage, maxDamage };
 }
 

--- a/game/verticalRaid.js
+++ b/game/verticalRaid.js
@@ -198,9 +198,14 @@ export function createVerticalRaid({
     const el = document.createElement('div');
     el.className = 'raider-unit';
     state.raiderBox.appendChild(el);
+    const base = stats.damage;
+    const minDamage = Math.max(1, Math.floor(base * 0.5));
+    const maxDamage = Math.max(minDamage, Math.ceil(base * 1.5));
     state.raiders.push({
       hp: stats.hp,
-      damage: stats.damage,
+      damage: base,
+      minDamage,
+      maxDamage,
       attackSpeed: stats.attackSpeed,
       timer: 0,
       el
@@ -218,9 +223,10 @@ export function createVerticalRaid({
         r.timer -= r.attackSpeed;
         if (living.length > 0) {
           const target = living[Math.floor(Math.random() * living.length)];
-          applyDamage(target.d, r.damage);
-          state.onDamage({ amount: r.damage, source: 'raider' });
-          showRaidDamageFloat(target.sprite, r.damage);
+          const dmg = Math.floor(Math.random() * (r.maxDamage - r.minDamage + 1)) + r.minDamage;
+          applyDamage(target.d, dmg);
+          state.onDamage({ amount: dmg, source: 'raider' });
+          showRaidDamageFloat(target.sprite, dmg);
           if (target.hpFill) {
             const ratio = target.d.currentHp / target.d.maxHp;
             target.hpFill.style.width = `${Math.max(0, ratio) * 100}%`;
@@ -230,12 +236,13 @@ export function createVerticalRaid({
             removeDisciple(target);
           }
         } else {
-          state.orb.current = Math.max(0, state.orb.current - r.damage);
-          state.onDamage({ amount: r.damage, source: 'raider' });
+          const dmg = Math.floor(Math.random() * (r.maxDamage - r.minDamage + 1)) + r.minDamage;
+          state.orb.current = Math.max(0, state.orb.current - dmg);
+          state.onDamage({ amount: dmg, source: 'raider' });
           if (state.orbFill) {
             state.orbFill.style.height = `${(state.orb.current / state.orb.max) * 100}%`;
           }
-          showRaidDamageFloat(state.orbEl, r.damage);
+          showRaidDamageFloat(state.orbEl, dmg);
           runAnimation(r.el, 'attack-flash');
           if (state.orb.current <= 0) end(false);
         }
@@ -268,12 +275,13 @@ export function createVerticalRaid({
       if (slot.timer >= slot.d.attackSpeed) {
         slot.timer -= slot.d.attackSpeed;
         const r = slot.target;
+        const dmg = Math.floor(Math.random() * (slot.d.maxDamage - slot.d.minDamage + 1)) + slot.d.minDamage;
         const before = r.hp;
-        r.hp = Math.max(0, r.hp - slot.d.damage);
+        r.hp = Math.max(0, r.hp - dmg);
         const dealt = before - r.hp;
         state.waveHp = Math.max(0, state.waveHp - dealt);
-        state.onDamage({ amount: slot.d.damage, source: 'disciple' });
-        showRaidDamageFloat(r.el, slot.d.damage, true);
+        state.onDamage({ amount: dealt, source: 'disciple' });
+        showRaidDamageFloat(r.el, dealt, true);
         runAnimation(slot.sprite, 'attack-flash');
         if (slot.attackFill) slot.attackFill.style.width = '0%';
         if (r.hp === 0) {

--- a/test/damage-range.test.js
+++ b/test/damage-range.test.js
@@ -1,0 +1,19 @@
+/* global describe, it */
+import { expect } from 'chai';
+import Disciple from '../game/disciple.js';
+import Enemy from '../game/enemy.js';
+
+describe('damage range assignment', () => {
+  it('assigns min and max damage to disciples', () => {
+    const d = new Disciple({ combatLevel: 4 });
+    const base = d.damage;
+    expect(d.minDamage).to.equal(Math.floor(base * 0.5));
+    expect(d.maxDamage).to.equal(Math.ceil(base * 1.5));
+  });
+
+  it('assigns min and max damage to enemies', () => {
+    const e = new Enemy(1, 1, { damage: 8 });
+    expect(e.minDamage).to.equal(Math.floor(8 * 0.5));
+    expect(e.maxDamage).to.equal(Math.ceil(8 * 1.5));
+  });
+});


### PR DESCRIPTION
## Summary
- add 50%-150% damage range to enemies and disciples
- randomize raid combat using new min/max ranges
- document raid damage variance and add tests for range assignment

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68902277d80083269857ad1f6f1cc0ed