### PR TITLE
feat: center raid orb and drop fight line

### DIFF
--- a/docs/23-raids.md
+++ b/docs/23-raids.md
@@ -1,6 +1,6 @@
 # 23 – Raids
 
-Night raids play out as a vertical autobattler. Raiders gather above the fight line and strike from above while disciples line up below to defend the Water Orb.
+Night raids play out as a vertical autobattler. Raiders gather above and strike from above while disciples line up below to defend the Water Orb, which sits centered beneath them.
 
 Raid behaviour is entirely data‑driven. A raid is started by calling `startRaid(config)` where `config` provides:
 
@@ -18,7 +18,7 @@ Raiders randomly target living disciples from their positions. Disciples remain 
 The raid ends when all waves are cleared or the orb is destroyed. Callbacks are fired at the start and end of each wave along with a final success or failure signal. When night falls the game automatically switches to a dedicated raid tab and begins a raid. Disciples temporarily switch to the "Idle" task so they remain visible in the interface.
 
 
-The overlay fills the entire screen. Raiders occupy a dedicated top container with the current wave life bar. Disciples stand in a row across the bottom container and show their HP, Water and attack progress bars underneath each sprite. A subtle vertical gradient brightens toward the fight line to draw focus while damage numbers briefly float above disciples, raiders and the orb whenever they are hit.
+The overlay fills the entire screen. Raiders occupy a dedicated top container with the current wave life bar. Disciples stand in a row across the bottom container and show their HP, Water and attack progress bars underneath each sprite. A subtle vertical gradient brightens toward the orb to draw focus while damage numbers briefly float above disciples, raiders and the orb whenever they are hit.
 Faint horizontal bands behind each row make the raider and disciple lines easier to see against the dark field.
 Bars beneath disciples have been thickened and outlined so their colors remain visible even against busy backgrounds.
 These bars now feature rounded corners, subtle inset shadows and dual-tone fills for added depth.

--- a/game/verticalRaid.js
+++ b/game/verticalRaid.js
@@ -64,10 +64,6 @@ export function createVerticalRaid({
     discipleBox.className = 'disciple-container';
     root.appendChild(discipleBox);
 
-    const line = document.createElement('div');
-    line.className = 'fight-line';
-    root.appendChild(line);
-
     const info = document.createElement('div');
     info.className = 'wave-info';
     const waveLabel = document.createElement('div');

--- a/style.css
+++ b/style.css
@@ -561,15 +561,6 @@ body.darkenshift-mode .tabsContainer button.active {
     );
 }
 
-.fight-line {
-    position: absolute;
-    left: 0;
-    right: 0;
-    top: 50%;
-    height: 2px;
-    background: rgba(255,255,255,0.2);
-}
-
 .raider-container {
     flex: 1;
     display: flex;
@@ -722,16 +713,6 @@ body.darkenshift-mode .tabsContainer button.active {
     height: 100%;
     z-index: 1;
     border-radius: 8px 0 0 8px;
-}
-
-.raid-orb {
-    position: absolute;
-    bottom: 8px;
-    left: 50%;
-    transform: translateX(-50%);
-    width: 48px;
-    height: 48px;
-    overflow: hidden;
 }
 
 .water-burst {
@@ -2787,9 +2768,9 @@ body.darkenshift-mode .tabsContainer button.active {
 }
 
 @keyframes orb-pulse {
-    0% { transform: scale(1); }
-    50% { transform: scale(1.2); }
-    100% { transform: scale(1); }
+    0% { transform: translate(var(--orb-x), var(--orb-y)) scale(1); }
+    50% { transform: translate(var(--orb-x), var(--orb-y)) scale(1.2); }
+    100% { transform: translate(var(--orb-x), var(--orb-y)) scale(1); }
 }
 
 @keyframes disciple-strike {
@@ -3498,7 +3479,9 @@ body.darkenshift-mode .tabsContainer button.active {
     opacity: 0.9;
     box-shadow: 0 0 4px rgba(255, 255, 255, 0.6);
     animation: sectGlow 3s infinite alternate;
-    transform: translate(-50%, -50%);
+    --orb-x: -50%;
+    --orb-y: -50%;
+    transform: translate(var(--orb-x), var(--orb-y));
 }
 .sect-orb .orb-fill {
     position: absolute;
@@ -3538,6 +3521,15 @@ body.darkenshift-mode .tabsContainer button.active {
 .colony-map.night .sect-orb.water {
     box-shadow: 0 0 30px rgba(80,180,255,0.9), 0 0 80px rgba(80,180,255,0.7);
     filter: brightness(1.2) saturate(1.2);
+}
+
+.raid-orb {
+    position: absolute;
+    bottom: 8px;
+    left: 50%;
+    --orb-y: 0;
+    transform: translate(var(--orb-x), var(--orb-y));
+    overflow: hidden;
 }
 .sect-bohio {
     position: absolute;
@@ -3658,8 +3650,8 @@ body.darkenshift-mode .tabsContainer button.active {
     to { transform: scale(1.3); opacity: 1; }
 }
 @keyframes sectGlow {
-    from { transform: scale(1); box-shadow: 0 0 6px rgba(255,255,255,0.8); }
-    to { transform: scale(1.1); box-shadow: 0 0 12px rgba(255,255,255,1); }
+    from { transform: translate(var(--orb-x), var(--orb-y)) scale(1); box-shadow: 0 0 6px rgba(255,255,255,0.8); }
+    to { transform: translate(var(--orb-x), var(--orb-y)) scale(1.1); box-shadow: 0 0 12px rgba(255,255,255,1); }
 }
 @keyframes sectGlowFlash {
     from { box-shadow: 0 0 12px rgba(255,255,255,1); }


### PR DESCRIPTION
## Summary
- remove raid fight line element and style
- ensure raid orb sits centered beneath disciple row
- document updated orb placement

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890ab9068bc83269bd7823259066805