### PR TITLE
feat: show combat level-up glow

### DIFF
--- a/docs/27-combat-stats.md
+++ b/docs/27-combat-stats.md
@@ -10,7 +10,9 @@ Disciples track four combat statistics that improve through battle:
 | **Magic Defense** | 2 flat damage reduced | \(\frac{\text{Damage Taken}}{\text{Max Water}}\) × 10 |
 
 Each stat has an experience bar shown in the disciple combat view. When the
-bar fills, the stat level increases, raising the displayed value.
+bar fills, the stat level increases, raising the displayed value. A '+ Stat'
+floating text and brief golden glow highlight the disciple when a level is
+gained.
 
 ## XP Requirement per Level
 

--- a/game/combatStats.js
+++ b/game/combatStats.js
@@ -1,4 +1,5 @@
 import { sectState } from './state.js';
+import { showCombatLevelUp } from './rendering.js';
 
 export const COMBAT_STAT_DEFS = {
   meleeDamage: { base: 1, unit: '', label: 'Melee Damage' },
@@ -38,9 +39,13 @@ export function ensureCombatStats(id) {
 export function addCombatStatXp(d, stat, amount = 1) {
   ensureCombatStats(d.id);
   const prev = sectState.discipleCombatStats[d.id][stat] || 0;
+  const prevLevel = getProgressFromXp(prev).level;
   const newXp = prev + amount;
   sectState.discipleCombatStats[d.id][stat] = newXp;
   const { level } = getProgressFromXp(newXp);
+  if (level > prevLevel) {
+    showCombatLevelUp(d, COMBAT_STAT_DEFS[stat].label);
+  }
   switch (stat) {
     case 'meleeDamage': {
       d.meleeDamage = COMBAT_STAT_DEFS.meleeDamage.base + level;

--- a/game/rendering.js
+++ b/game/rendering.js
@@ -29,3 +29,18 @@ export function showRaidDamageFloat(el, amount, isRaider = false) {
   );
   setTimeout(() => dmg.remove(), 3000);
 }
+
+// Display a floating '+ X' text and glow when a disciple levels a combat stat.
+export function showCombatLevelUp(d, text) {
+  if (typeof document === 'undefined') return;
+  const el = document.querySelector(`.sect-disciple[data-disciple-id="${d.id}"]`);
+  if (!el) return;
+  const gain = document.createElement('div');
+  gain.classList.add('levelup-float');
+  gain.textContent = `+ ${text}`;
+  el.appendChild(gain);
+  gain.addEventListener('animationend', () => gain.remove(), { once: true });
+  setTimeout(() => gain.remove(), 3000);
+  el.classList.add('glow-notify');
+  setTimeout(() => el.classList.remove('glow-notify'), 1000);
+}

--- a/style.css
+++ b/style.css
@@ -1877,6 +1877,20 @@ body.darkenshift-mode .tabsContainer button.active {
     color: white;
 }
 
+.levelup-float {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    color: gold;
+    font-weight: bold;
+    pointer-events: none;
+    z-index: 1;
+    text-shadow: 0 0 2px #000;
+    font-size: 1.4em;
+    animation: damage-float 3s ease-out forwards;
+}
+
 @keyframes damage-float {
     from {
         opacity: 1;

--- a/test/water-shield.test.js
+++ b/test/water-shield.test.js
@@ -1,4 +1,4 @@
-/* global describe, it, before, after */
+/* global describe, it, before, after, beforeEach */
 import { expect } from 'chai';
 import Disciple from '../game/disciple.js';
 import { initializeDisciple } from '../utils/discipleInit.js';


### PR DESCRIPTION
## Summary
- display +Stat floating text and glow when a disciple levels any combat stat
- document combat stat level-up feedback
- fix missing global in water shield test

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891592b16e08326aa954a57c0394a32