### PR TITLE
feat: add starting mood buffs

### DIFF
--- a/docs/11-needs.md
+++ b/docs/11-needs.md
@@ -27,6 +27,8 @@
 
 ### Mood (0–100)
 - Starts at 100 and reflects overall disciple happiness.
+- Verdantia's spring climate adds +25 mood for its comfortable temperature.
+- A "Humble beginnings" moodlet grants +50 mood for the first 30 days.
 - Housing: each disciple beyond available bohios gives –25 mood to all; each unused bohio grants +10 mood.
 - Metamorphosis stages apply –50 mood per stage.
 - Injuries: every injured limb gives –20 mood while injured and for 20 minutes after healing (stacks). Destroyed limbs give –20 mood for the first and –10 for each additional.

--- a/game/sect.js
+++ b/game/sect.js
@@ -114,6 +114,7 @@ export const sectSystem = {
   memorySlots: 2,
   seasonIndex: 0,
   seasonDay: 0,
+  totalDays: 0,
   seasonTimer: 0,
   weather: null,
   waterRegenBase: 0,
@@ -1244,6 +1245,7 @@ export function tickSectSystem(delta) {
       );
     }
     sectSystem.seasonDay += 1;
+    sectSystem.totalDays += 1;
     document.dispatchEvent(new CustomEvent('day-passed', {
       detail: { day: sectSystem.seasonDay, season: sectSystem.seasonIndex }
     }));
@@ -1476,6 +1478,17 @@ function updateDiscipleMood(d, dt) {
 
   d.moodModifiers = [];
   let mood = 100;
+  const seasonClass = seasonClasses[sectSystem.seasonIndex];
+  if (seasonClass === 'spring') {
+    const amount = 25;
+    mood += amount;
+    d.moodModifiers.push({ label: 'Comfortable temperature', value: amount });
+  }
+  if (sectSystem.totalDays < 30) {
+    const amount = 50;
+    mood += amount;
+    d.moodModifiers.push({ label: 'Humble beginnings', value: amount });
+  }
   const bohio = sectState.buildings.bohio || 0;
   const diff = sectSystem.disciples.length - bohio;
   if (diff > 0) {
@@ -1685,6 +1698,7 @@ export function skipToNextNight() {
   const nightStart = NIGHT_START_SECONDS;
   if (sectSystem.scheduleIndex >= nightIndex) {
     sectSystem.seasonDay += 1;
+    sectSystem.totalDays += 1;
     document.dispatchEvent(
       new CustomEvent('day-passed', {
         detail: { day: sectSystem.seasonDay, season: sectSystem.seasonIndex }


### PR DESCRIPTION
## Summary
- add spring comfortable temperature and humble beginnings mood buffs
- track total days to expire humble beginnings after 30 days
- document new mood modifiers

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test` *(fails: collects fruit each second, collects softwood each second)*

------
https://chatgpt.com/codex/tasks/task_e_6891400ade348326ba9439fb0975cfc8