### PR TITLE
feat: apply destroyed limb effects

### DIFF
--- a/docs/24-injury-system.md
+++ b/docs/24-injury-system.md
@@ -1,6 +1,6 @@
 # 24 – Injury System and Health Tab
 
-This module introduces a granular injury system for disciples. Each body part contributes a portion of the disciple's maximum health. Injuries progress from **Bruise** → **Wound** → **Destroyed** and reduce available HP.
+This module introduces a granular injury system for disciples. Injuries progress from **Bruise** → **Wound** → **Destroyed**. Destroyed parts impose penalties but no longer reduce maximum health.
 
 When a disciple's Water reaches 0 they start taking damage each second. Any damage suffered while Water is depleted also targets a random body part. Every hit randomly chooses among the following chances:
 
@@ -18,20 +18,6 @@ When a disciple's Water reaches 0 they start taking damage each second. Any dama
 | Inner Meridians | 10% |
 | General | 26% |
 
-## Body Part Contributions
-
-| Body Part     | HP % | Vital |
-|---------------|------|-------|
-| Head          | 20%  | ✅ |
-| Eye (×2)      | 5% (2.5% each) |  |
-| Vocal Sac     | 5%   | |
-| Hands (×2)    | 10% (5% each) | |
-| Legs (×2)     | 10% (5% each) | |
-| Belly         | 10%  | |
-| Inner Meridians | 10% | |
-
-The sum of healthy parts determines current maximum HP.
-
 ## Injury Progression
 
 | Tier      | Effect                          | Progress Speed |
@@ -45,8 +31,6 @@ Resting halves the injury rate. Each disciple has a **Resilience** stat (startin
 ## Stacking and Death
 
 Only one injury per body part is tracked. Incoming injuries upgrade severity. Destroying any vital part immediately incapacitates the disciple.
-
-When all non-vital parts are destroyed the disciple is effectively crippled with only 1 HP remaining.
 
 Head (Vital)	Instant death. Disciple collapses and dies.
 Left Eye	-50% hit accuracy, -25% workspeed.	Stacks with right eye loss.
@@ -62,4 +46,4 @@ General Damage	Reduces current HP only. No specific function loss.	Represents mi
 
 ## Health Tab
 
-The disciple overlay now contains a **Health** tab. Each body part displays an injury bar indicating current severity. Bruises fill the bar with a brown tint, wounds with red and destroyed parts appear dark.
+The disciple overlay now contains a **Health** tab. Each body part displays an injury bar indicating current severity and any active effects. Bruises fill the bar with a brown tint, wounds with red and destroyed parts appear dark.

--- a/docs/25-quirks.md
+++ b/docs/25-quirks.md
@@ -2,7 +2,7 @@
 
 Disciples can possess **quirks** that influence their behavior and abilities. Each new disciple spawns with 1–3 random quirks drawn from the list below. Quirks persist and appear on the disciple overlay's **Moodlets** tab.
 
-Some disciples may also arrive with destroyed body parts, reducing their maximum health and potentially incapacitating them if vital areas are lost.
+Some disciples may also arrive with destroyed body parts, potentially incapacitating them if vital areas are lost.
 
 ## Quirk List
 

--- a/game/injury.js
+++ b/game/injury.js
@@ -1,14 +1,14 @@
 export const BODY_PARTS = [
-  { key: 'head', label: 'Head', contribution: 0.2, vital: true },
-  { key: 'leftEye', label: 'Left Eye', contribution: 0.025, vital: false },
-  { key: 'rightEye', label: 'Right Eye', contribution: 0.025, vital: false },
-  { key: 'vocalSac', label: 'Vocal Sac', contribution: 0.05, vital: false },
-  { key: 'leftHand', label: 'Left Hand', contribution: 0.05, vital: false },
-  { key: 'rightHand', label: 'Right Hand', contribution: 0.05, vital: false },
-  { key: 'leftLeg', label: 'Left Leg', contribution: 0.05, vital: false },
-  { key: 'rightLeg', label: 'Right Leg', contribution: 0.05, vital: false },
-  { key: 'belly', label: 'Belly', contribution: 0.1, vital: false },
-  { key: "meridians", label: "Inner Meridians", contribution: 0.1, vital: false },
+  { key: 'head', label: 'Head', vital: true },
+  { key: 'leftEye', label: 'Left Eye', vital: false },
+  { key: 'rightEye', label: 'Right Eye', vital: false },
+  { key: 'vocalSac', label: 'Vocal Sac', vital: false },
+  { key: 'leftHand', label: 'Left Hand', vital: false },
+  { key: 'rightHand', label: 'Right Hand', vital: false },
+  { key: 'leftLeg', label: 'Left Leg', vital: false },
+  { key: 'rightLeg', label: 'Right Leg', vital: false },
+  { key: 'belly', label: 'Belly', vital: false },
+  { key: 'meridians', label: 'Inner Meridians', vital: false },
 ];
 
 export const BODY_PART_CHANCES = [
@@ -50,15 +50,114 @@ export function ensureInjuryState(d) {
   });
 }
 
