### PR TITLE
feat: soften raid background

### DIFF
--- a/docs/23-raids.md
+++ b/docs/23-raids.md
@@ -1,6 +1,6 @@
 # 23 – Raids
 
-Night raids play out as a vertical autobattler. Raiders gather above the fight line and strike from above while disciples line up below to defend the Water Orb.
+Night raids play out as a vertical autobattler. Raiders gather above a soft gradient band marking the fight boundary while disciples line up below to defend the Water Orb.
 
 Raid behaviour is entirely data‑driven. A raid is started by calling `startRaid(config)` where `config` provides:
 
@@ -18,8 +18,7 @@ Raiders randomly target living disciples from their positions. Disciples remain 
 The raid ends when all waves are cleared or the orb is destroyed. Callbacks are fired at the start and end of each wave along with a final success or failure signal. When night falls the game automatically opens a dedicated raid overlay and begins a raid. Disciples temporarily switch to the "Idle" task so they remain visible in the interface.
 
 
-The overlay fills the entire screen. Raiders occupy a dedicated top container with the current wave life bar. Disciples stand in a row across the bottom container and show their HP, Water and attack progress bars underneath each sprite. A subtle vertical gradient brightens toward the fight line to draw focus while damage numbers briefly float above disciples, raiders and the orb whenever they are hit.
-Faint horizontal bands behind each row make the raider and disciple lines easier to see against the dark field.
+The overlay fills the entire screen. Raiders occupy a dedicated top container with the current wave life bar. Disciples stand in a row across the bottom container and show their HP, Water and attack progress bars underneath each sprite. The battlefield uses a deep water tint from the theme with a faint vignette and ripple texture. A translucent gradient band replaces the old divider, and pale green and blue zone tints sit behind the raider and orb areas to keep units readable while damage numbers briefly float above disciples, raiders and the orb whenever they are hit.
 Bars beneath disciples have been thickened and outlined so their colors remain visible even against busy backgrounds.
 These bars now feature rounded corners, subtle inset shadows and dual-tone fills for added depth.
 

