### PR TITLE
feat: add raid fight-line gradient

### DIFF
--- a/docs/23-raids.md
+++ b/docs/23-raids.md
@@ -17,7 +17,7 @@ Raiders randomly target living disciples from their positions. Disciples remain 
 
 The raid ends when all waves are cleared or the orb is destroyed. Callbacks are fired at the start and end of each wave along with a final success or failure signal. When night falls the game automatically opens a dedicated raid overlay and begins a raid. Disciples temporarily switch to the "Idle" task so they remain visible in the interface.
 
-The overlay fills the entire screen. Raiders occupy a dedicated top container with the current wave life bar. Disciples stand in a row across the bottom container and show their HP, Water and attack progress bars underneath each sprite. Damage numbers briefly float above disciples, raiders and the orb whenever they are hit.
+The overlay fills the entire screen. Raiders occupy a dedicated top container with the current wave life bar. Disciples stand in a row across the bottom container and show their HP, Water and attack progress bars underneath each sprite. A subtle vertical gradient brightens toward the fight line to draw focus while damage numbers briefly float above disciples, raiders and the orb whenever they are hit.
 Bars beneath disciples have been thickened and outlined so their colors remain visible even against busy backgrounds.
 
 

--- a/style.css
+++ b/style.css
@@ -551,6 +551,12 @@ body.darkenshift-mode .tabsContainer button.active {
     pointer-events: none;
     display: flex;
     flex-direction: column;
+    background: linear-gradient(
+        to bottom,
+        rgba(0, 0, 0, 0.5) 0%,
+        rgba(255, 255, 255, 0.1) 50%,
+        rgba(0, 0, 0, 0.5) 100%
+    );
 }
 
 .fight-line {


### PR DESCRIPTION
## Summary
- add vertical gradient that brightens toward raid fight line
- document raid screen gradient focus

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68902620a11c83269ee2772e8fb050af