-export function calculateMaxHealth(d) {
+export function applyInjuryEffects(d) {
   ensureInjuryState(d);
-  const base = d.maxHp;
-  let hp = base;
+  if (!d.baseStats) {
+    d.baseStats = {
+      attackSpeed: d.attackSpeed ?? 5000,
+      hitAccuracy: d.hitAccuracy ?? 1,
+      workSpeedMult: d.workSpeedMult ?? 1,
+      mobility: d.mobility ?? 1,
+      waterRegenMult: d.waterRegenMult ?? 1,
+      metamorphSpeedMult: d.metamorphSpeedMult ?? 1
+    };
+  }
+  let attackSpeedMult = 1;
+  let accuracyMult = 1;
+  let workSpeedMult = 1;
+  let mobilityMult = 1;
+  let waterRegenMult = 1;
+  let metamorphMult = 1;
+  let canChant = true;
+  let canMelee = true;
+  let canMove = true;
+  const effects = {};
+
+  const s = d.injuries;
+  const leftEyeDestroyed = s.leftEye?.tier === 'destroyed';
+  const rightEyeDestroyed = s.rightEye?.tier === 'destroyed';
+  const leftHandDestroyed = s.leftHand?.tier === 'destroyed';
+  const rightHandDestroyed = s.rightHand?.tier === 'destroyed';
+  const leftLegDestroyed = s.leftLeg?.tier === 'destroyed';
+  const rightLegDestroyed = s.rightLeg?.tier === 'destroyed';
+
   BODY_PARTS.forEach(p => {
-    const state = d.injuries[p.key];
-    if (state.tier === 'destroyed') hp -= base * p.contribution;
+    const state = s[p.key];
+    if (!state || !state.tier) return;
+    if (state.tier === 'destroyed') {
+      switch (p.key) {
+        case 'head':
+          effects[p.key] = 'Instant death';
+          d.health = 0;
+          d.currentHp = 0;
+          d.incapacitated = true;
+          break;
+        case 'leftEye':
+        case 'rightEye':
+          accuracyMult *= 0.5;
+          workSpeedMult *= 0.75;
+          effects[p.key] = '-50% hit accuracy, -25% work speed';
+          break;
+        case 'vocalSac':
+          canChant = false;
+          effects[p.key] = 'Cannot chant or cast spells';
+          break;
+        case 'leftHand':
+        case 'rightHand':
+          attackSpeedMult *= 2;
+          workSpeedMult *= 0.75;
+          effects[p.key] = '-50% attack speed, -25% work speed';
+          break;
+        case 'leftLeg':
+        case 'rightLeg':
+          mobilityMult *= 0.5;
+          workSpeedMult *= 0.5;
+          effects[p.key] = '-50% mobility, -50% work speed';
+          break;
+        case 'belly':
+          workSpeedMult *= 0.75;
+          effects[p.key] = '-25% work speed';
+          break;
+        case 'meridians':
+          waterRegenMult *= 0.5;
+          metamorphMult *= 0.5;
+          effects[p.key] = 'Halved water regen and metamorphosis speed';
+          break;
+      }
+    } else if (state.tier === 'wound') {
+      effects[p.key] = 'Wound: HP drain and severe penalty';
+    } else if (state.tier === 'bruise') {
+      effects[p.key] = 'Bruise: minor penalty';
+    }
   });
-  return Math.round(hp);
+
+  if (leftEyeDestroyed && rightEyeDestroyed) {
+    accuracyMult = 0;
+    effects.leftEye = '0% hit accuracy; ranged attacks impossible';
+    effects.rightEye = '0% hit accuracy; ranged attacks impossible';
+  }
+  if (leftHandDestroyed && rightHandDestroyed) {
+    canMelee = false;
+    effects.leftHand = 'Cannot perform melee attacks or crafting';
+    effects.rightHand = 'Cannot perform melee attacks or crafting';
+  }
+  if (leftLegDestroyed && rightLegDestroyed) {
+    mobilityMult = 0;
+    canMove = false;
+    effects.leftLeg = 'Cannot move';
+    effects.rightLeg = 'Cannot move';
+  }
+
+  d.attackSpeed = d.baseStats.attackSpeed * attackSpeedMult;
+  d.hitAccuracy = d.baseStats.hitAccuracy * accuracyMult;
+  d.workSpeedMult = d.baseStats.workSpeedMult * workSpeedMult;
+  d.mobility = d.baseStats.mobility * mobilityMult;
+  d.waterRegenMult = d.baseStats.waterRegenMult * waterRegenMult;
+  d.metamorphSpeedMult = d.baseStats.metamorphSpeedMult * metamorphMult;
+  d.canChant = canChant;
+  d.canMelee = canMelee;
+  d.canMove = canMove;
+  d.injuryEffects = effects;
 }
 
 export function applyStarvationHit(d) {
@@ -82,6 +181,7 @@ export function applyInjury(d, partKey, tier) {
     const range = INJURY_TIERS[newIndex].rateRange;
     part.rate = Math.random() * (range[1] - range[0]) + range[0];
     part.progress = 0;
+    applyInjuryEffects(d);
   }
 }
 
@@ -112,6 +212,6 @@ export function tickInjuries(d, dt, resilience = 0, task = 'Idle') {
       state.tier = null;
     }
   });
