### PR TITLE
feat: add metamorph mastery upgrades

### DIFF
--- a/docs/21-metamorphosis-ui.md
+++ b/docs/21-metamorphosis-ui.md
@@ -49,4 +49,4 @@ Integrate a Taino‑inspired frog glyph around the icon for ambient feedback.
 - Progress rings feature a lilac to teal gradient with a subtle glow.
 - Progress numbers appear on semi-transparent parchment panels.
 - Training rooms unlock after obtaining Undead Nectar, letting disciples be assigned from this panel.
-- When mastery levels are ready, a Level Up button appears beneath the rings to choose from three placeholder upgrades.
+- When mastery levels are ready, a Level Up button appears beneath the rings to choose from three random upgrades.

--- a/docs/26-metamorph-mastery-upgrades.md
+++ b/docs/26-metamorph-mastery-upgrades.md
@@ -1,0 +1,25 @@
+# 26 – Metamorph Mastery Upgrades
+
+Each mastery level grants the disciple a choice between three random upgrades. Upgrades are divided by rarity.
+
+## Common (70%)
+- 10% melee damage
+- 10% spell potency
+- 10% crit damage
+- 10% work speed
+- 10% metamorph speed
+
+## Uncommon (20%)
+- 5 base mood
+- 10% attack speed
+- 10% max water
+- 5% crit chance
+- 20% metamorph speed
+- Reduced water spell cost 10%
+
+## Rare (9%)
+- 40% metamorph speed
+- 20% max water
+- Water barrier spell: reduces damage by 30% for 15 seconds and costs 30 water (30 sec cooldown)
+- Iron tongue spell
+- Blizzard spell: slows all enemies and deals \(10 × 0.10 potency damage per sec\) for 5 seconds (10 sec cooldown)

--- a/game/metamorphMastery.js
+++ b/game/metamorphMastery.js
@@ -24,7 +24,8 @@ export function ensureMeta(id) {
       stage: 0,
       masteryXp: 0,
       masteryLevel: 0,
-      masteryPending: false
+      masteryPending: false,
+      upgrades: []
     };
   } else {
     const meta = sectState.discipleMetamorphosis[id];
@@ -32,6 +33,7 @@ export function ensureMeta(id) {
     if (meta.masteryLevel === undefined)
       meta.masteryLevel = getMasteryProgress(meta.masteryXp).level;
     if (meta.masteryPending === undefined) meta.masteryPending = false;
+    if (!Array.isArray(meta.upgrades)) meta.upgrades = [];
   }
 }
 

--- a/game/metamorphMasteryUpgrades.js
+++ b/game/metamorphMasteryUpgrades.js
@@ -1,0 +1,175 @@
+import { calculateMaxWater } from '../utils/water.js';
+
+// Upgrade definitions grouped by rarity
+export const UPGRADES = [
+  // Common
+  {
+    id: 'melee-damage-10',
+    name: '10% melee damage',
+    rarity: 'common',
+    apply(d) {
+      d.meleeDamageMult = (d.meleeDamageMult || 1) * 1.1;
+    }
+  },
+  {
+    id: 'spell-potency-10',
+    name: '10% spell potency',
+    rarity: 'common',
+    apply(d) {
+      d.spellPotency = (d.spellPotency || 1) * 1.1;
+    }
+  },
+  {
+    id: 'crit-damage-10',
+    name: '10% crit damage',
+    rarity: 'common',
+    apply(d) {
+      d.critDamageMult = (d.critDamageMult || 1) * 1.1;
+    }
+  },
+  {
+    id: 'work-speed-10',
+    name: '10% work speed',
+    rarity: 'common',
+    apply(d) {
+      d.workSpeedMult = (d.workSpeedMult || 1) * 1.1;
+    }
+  },
+  {
+    id: 'metamorph-speed-10',
+    name: '10% metamorph speed',
+    rarity: 'common',
+    apply(d) {
+      d.metamorphSpeedMult = (d.metamorphSpeedMult || 1) * 1.1;
+    }
+  },
+
+  // Uncommon
+  {
+    id: 'base-mood-5',
+    name: '5 base mood',
+    rarity: 'uncommon',
+    apply(d) {
+      d.baseMoodBonus = (d.baseMoodBonus || 0) + 5;
+    }
+  },
+  {
+    id: 'attack-speed-10',
+    name: '10% attack speed',
+    rarity: 'uncommon',
+    apply(d) {
+      d.attackSpeedMult = (d.attackSpeedMult || 1) * 1.1;
+    }
+  },
+  {
+    id: 'max-water-10',
+    name: '10% max water',
+    rarity: 'uncommon',
+    apply(d) {
+      d.maxWaterBonus = (d.maxWaterBonus || 0) + calculateMaxWater(0) * 0.1;
+    }
+  },
+  {
+    id: 'crit-chance-5',
+    name: '5% crit chance',
+    rarity: 'uncommon',
+    apply(d) {
+      d.critChanceBonus = (d.critChanceBonus || 0) + 0.05;
+    }
+  },
+  {
+    id: 'metamorph-speed-20',
+    name: '20% metamorph speed',
+    rarity: 'uncommon',
+    apply(d) {
+      d.metamorphSpeedMult = (d.metamorphSpeedMult || 1) * 1.2;
+    }
+  },
+  {
+    id: 'water-spell-cost-10',
+    name: 'Reduced water spell cost 10%',
+    rarity: 'uncommon',
+    apply(d) {
+      d.waterSpellCostMult = (d.waterSpellCostMult || 1) * 0.9;
+    }
+  },
+
+  // Rare
+  {
+    id: 'metamorph-speed-40',
+    name: '40% metamorph speed',
+    rarity: 'rare',
+    apply(d) {
+      d.metamorphSpeedMult = (d.metamorphSpeedMult || 1) * 1.4;
+    }
+  },
+  {
+    id: 'max-water-20',
+    name: '20% max water',
+    rarity: 'rare',
+    apply(d) {
+      d.maxWaterBonus = (d.maxWaterBonus || 0) + calculateMaxWater(0) * 0.2;
+    }
+  },
+  {
+    id: 'water-barrier-spell',
+    name: 'Water barrier spell',
+    rarity: 'rare',
+    apply(d) {
+      d.waterBarrierSpell = true;
+    }
+  },
+  {
+    id: 'iron-tongue-spell',
+    name: 'Iron tongue spell',
+    rarity: 'rare',
+    apply(d) {
+      d.ironTongueSpell = true;
+    }
+  },
+  {
+    id: 'blizzard-spell',
+    name: 'Blizzard spell',
+    rarity: 'rare',
+    apply(d) {
+      d.blizzardSpell = true;
+    }
+  }
+];
+
+const RARITY_WEIGHTS = {
+  common: 0.7,
+  uncommon: 0.2,
+  rare: 0.09
+};
+
+function pickRarity(rng = Math.random) {
+  const r = rng();
+  let acc = 0;
+  for (const [rarity, weight] of Object.entries(RARITY_WEIGHTS)) {
+    acc += weight;
+    if (r < acc) return rarity;
+  }
+  return 'common';
+}
+
+export function getRandomUpgrades(count = 3, rng = Math.random) {
+  const results = [];
+  const used = new Set();
+  while (results.length < count) {
+    const rarity = pickRarity(rng);
+    const pool = UPGRADES.filter(u => u.rarity === rarity && !used.has(u.id));
+    if (pool.length === 0) continue;
+    const choice = pool[Math.floor(rng() * pool.length)];
+    results.push(choice);
+    used.add(choice.id);
+  }
+  return results;
+}
+
+export function applyUpgradeById(d, meta, id) {
+  const upgrade = UPGRADES.find(u => u.id === id);
+  if (!upgrade) return;
+  upgrade.apply(d);
+  if (meta && Array.isArray(meta.upgrades)) meta.upgrades.push(id);
+}

