### PR TITLE
feat: show metamorphosis upgrades

### DIFF
--- a/docs/13-metamorphosis-stages-&-methods.md
+++ b/docs/13-metamorphosis-stages-&-methods.md
@@ -11,6 +11,7 @@ Each disciple evolves through frog-like spiritual metamorphosis. Accessible via 
 - **Current Metamorphosis Stage** label above the metamorphosis orb
 - **Glowing orb** with animated fill toward next breakthrough
 - **Progress bar** showing XP and % toward next phase
+- **Active Mastery Upgrades** listed beneath the assignment showing cumulative effects
 - **metamorphosis Stats**: method modifiers, room/building multipliers, season, humidity, and training bonuses
 - **Left panel disciple list** for selecting which coquí's progress to view
 

--- a/game/metamorphosis.js
+++ b/game/metamorphosis.js
@@ -5,7 +5,7 @@ import { METAMORPHOSIS_STAGE_REQ, TRAINING_NECTAR_RATE } from './constants.js';
 import { showPathOverlay } from './pathOverlay.js';
 import { applyStageBonuses } from './metamorphosisBonuses.js';
 import { ensureMeta, addMasteryXp, getMasteryProgress } from './metamorphMastery.js';
-import { getRandomUpgrades, applyUpgradeById } from './metamorphMasteryUpgrades.js';
+import { getRandomUpgrades, applyUpgradeById, UPGRADES } from './metamorphMasteryUpgrades.js';
 
 export const metamorphosisState = {
   requirement: METAMORPHOSIS_STAGE_REQ
@@ -23,6 +23,7 @@ let masteryBtn;
 let statsContainer;
 let statsPanel;
 let statsToggle;
+let upgradesContainer;
 let selectedDiscipleId = null;
 let breakthroughHandler;
 let masteryBtnHandler;
@@ -79,6 +80,7 @@ export function initMetamorphosis() {
       <button id="masteryLevelUpBtn" class="levelup-btn" style="display:none;">Level Up</button>
       <button id="breakthroughBtn" class="breakthrough-btn" style="display:none;">Breakthrough</button>
       <div class="assigned-disciple">Assigned to <span id="assignedDisciple">disciple 1</span></div>
+      <div id="metamorphosisUpgrades" class="meta-upgrades"></div>
     </div>
   `;
   progressFill = container.querySelector('#metamorphosisBarFill');
@@ -88,6 +90,7 @@ export function initMetamorphosis() {
   ringWrapper = container.querySelector('.metamorphosis-progress');
   breakthroughBtn = container.querySelector('#breakthroughBtn');
   masteryBtn = container.querySelector('#masteryLevelUpBtn');
+  upgradesContainer = container.querySelector('#metamorphosisUpgrades');
   if (breakthroughBtn) {
     breakthroughHandler = () => {
       if (selectedDiscipleId) breakthrough(selectedDiscipleId);
@@ -235,6 +238,7 @@ function renderMetamorphosis() {
   const label = container.querySelector('#assignedDisciple');
   if (label && d) label.textContent = d.name || `Disciple ${d.id}`;
 
+  renderUpgrades(meta);
   updateStats();
 }
 
@@ -333,6 +337,21 @@ function getCultivationSpeed(d) {
   return d.potential * d.potential * (d.metamorphSpeedMult || 1);
 }
 function getSeasonMultiplier() { return 1; }
+
+function renderUpgrades(meta) {
+  if (!upgradesContainer) return;
+  const list = meta?.upgrades || [];
+  if (list.length === 0) {
+    upgradesContainer.textContent = 'No upgrades';
+    return;
+  }
+  upgradesContainer.innerHTML = list
+    .map(id => {
+      const u = UPGRADES.find(x => x.id === id);
+      return `<div class="meta-upgrade">${u ? u.name : id}</div>`;
+    })
+    .join('');
+}
 
 function updateStats() {
   if (!statsContainer || !selectedDiscipleId) return;

--- a/style.css
+++ b/style.css
@@ -2485,11 +2485,20 @@ body.darkenshift-mode .tabsContainer button.active {
 }
 .metamorphosis-room .progress-area,
 .metamorphosis-room .assigned-disciple,
+.metamorphosis-room .meta-upgrades,
 .metamorphosis-room .metamorphosis-stage {
     background: rgba(252, 236, 194, 0.5);
     padding: 4px 8px;
     border-radius: 6px;
     margin-bottom: 8px;
+}
+.metamorphosis-room .meta-upgrades {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+.meta-upgrades .meta-upgrade {
+    font-size: 0.9em;
 }
 .metamorphosis-progress {
     width: 200px;

--- a/test/water-shield.test.js
+++ b/test/water-shield.test.js
@@ -1,4 +1,4 @@
-/* global describe, it, before, after */
+/* global describe, it, before, after, beforeEach */
 import { expect } from 'chai';
 import Disciple from '../game/disciple.js';
 import { initializeDisciple } from '../utils/discipleInit.js';


### PR DESCRIPTION
## Summary
- display active mastery upgrades under assignment
- style metamorphosis upgrades list
- document metamorphosis upgrade display

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689169030a14832696b1787887a37776