-  const maxHp = calculateMaxHealth(d);
-  d.health = Math.min(maxHp, d.health + resilience * dt);
+  d.health = Math.min(d.maxHp, d.health + resilience * dt);
+  applyInjuryEffects(d);
 }

--- a/script.js
+++ b/script.js
@@ -1286,6 +1286,13 @@ function buildDiscipleHealthView(d) {
     bar.appendChild(fill);
     row.append(label);
     row.appendChild(bar);
+    const effect = d.injuryEffects?.[p.key];
+    if (effect) {
+      const eff = document.createElement('div');
+      eff.className = 'body-part-effect';
+      eff.textContent = effect;
+      row.appendChild(eff);
+    }
     container.appendChild(row);
   });
   return container;

--- a/style.css
+++ b/style.css
@@ -4366,6 +4366,12 @@ body.darkenshift-mode .tabsContainer button.active {
   background: #111;
 }
 
+.body-part-effect {
+  font-size: 0.8rem;
+  color: #ccc;
+  margin-top: 2px;
+}
+
 body.raid-active .player-sect-panel {
   display: none;
 }

--- a/utils/discipleInit.js
+++ b/utils/discipleInit.js
@@ -1,7 +1,7 @@
 import Disciple from '../game/disciple.js';
 import { calculateMaxWater } from './water.js';
 import { sectState } from '../game/state.js';
-import { ensureInjuryState, BODY_PARTS, calculateMaxHealth } from '../game/injury.js';
+import { ensureInjuryState, BODY_PARTS, applyInjuryEffects } from '../game/injury.js';
 import { applyStageBonuses } from '../game/metamorphosisBonuses.js';
 import { generateRandomQuirks } from '../game/quirks.js';
 
@@ -48,8 +48,9 @@ export function initializeDisciple(d, { allowInjuries = true, generateQuirks: ge
         if (p.vital) d.incapacitated = true;
       }
     });
-    d.health = calculateMaxHealth(d);
+    d.health = d.maxHp;
     d.currentHp = d.health;
+    applyInjuryEffects(d);
   }
   if (!sectState.discipleMetamorphosis[d.id]) {
     sectState.discipleMetamorphosis[d.id] = {


### PR DESCRIPTION
## Summary
- add injury effect system and display active penalties on health tab
- prevent destroyed parts from reducing disciple max HP
- document injury effect changes and quirks update

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68912ea3a6d88326ade846fc1fdf4f56