### PR TITLE
feat: center raid orb and drop fight line

### DIFF
--- a/docs/23-raids.md
+++ b/docs/23-raids.md
@@ -1,6 +1,6 @@
 # 23 – Raids
 
-Night raids play out as a vertical autobattler. Raiders gather above the fight line and strike from above while disciples line up below to defend the Water Orb.
+Night raids play out as a vertical autobattler. Raiders gather above and strike from above while disciples line up below to defend the Water Orb, which hovers at the center of the field.
 
 Raid behaviour is entirely data‑driven. A raid is started by calling `startRaid(config)` where `config` provides:
 
@@ -18,7 +18,7 @@ Raiders randomly target living disciples from their positions. Disciples remain 
 The raid ends when all waves are cleared or the orb is destroyed. Callbacks are fired at the start and end of each wave along with a final success or failure signal. When night falls the game automatically switches to a dedicated raid tab and begins a raid. Disciples temporarily switch to the "Idle" task so they remain visible in the interface.
 
 
-The overlay fills the entire screen. Raiders occupy a dedicated top container with the current wave life bar. Disciples stand in a row across the bottom container and show their HP, Water and attack progress bars underneath each sprite. A subtle vertical gradient brightens toward the fight line to draw focus while damage numbers briefly float above disciples, raiders and the orb whenever they are hit.
+The overlay fills the entire screen. Raiders occupy a dedicated top container with the current wave life bar. Disciples stand in a row across the bottom container and show their HP, Water and attack progress bars underneath each sprite. A subtle vertical gradient brightens toward the orb to draw focus while damage numbers briefly float above disciples, raiders and the orb whenever they are hit.
 Faint horizontal bands behind each row make the raider and disciple lines easier to see against the dark field.
 Bars beneath disciples have been thickened and outlined so their colors remain visible even against busy backgrounds.
 These bars now feature rounded corners, subtle inset shadows and dual-tone fills for added depth.

--- a/game/verticalRaid.js
+++ b/game/verticalRaid.js
@@ -64,10 +64,6 @@ export function createVerticalRaid({
     discipleBox.className = 'disciple-container';
     root.appendChild(discipleBox);
 
-    const line = document.createElement('div');
-    line.className = 'fight-line';
-    root.appendChild(line);
-
     const info = document.createElement('div');
     info.className = 'wave-info';
     const waveLabel = document.createElement('div');

--- a/style.css
+++ b/style.css
@@ -561,15 +561,6 @@ body.darkenshift-mode .tabsContainer button.active {
     );
 }
 
-.fight-line {
-    position: absolute;
-    left: 0;
-    right: 0;
-    top: 50%;
-    height: 2px;
-    background: rgba(255,255,255,0.2);
-}
-
 .raider-container {
     flex: 1;
     display: flex;
@@ -726,9 +717,9 @@ body.darkenshift-mode .tabsContainer button.active {
 
 .raid-orb {
     position: absolute;
-    bottom: 8px;
+    top: 50%;
     left: 50%;
-    transform: translateX(-50%);
+    transform: translate(-50%, -50%);
     width: 48px;
     height: 48px;
     overflow: hidden;


### PR DESCRIPTION
## Summary
- remove raid fight line element and style
- center the raid orb in the battle area
- document updated layout

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890ab9068bc83269bd7823259066805