--- a/game/metamorphosis.js
+++ b/game/metamorphosis.js
@@ -5,6 +5,7 @@ import { METAMORPHOSIS_STAGE_REQ, TRAINING_NECTAR_RATE } from './constants.js';
 import { showPathOverlay } from './pathOverlay.js';
 import { applyStageBonuses } from './metamorphosisBonuses.js';
 import { ensureMeta, addMasteryXp, getMasteryProgress } from './metamorphMastery.js';
+import { getRandomUpgrades, applyUpgradeById } from './metamorphMasteryUpgrades.js';
 
 export const metamorphosisState = {
   requirement: METAMORPHOSIS_STAGE_REQ
@@ -305,12 +306,19 @@ export function tickMetamorphosis(dt) {
 }
 
 function handleMasteryLevelUp(id) {
-  window.prompt(
-    'Choose upgrade:\n1) Placeholder Upgrade 1\n2) Placeholder Upgrade 2\n3) Placeholder Upgrade 3',
-    '1'
-  );
+  const d = sectSystem.disciples.find(x => x.id === id);
   const meta = sectState.discipleMetamorphosis[id];
-  if (meta) meta.masteryPending = false;
+  if (!d || !meta) return;
+  const options = getRandomUpgrades(3);
+  const text = options
+    .map((u, i) => `${i + 1}) ${u.name}`)
+    .join('\n');
+  const choice = window.prompt(`Choose upgrade:\n${text}`, '1');
+  const idx = Number(choice) - 1;
+  if (options[idx]) {
+    applyUpgradeById(d, meta, options[idx].id);
+  }
+  meta.masteryPending = false;
   renderMetamorphosis();
 }
 
@@ -322,7 +330,7 @@ function getRoomMultiplier() { return 1; }
 function getPathMatchMultiplier() { return 1; }
 function getStabilityFactor() { return 1; }
 function getCultivationSpeed(d) {
-  return d.potential * d.potential;
+  return d.potential * d.potential * (d.metamorphSpeedMult || 1);
 }
 function getSeasonMultiplier() { return 1; }
 

--- a/test/metamorph-mastery-upgrades.test.js
+++ b/test/metamorph-mastery-upgrades.test.js
@@ -1,0 +1,21 @@
+/* global describe, it */
+import { strict as assert } from 'assert';
+import { applyUpgradeById } from '../game/metamorphMasteryUpgrades.js';
+import { getMaxWater } from '../game/metamorphosisBonuses.js';
+
+describe('metamorph mastery upgrades', () => {
+  it('applies metamorph speed bonus', () => {
+    const d = { id: 1, potential: 2 };
+    const meta = { upgrades: [] };
+    applyUpgradeById(d, meta, 'metamorph-speed-10');
+    assert.equal(d.metamorphSpeedMult, 1.1);
+    assert.deepEqual(meta.upgrades, ['metamorph-speed-10']);
+  });
+
+  it('applies max water bonus', () => {
+    const d = { id: 1 };
+    const meta = { upgrades: [] };
+    applyUpgradeById(d, meta, 'max-water-10');
+    assert.equal(getMaxWater(d, 0), 33);
+  });
+});


### PR DESCRIPTION
## Summary
- add weighted random upgrade choices for metamorph mastery
- track selected upgrades and apply their effects
- document mastery upgrades and update UI notes

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890ac9e867c8326997d38b8e760e7be