### PR TITLE
feat: soften raid bars with gradients and shadows

### DIFF
--- a/docs/23-raids.md
+++ b/docs/23-raids.md
@@ -19,6 +19,7 @@ The raid ends when all waves are cleared or the orb is destroyed. Callbacks are 
 
 The overlay fills the entire screen. Raiders occupy a dedicated top container with the current wave life bar. Disciples stand in a row across the bottom container and show their HP, Water and attack progress bars underneath each sprite. Damage numbers briefly float above disciples, raiders and the orb whenever they are hit.
 Bars beneath disciples have been thickened and outlined so their colors remain visible even against busy backgrounds.
+These bars now feature rounded corners, subtle inset shadows and dual-tone fills for added depth.
 
 
 Damage floats use red text when disciples take damage and white when raiders are struck. Raiders appear as round purple orbs with menacing red eyes and a thin black border so each unit is clearly visible.

--- a/game/ui.js
+++ b/game/ui.js
@@ -92,12 +92,31 @@ export function updatePlayerStatsUI(elems = {}, data = {}) {
 
 export function renderCombatDisciples() {}
 
+function shadeColor(color, percent) {
+  let col = color.startsWith('#') ? color.slice(1) : color;
+  if (col.length === 3) col = col.split('').map(c => c + c).join('');
+  const num = parseInt(col, 16);
+  const amt = Math.round(2.55 * percent);
+  const r = (num >> 16) + amt;
+  const g = ((num >> 8) & 0x00ff) + amt;
+  const b = (num & 0x00ff) + amt;
+  return `#${(
+    0x1000000 +
+    (r < 255 ? (r < 0 ? 0 : r) : 255) * 0x10000 +
+    (g < 255 ? (g < 0 ? 0 : g) : 255) * 0x100 +
+    (b < 255 ? (b < 0 ? 0 : b) : 255)
+  )
+    .toString(16)
+    .slice(1)}`;
+}
+
 export function makeBar(value, max, color) {
   const bar = document.createElement('div');
   bar.className = 'bar';
   const fill = document.createElement('div');
   fill.className = 'bar-fill';
-  fill.style.background = color;
+  const darker = shadeColor(color, -20);
+  fill.style.background = `linear-gradient(to bottom, ${color}, ${darker})`;
   fill.style.width = `${Math.min(100, (value / max) * 100)}%`;
   bar.appendChild(fill);
   return bar;

--- a/style.css
+++ b/style.css
@@ -530,15 +530,17 @@ body.darkenshift-mode .tabsContainer button.active {
     height: 4px;
     background: #333;
     border: 1px solid #e74c3c;
-    border-radius: 4px;
+    border-radius: 8px;
     overflow: hidden;
+    box-shadow: inset 0 0 2px rgba(0,0,0,0.6);
 }
 
 .raid-life-fill {
     height: 100%;
     width: 100%;
-    background: #e74c3c;
+    background: linear-gradient(to bottom, #e74c3c, #b33224);
     transition: width 0.3s;
+    border-radius: 8px 0 0 8px;
 }
 
 .raid-container {
@@ -604,8 +606,9 @@ body.darkenshift-mode .tabsContainer button.active {
     height: 10px;
     background: #333;
     border: 1px solid #e74c3c;
-    border-radius: 4px;
+    border-radius: 8px;
     overflow: hidden;
+    box-shadow: inset 0 0 2px rgba(0,0,0,0.6);
 }
 
 .wave-life-fill {
@@ -614,8 +617,9 @@ body.darkenshift-mode .tabsContainer button.active {
     left: 0;
     height: 100%;
     width: 100%;
-    background: #e74c3c;
+    background: linear-gradient(to bottom, #e74c3c, #b33224);
     transition: width 0.3s;
+    border-radius: 8px 0 0 8px;
 }
 
 .wave-life-label {
@@ -698,6 +702,9 @@ body.darkenshift-mode .tabsContainer button.active {
     background: #444;
     border: 1px solid #222;
     position: relative;
+    border-radius: 8px;
+    overflow: hidden;
+    box-shadow: inset 0 0 2px rgba(0,0,0,0.6);
 }
 
 .raid-disciple-bars .bar-fill {
@@ -706,6 +713,7 @@ body.darkenshift-mode .tabsContainer button.active {
     left: 0;
     height: 100%;
     z-index: 1;
+    border-radius: 8px 0 0 8px;
 }
 
 .raid-orb {


### PR DESCRIPTION
## Summary
- Round raid bars with 8px corners and inset shadows for depth
- Apply dual-tone gradients for bar fills via reusable shading helper
- Document new raid bar styling

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689025d66bc08326b04262a68b7bf9ca