--- a/game/verticalRaid.js
+++ b/game/verticalRaid.js
@@ -64,10 +64,6 @@ export function createVerticalRaid({
     discipleBox.className = 'disciple-container';
     root.appendChild(discipleBox);
 
-    const line = document.createElement('div');
-    line.className = 'fight-line';
-    root.appendChild(line);
-
     const info = document.createElement('div');
     info.className = 'wave-info';
     const waveLabel = document.createElement('div');

--- a/style.css
+++ b/style.css
@@ -34,6 +34,15 @@ body {
     --core-accent: #7fafff;
     --core-text: #e0e0f0;
     --core-glow: rgba(127, 175, 255, 0.2);
+    --raid-pond-bg: color-mix(in srgb, var(--core-bg) 80%, var(--core-accent) 20%);
+    --raid-band-color: color-mix(in srgb, var(--core-accent) 40%, transparent);
+    --raid-zone-orb: color-mix(in srgb, var(--core-accent) 20%, transparent);
+    --raid-zone-fight: color-mix(in srgb, var(--verdantia-jade) 20%, transparent);
+    --raid-panel-tint: color-mix(in srgb, var(--core-bg) 70%, transparent);
+    --raid-texture: url('/img/water-mid.png');
+    --raid-texture-opacity: 0.08;
+    --raid-band-height: 12px;
+    --raid-vignette-blur: 80px;
     --season-start: rgba(80,160,80,0.9);
     --season-end: rgba(30,70,30,1.0);
     --verdantia-base: #293a2c;
@@ -528,17 +537,17 @@ body.darkenshift-mode .tabsContainer button.active {
     right: 4px;
     bottom: 2px;
     height: 4px;
-    background: #333;
-    border: 1px solid #e74c3c;
+    background: var(--core-bg);
+    border: 1px solid var(--core-accent);
     border-radius: 8px;
     overflow: hidden;
-    box-shadow: inset 0 0 2px rgba(0,0,0,0.6);
+    box-shadow: inset 0 0 2px var(--core-bg);
 }
 
 .raid-life-fill {
     height: 100%;
     width: 100%;
-    background: linear-gradient(to bottom, #e74c3c, #b33224);
+    background: linear-gradient(to bottom, var(--core-accent), var(--core-border));
     transition: width 0.3s;
     border-radius: 8px 0 0 8px;
 }
@@ -553,21 +562,30 @@ body.darkenshift-mode .tabsContainer button.active {
     pointer-events: none;
     display: flex;
     flex-direction: column;
-    background: linear-gradient(
-        to bottom,
-        rgba(0, 0, 0, 0.5) 0%,
-        rgba(255, 255, 255, 0.1) 50%,
-        rgba(0, 0, 0, 0.5) 100%
-    );
+    background: var(--raid-pond-bg);
+    box-shadow: inset 0 0 var(--raid-vignette-blur) var(--core-bg);
+    position: relative;
 }
 
-.fight-line {
+.raid-container::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: var(--raid-texture) center/cover no-repeat;
+    opacity: var(--raid-texture-opacity);
+    pointer-events: none;
+}
+
+.raid-container::after {
+    content: '';
     position: absolute;
     left: 0;
     right: 0;
     top: 50%;
-    height: 2px;
-    background: rgba(255,255,255,0.2);
+    height: var(--raid-band-height);
+    transform: translateY(-50%);
+    background: linear-gradient(to bottom, transparent, var(--raid-band-color), transparent);
+    pointer-events: none;
 }
 
 .raider-container {
@@ -577,7 +595,7 @@ body.darkenshift-mode .tabsContainer button.active {
     align-items: center;
     gap: 8px;
     padding-bottom: 16px;
-    background: rgba(255, 255, 255, 0.1);
+    background: var(--raid-zone-fight);
 }
 
 .disciple-container {
@@ -587,7 +605,7 @@ body.darkenshift-mode .tabsContainer button.active {
     align-items: flex-start;
     gap: 24px;
     padding-top: 16px;
-    background: rgba(255, 255, 255, 0.1);
+    background: var(--raid-zone-orb);
 }
 
 .wave-info {
@@ -599,9 +617,12 @@ body.darkenshift-mode .tabsContainer button.active {
     gap: 6px;
     align-items: center;
     pointer-events: none;
-    color: #fff;
+    color: var(--core-text);
     font-size: 0.8rem;
-    text-shadow: 0 0 2px #000;
+    text-shadow: 0 0 2px var(--core-bg);
+    background: var(--raid-panel-tint);
+    border-radius: 8px;
+    padding: 2px 6px;
 }
 
 .wave-count {
@@ -612,11 +633,11 @@ body.darkenshift-mode .tabsContainer button.active {
     position: relative;
     width: 160px;
     height: 10px;
-    background: #333;
-    border: 1px solid #e74c3c;
+    background: var(--core-bg);
+    border: 1px solid var(--core-accent);
     border-radius: 8px;
     overflow: hidden;
-    box-shadow: inset 0 0 2px rgba(0,0,0,0.6);
+    box-shadow: inset 0 0 2px var(--core-bg);
 }
 
 .wave-life-fill {
@@ -625,7 +646,7 @@ body.darkenshift-mode .tabsContainer button.active {
     left: 0;
     height: 100%;
     width: 100%;
-    background: linear-gradient(to bottom, #e74c3c, #b33224);
+    background: linear-gradient(to bottom, var(--core-accent), var(--core-border));
     transition: width 0.3s;
     border-radius: 8px 0 0 8px;
 }
@@ -912,8 +933,8 @@ body.darkenshift-mode .tabsContainer button.active {
     display: flex;
     flex-direction: column;
     padding: 0;
-    background: none;
-    border: none;
+    background: var(--raid-panel-tint);
+    border: 1px solid var(--core-border);
 }
 
 .raid-battle-area {
@@ -927,6 +948,9 @@ body.darkenshift-mode .tabsContainer button.active {
     gap: 8px;
     justify-content: center;
     margin-top: 8px;
+    background: var(--raid-panel-tint);
+    border-radius: 8px;
+    padding: 4px 8px;
 }
 
 #battle-container {


### PR DESCRIPTION
## Summary
- replace raid's hard divider with gradient band and pond-themed backdrop
- use theme colors for zone bands and translucent panels
- document updated raid visuals

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890285909588326bb802fc7042c95be