### PR TITLE
feat: show limb injury effects and restrict destroyed spawns

### DIFF
--- a/docs/24-injury-system.md
+++ b/docs/24-injury-system.md
@@ -46,8 +46,8 @@ Resting halves the injury rate. Each disciple has a **Resilience** stat (startin
 
 Only one injury per body part is tracked. Incoming injuries upgrade severity. Destroying any vital part immediately incapacitates the disciple.
 
-When all non-vital parts are destroyed the disciple is effectively crippled with only 1 HP remaining.
+When all non-vital parts are destroyed the disciple is effectively crippled with only 1 HP remaining. New disciples never spawn with a destroyed head and arrive with at most two destroyed limbs.
 
 ## Health Tab
 
-The disciple overlay now contains a **Health** tab. Each body part displays an injury bar indicating current severity. Bruises fill the bar with a brown tint, wounds with red and destroyed parts appear dark.
+The disciple overlay now contains a **Health** tab. Each body part displays an injury bar indicating current severity and lists the effect of any injury. Bruises fill the bar with a brown tint, wounds with red and destroyed parts show a solid red bar.

--- a/docs/25-quirks.md
+++ b/docs/25-quirks.md
@@ -2,7 +2,7 @@
 
 Disciples can possess **quirks** that influence their behavior and abilities. Each new disciple spawns with 1–3 random quirks drawn from the list below. Quirks persist and appear on the disciple overlay's **Moodlets** tab.
 
-Some disciples may also arrive with destroyed body parts, reducing their maximum health and potentially incapacitating them if vital areas are lost.
+Some disciples may also arrive with destroyed body parts, reducing their maximum health and potentially incapacitating them if vital areas are lost. They will never appear with more than two destroyed limbs or with a destroyed head.
 
 ## Quirk List
 

--- a/game/injury.js
+++ b/game/injury.js
@@ -36,9 +36,9 @@ export function randomBodyPart() {
 }
 
 export const INJURY_TIERS = [
-  { key: 'bruise', rateRange: [0.25, 0.5], heals: true },
-  { key: 'wound', rateRange: [0.5, 1.0], heals: true },
-  { key: 'destroyed', rateRange: [0, 0], heals: false }
+  { key: 'bruise', rateRange: [0.25, 0.5], heals: true, effect: 'Minor penalty' },
+  { key: 'wound', rateRange: [0.5, 1.0], heals: true, effect: 'HP drain and severe penalty' },
+  { key: 'destroyed', rateRange: [0, 0], heals: false, effect: 'Part nonfunctional' }
 ];
 
 export function ensureInjuryState(d) {

--- a/script.js
+++ b/script.js
@@ -55,7 +55,7 @@ import {
   calculateMaxStamina,
   calculateStaminaRegen
 } from './utils/stamina.js';
-import { BODY_PARTS } from './game/injury.js';
+import { BODY_PARTS, INJURY_TIERS } from './game/injury.js';
 import {
   calculateMaxWater,
   calculateWaterRegen
@@ -1286,6 +1286,15 @@ function buildDiscipleHealthView(d) {
     bar.appendChild(fill);
     row.append(label);
     row.appendChild(bar);
+    if (state?.tier) {
+      const info = INJURY_TIERS.find(t => t.key === state.tier);
+      if (info) {
+        const effect = document.createElement('span');
+        effect.className = 'body-part-effect';
+        effect.textContent = `${state.tier.charAt(0).toUpperCase() + state.tier.slice(1)} - ${info.effect}`;
+        row.appendChild(effect);
+      }
+    }
     container.appendChild(row);
   });
   return container;

--- a/style.css
+++ b/style.css
@@ -4371,7 +4371,12 @@ body.darkenshift-mode .tabsContainer button.active {
 }
 
 .injury-bar-fill.destroyed {
-  background: #111;
+  background: #a00;
+}
+
+.body-part-effect {
+  margin-left: 4px;
+  font-size: 0.85em;
 }
 
 body.raid-active .player-sect-panel {

--- a/test/injury-system.test.js
+++ b/test/injury-system.test.js
@@ -77,4 +77,14 @@ describe('injury system', () => {
     applyStageBonuses(d);
     expect(d.resilience).to.be.closeTo(1 + 2 * 0.002, 1e-6);
   });
+
+  it('limits destroyed limbs and avoids destroyed heads on spawn', () => {
+    for (let i = 0; i < 50; i++) {
+      const d = new Disciple({ id: i + 1 });
+      initializeDisciple(d, { allowInjuries: true, generateQuirks: false });
+      const destroyed = BODY_PARTS.filter(p => d.injuries[p.key].tier === 'destroyed');
+      expect(d.injuries.head.tier).to.not.equal('destroyed');
+      expect(destroyed.length).to.be.at.most(2);
+    }
+  });
 });

--- a/utils/discipleInit.js
+++ b/utils/discipleInit.js
@@ -41,13 +41,17 @@ export function initializeDisciple(d, { allowInjuries = true, generateQuirks: ge
   ensureInjuryState(d);
   if (genQuirks && !d.quirks) d.quirks = generateRandomQuirks();
   if (allowInjuries) {
-    BODY_PARTS.forEach(p => {
+    let destroyed = 0;
+    for (const p of BODY_PARTS) {
+      if (destroyed >= 2) break;
+      if (p.key === 'head') continue;
       if (!d.injuries[p.key].tier && Math.random() < 0.05) {
         d.injuries[p.key].tier = 'destroyed';
         d.injuries[p.key].progress = 200;
+        destroyed++;
         if (p.vital) d.incapacitated = true;
       }
-    });
+    }
     d.health = calculateMaxHealth(d);
     d.currentHp = d.health;
   }


### PR DESCRIPTION
## Summary
- display limb injury effects in disciple health tab
- mark destroyed parts in red and cap destroyed limbs at two
- document injury limits

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890ae0250d08326bc5c91e1c3b13968