### PR TITLE
feat: add combat stat xp

### DIFF
--- a/docs/27-combat-stats.md
+++ b/docs/27-combat-stats.md
@@ -1,0 +1,13 @@
+# Combat Stats
+
+Disciples track four combat statistics that improve through battle:
+
+| Stat | Base Value | Growth Method |
+| --- | --- | --- |
+| **Melee Damage** | 1 flat damage | +1 XP per hit landed |
+| **Spell Damage** | 0% additive | +1 XP per damaging spell |
+| **Defense** | 2 flat damage reduced | +1 XP per physical hit taken |
+| **Magic Defense** | 2 flat damage reduced | +1 XP per spell hit taken |
+
+Each stat has an experience bar shown in the disciple combat view. When the
+bar fills, the stat level increases, raising the displayed value.

--- a/game/combat.js
+++ b/game/combat.js
@@ -1,7 +1,8 @@
 // Generic damage helper used by raid modules.
 import { randomBodyPart, applyInjury } from './injury.js';
+import { addCombatStatXp } from './combatStats.js';
 
-export function applyDamage(target, amount) {
+export function applyDamage(target, amount, type = 'physical') {
   let remaining = Math.round(amount);
   if (target.water > 0) {
     const absorbed = Math.min(target.water, remaining);
@@ -18,6 +19,10 @@ export function applyDamage(target, amount) {
   target.currentHp = Math.max(0, target.currentHp - remaining);
   if (Object.hasOwn(target, 'health')) {
     target.health = target.currentHp;
+  }
+  if (target && Object.hasOwn(target, 'id')) {
+    if (type === 'physical') addCombatStatXp(target, 'defense', 1);
+    if (type === 'spell') addCombatStatXp(target, 'magicDefense', 1);
   }
   return remaining;
 }

--- a/game/combatStats.js
+++ b/game/combatStats.js
@@ -1,0 +1,57 @@
+import { sectState } from './state.js';
+import { getTaskSkillProgress } from '../utils/skills.js';
+
+export const COMBAT_STAT_DEFS = {
+  meleeDamage: { base: 1, unit: '', label: 'Melee Damage' },
+  spellDamage: { base: 0, unit: '%', label: 'Spell Damage' },
+  defense: { base: 2, unit: '', label: 'Defense' },
+  magicDefense: { base: 2, unit: '', label: 'Magic Defense' }
+};
+
+export function ensureCombatStats(id) {
+  if (!sectState.discipleCombatStats[id]) {
+    sectState.discipleCombatStats[id] = {
+      meleeDamage: 0,
+      spellDamage: 0,
+      defense: 0,
+      magicDefense: 0
+    };
+  }
+}
+
+export function addCombatStatXp(d, stat, amount = 1) {
+  ensureCombatStats(d.id);
+  const prev = sectState.discipleCombatStats[d.id][stat] || 0;
+  const newXp = prev + amount;
+  sectState.discipleCombatStats[d.id][stat] = newXp;
+  const { level } = getTaskSkillProgress(newXp);
+  switch (stat) {
+    case 'meleeDamage': {
+      d.meleeDamage = COMBAT_STAT_DEFS.meleeDamage.base + level;
+      d.damage = d.meleeDamage;
+      d.minDamage = Math.max(1, Math.floor(d.meleeDamage * 0.5));
+      d.maxDamage = Math.ceil(d.meleeDamage * 1.5);
+      break;
+    }
+    case 'spellDamage': {
+      d.spellDamage = COMBAT_STAT_DEFS.spellDamage.base + level;
+      break;
+    }
+    case 'defense': {
+      d.defense = COMBAT_STAT_DEFS.defense.base + level;
+      break;
+    }
+    case 'magicDefense': {
+      d.magicDefense = COMBAT_STAT_DEFS.magicDefense.base + level;
+      break;
+    }
+    default:
+      break;
+  }
+}
+
+export function getCombatStatProgress(d, stat) {
+  ensureCombatStats(d.id);
+  const xp = sectState.discipleCombatStats[d.id][stat] || 0;
+  return getTaskSkillProgress(xp);
+}

--- a/game/disciple.js
+++ b/game/disciple.js
@@ -4,6 +4,7 @@
 import { generateDiscipleAttributes } from './discipleAttributes.js';
 import { sectState } from './state.js';
 import { STAGE_BONUS } from './metamorphosisBonuses.js';
+import { COMBAT_STAT_DEFS, ensureCombatStats, getCombatStatProgress } from './combatStats.js';
 
 export default class Disciple {
   constructor({ id = 0, name = `Disciple ${id}`, maxHp = 10, attributes = generateDiscipleAttributes() } = {}) {
@@ -21,7 +22,8 @@ export default class Disciple {
     // base resilience percentage per second for healing injuries and HP
     this.baseResilience = 1;
     this.resilience = this.baseResilience;
-    this.defense = 1;
+    this.defense = COMBAT_STAT_DEFS.defense.base;
+    this.magicDefense = COMBAT_STAT_DEFS.magicDefense.base;
     this.lastTab = 'general';
     // mood system
     this.mood = 100;
@@ -31,16 +33,27 @@ export default class Disciple {
   }
 
   updateCombatStats() {
+    ensureCombatStats(this.id);
     // Combat stats no longer scale with attributes or combat levels.
-    // Damage and defense grow purely with metamorphosis bonuses.
+    // Damage and defense grow with metamorphosis bonuses and stat XP.
     const stage = sectState.discipleMetamorphosis[this.id]?.stage || 0;
     const stageBonus = stage * STAGE_BONUS.attack;
-    const base = 1 + stageBonus;
-    this.damage = base;
-    this.minDamage = Math.max(1, Math.floor(this.damage * 0.5));
-    this.maxDamage = Math.ceil(this.damage * 1.5);
+
+    const meleeLevel = getCombatStatProgress(this, 'meleeDamage').level;
+    this.meleeDamage = COMBAT_STAT_DEFS.meleeDamage.base + meleeLevel + stageBonus;
+    this.damage = this.meleeDamage;
+    this.minDamage = Math.max(1, Math.floor(this.meleeDamage * 0.5));
+    this.maxDamage = Math.ceil(this.meleeDamage * 1.5);
     this.attackSpeed = 5000;
-    this.defense = base;
+
+    const defLevel = getCombatStatProgress(this, 'defense').level;
+    this.defense = COMBAT_STAT_DEFS.defense.base + defLevel + stageBonus;
+
+    const mdefLevel = getCombatStatProgress(this, 'magicDefense').level;
+    this.magicDefense = COMBAT_STAT_DEFS.magicDefense.base + mdefLevel + stageBonus;
+
+    const spellLevel = getCombatStatProgress(this, 'spellDamage').level;
+    this.spellDamage = COMBAT_STAT_DEFS.spellDamage.base + spellLevel;
   }
 
   takeDamage(amount) {

--- a/game/orbSpells.js
+++ b/game/orbSpells.js
@@ -2,6 +2,7 @@ import { sectSystem } from './sect.js';
 import { sectState } from './state.js';
 import { raidState } from './raids.js';
 import addLog from './log.js';
+import { addCombatStatXp } from './combatStats.js';
 
 export function orbDamageMultiplier() {
   return 1 + 0.2 * (sectState.buildings.orbSpellStrength || 0);
@@ -35,6 +36,7 @@ export function castWaterBurst() {
   sectSystem.orbs.water.current -= cost;
   const damage = 20 * orbDamageMultiplier();
   raidState.raid.castWaterBurst(damage);
+  sectSystem.disciples.forEach(d => addCombatStatXp(d, 'spellDamage', 1));
   addLog('Water Burst unleashed!', 'info');
 }
 

--- a/game/state.js
+++ b/game/state.js
@@ -110,6 +110,7 @@ export const sectState = {
   taskTimers: { gatherFruits: 0 },
   discipleProgress: {},
   discipleSkills: {},
+  discipleCombatStats: {},
   discipleConstructXp: {},
   discipleMetamorphosis: {},
   disciplePaths: {},

--- a/game/verticalRaid.js
+++ b/game/verticalRaid.js
@@ -1,5 +1,6 @@
 import { showRaidDamageFloat } from './rendering.js';
 import { applyDamage } from './combat.js';
+import { addCombatStatXp } from './combatStats.js';
 import { runAnimation } from '../utils/animation.js';
 import { makeBar } from './ui.js';
 import { sectState } from './state.js';
@@ -220,7 +221,7 @@ export function createVerticalRaid({
         if (living.length > 0) {
           const target = living[Math.floor(Math.random() * living.length)];
           const dmg = Math.floor(Math.random() * (r.maxDamage - r.minDamage + 1)) + r.minDamage;
-          applyDamage(target.d, dmg);
+          applyDamage(target.d, dmg, 'physical');
           state.onDamage({ amount: dmg, source: 'raider' });
           showRaidDamageFloat(target.sprite, dmg);
           if (target.hpFill) {
@@ -277,6 +278,7 @@ export function createVerticalRaid({
         const dealt = before - r.hp;
         state.waveHp = Math.max(0, state.waveHp - dealt);
         state.onDamage({ amount: dealt, source: 'disciple' });
+        addCombatStatXp(slot.d, 'meleeDamage', 1);
         showRaidDamageFloat(r.el, dealt, true);
         runAnimation(slot.sprite, 'attack-flash');
         if (slot.attackFill) slot.attackFill.style.width = '0%';

--- a/script.js
+++ b/script.js
@@ -119,6 +119,7 @@ import {
 } from "./game/disciples.js";
 import { raidState, tickRaid } from './game/raids.js';
 import { getMoodEmoji } from './game/mood.js';
+import { getCombatStatProgress } from './game/combatStats.js';
 // developer debug tools
 import { init as initDebug } from "./game/debug.js";
 import { attachOrbGlow, enableOrbGlow, disableOrbGlow, updateOrbGlow, flashOrbGlow } from './game/orbGlow.js';
@@ -767,6 +768,21 @@ function updateDiscipleMoodDisplay() {
   }
 }
 
+function formatCombatStat(key, value) {
+  switch (key) {
+    case 'meleeDamage':
+      return `Melee Damage ${Math.round(value)}`;
+    case 'spellDamage':
+      return `Spell Damage ${Math.round(value)}%`;
+    case 'defense':
+      return `Defense ${Math.round(value)}`;
+    case 'magicDefense':
+      return `Magic Defense ${Math.round(value)}`;
+    default:
+      return `${key} ${Math.round(value)}`;
+  }
+}
+
 function updateDiscipleCombatStatsDisplay() {
   if (discipleOverlay && discipleOverlayActiveTab === 'combat') {
     const d = discipleOverlayData.disciple;
@@ -775,12 +791,17 @@ function updateDiscipleCombatStatsDisplay() {
     if (!section) return;
     const stats = section.querySelector('.combat-stats');
     if (stats) {
-      const atkInterval = (d.attackSpeed / 1000).toFixed(1);
-      const defense = Math.round(d.defense ?? 0);
-      stats.innerHTML =
-        `Damage ${Math.round(d.damage)}<br>` +
-        `Attack every ${atkInterval}s<br>` +
-        `Defense ${defense}`;
+      ['meleeDamage', 'spellDamage', 'defense', 'magicDefense'].forEach(key => {
+        const row = stats.querySelector(`.combat-stat[data-stat="${key}"]`);
+        if (!row) return;
+        const label = row.querySelector('.combat-stat-label');
+        if (label) label.textContent = formatCombatStat(key, d[key] ?? 0);
+        const fill = row.querySelector('.disciple-skill-progress-fill');
+        if (fill) {
+          const prog = getCombatStatProgress(d, key);
+          fill.style.width = `${Math.floor(prog.progress * 100)}%`;
+        }
+      });
     }
   }
 }
@@ -1006,15 +1027,26 @@ function startDiscipleMovement() {
 function buildDiscipleCombatStatsView(d) {
   const body = document.createElement('div');
   body.className = 'disciple-combat';
-  const atkInterval = (d.attackSpeed / 1000).toFixed(1);
-  const defense = Math.round(d.defense ?? 0);
-
   const stats = document.createElement('div');
   stats.className = 'combat-stats';
-  stats.innerHTML =
-    `Damage ${Math.round(d.damage)}<br>` +
-    `Attack every ${atkInterval}s<br>` +
-    `Defense ${defense}`;
+  ['meleeDamage', 'spellDamage', 'defense', 'magicDefense'].forEach(key => {
+    const row = document.createElement('div');
+    row.className = 'combat-stat';
+    row.dataset.stat = key;
+    const label = document.createElement('div');
+    label.className = 'combat-stat-label';
+    label.textContent = formatCombatStat(key, d[key] ?? 0);
+    const bar = document.createElement('div');
+    bar.className = 'disciple-skill-progress';
+    const fill = document.createElement('div');
+    fill.className = 'disciple-skill-progress-fill';
+    const prog = getCombatStatProgress(d, key);
+    fill.style.width = `${Math.floor(prog.progress * 100)}%`;
+    bar.appendChild(fill);
+    row.appendChild(label);
+    row.appendChild(bar);
+    stats.appendChild(row);
+  });
   body.appendChild(stats);
 
   return body;

--- a/style.css
+++ b/style.css
@@ -848,6 +848,16 @@ body.darkenshift-mode .tabsContainer button.active {
     font-size: 0.8rem;
 }
 
+.combat-stat {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    margin-bottom: 4px;
+}
+.combat-stat-label {
+    width: 140px;
+}
+
 .water-regen-overlay {
     flex-direction: column;
     gap: 8px;

--- a/test/combat-stats-xp.test.js
+++ b/test/combat-stats-xp.test.js
@@ -1,0 +1,30 @@
+/* global describe, it, beforeEach */
+import { expect } from 'chai';
+import Disciple from '../game/disciple.js';
+import { sectState } from '../game/state.js';
+import { ensureCombatStats, addCombatStatXp } from '../game/combatStats.js';
+import { applyDamage } from '../game/combat.js';
+
+describe('combat stat xp', () => {
+  beforeEach(() => {
+    sectState.discipleCombatStats = {};
+  });
+
+  it('gains defense xp when taking physical damage', () => {
+    const d = new Disciple({ id: 1 });
+    ensureCombatStats(d.id);
+    const start = sectState.discipleCombatStats[d.id].defense;
+    applyDamage(d, 1, 'physical');
+    const end = sectState.discipleCombatStats[d.id].defense;
+    expect(end).to.equal(start + 1);
+  });
+
+  it('gains melee damage xp when adding xp', () => {
+    const d = new Disciple({ id: 2 });
+    ensureCombatStats(d.id);
+    const start = sectState.discipleCombatStats[d.id].meleeDamage;
+    addCombatStatXp(d, 'meleeDamage', 2);
+    const end = sectState.discipleCombatStats[d.id].meleeDamage;
+    expect(end).to.equal(start + 2);
+  });
+});

--- a/test/resource-gathering.test.js
+++ b/test/resource-gathering.test.js
@@ -31,6 +31,7 @@ describe('resource gathering', () => {
     Object.keys(sectState.discipleTasks).forEach(k => delete sectState.discipleTasks[k]);
     Object.keys(sectState.discipleProgress).forEach(k => delete sectState.discipleProgress[k]);
     Object.keys(sectState.discipleSkills).forEach(k => delete sectState.discipleSkills[k]);
+    Object.keys(sectState.discipleCombatStats).forEach(k => delete sectState.discipleCombatStats[k]);
     sectState.fruits = 0;
     sectState.softwood = 0;
     sectState.buildings.bohio = 0;


### PR DESCRIPTION
## Summary
- add combat stat xp tracking and scaling
- surface combat stat experience in disciple UI
- document new combat stats and growth methods

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test` *(fails: resource gathering collects fruit each second, resource gathering collects softwood each second)*

------
https://chatgpt.com/codex/tasks/task_e_68914cc95cec8326831a2b26683701a6