### PR TITLE
feat: show combat level-up glow

### DIFF
--- a/docs/27-combat-stats.md
+++ b/docs/27-combat-stats.md
@@ -6,11 +6,14 @@ Disciples track four combat statistics that improve through battle:
 | --- | --- | --- |
 | **Melee Damage** | 1 flat damage | \(\frac{\text{Damage Dealt}}{\text{Target Max HP}}\) × 10 |
 | **Spell Damage** | 0% additive | \(\frac{\text{Damage Dealt}}{\text{Target Max HP}}\) × 10 |
-| **Defense** | 2 flat damage reduced | \(\frac{\text{Damage Taken}}{\text{Max Water}}\) × 10 |
-| **Magic Defense** | 2 flat damage reduced | \(\frac{\text{Damage Taken}}{\text{Max Water}}\) × 10 |
+| **Defense** | 2 flat damage reduced | \(\frac{\text{Damage Received}}{\text{Max Water}}\) × 10 |
+| **Magic Defense** | 2 flat damage reduced | \(\frac{\text{Damage Received}}{\text{Max Water}}\) × 10 |
 
 Each stat has an experience bar shown in the disciple combat view. When the
-bar fills, the stat level increases, raising the displayed value.
+bar fills, the stat level increases, raising the displayed value. A '+1 Stat'
+floating text and golden glow highlight the disciple for five seconds when a
+level is gained. Even blocked or absorbed hits contribute Defense XP based on
+the incoming damage.
 
 ## XP Requirement per Level
 

--- a/game/combat.js
+++ b/game/combat.js
@@ -5,7 +5,8 @@ import { getMaxWater } from './metamorphosisBonuses.js';
 import { sectState } from './state.js';
 
 export function applyDamage(target, amount, type = 'physical') {
-  let remaining = Math.round(amount);
+  const raw = Math.max(0, Math.round(amount));
+  let remaining = raw;
   const reduction =
     type === 'physical'
       ? target.defense || 0
@@ -14,8 +15,9 @@ export function applyDamage(target, amount, type = 'physical') {
       : 0;
   remaining = Math.max(0, remaining - reduction);
 
+  let absorbed = 0;
   if (target.water > 0) {
-    const absorbed = Math.min(target.water, remaining);
+    absorbed = Math.min(target.water, remaining);
     target.water -= absorbed;
     remaining -= absorbed;
   }
@@ -34,7 +36,8 @@ export function applyDamage(target, amount, type = 'physical') {
   if (target && Object.hasOwn(target, 'id')) {
     const waterSense = sectState.discipleSkills[target.id]?.WaterSense || 0;
     const maxWater = getMaxWater(target, waterSense) || 1;
-    const xp = (damageToHp / maxWater) * 10;
+    const xpSource = damageToHp > 0 ? damageToHp + absorbed : raw;
+    const xp = (xpSource / maxWater) * 10;
     if (xp > 0) {
       if (type === 'physical') addCombatStatXp(target, 'defense', xp);
       if (type === 'spell') addCombatStatXp(target, 'magicDefense', xp);

--- a/game/combatStats.js
+++ b/game/combatStats.js
@@ -1,4 +1,5 @@
 import { sectState } from './state.js';
+import { showCombatLevelUp } from './rendering.js';
 
 export const COMBAT_STAT_DEFS = {
   meleeDamage: { base: 1, unit: '', label: 'Melee Damage' },
@@ -38,9 +39,14 @@ export function ensureCombatStats(id) {
 export function addCombatStatXp(d, stat, amount = 1) {
   ensureCombatStats(d.id);
   const prev = sectState.discipleCombatStats[d.id][stat] || 0;
+  const prevLevel = getProgressFromXp(prev).level;
   const newXp = prev + amount;
   sectState.discipleCombatStats[d.id][stat] = newXp;
   const { level } = getProgressFromXp(newXp);
+  if (level > prevLevel) {
+    const diff = level - prevLevel;
+    showCombatLevelUp(d, COMBAT_STAT_DEFS[stat].label, diff);
+  }
   switch (stat) {
     case 'meleeDamage': {
       d.meleeDamage = COMBAT_STAT_DEFS.meleeDamage.base + level;

--- a/game/rendering.js
+++ b/game/rendering.js
@@ -29,3 +29,18 @@ export function showRaidDamageFloat(el, amount, isRaider = false) {
   );
   setTimeout(() => dmg.remove(), 3000);
 }
+
+// Display a floating '+ X' text and glow when a disciple levels a combat stat.
+export function showCombatLevelUp(d, text, amount = 1) {
+  if (typeof document === 'undefined') return;
+  const el = document.querySelector(`.sect-disciple[data-disciple-id="${d.id}"]`);
+  if (!el) return;
+  const gain = document.createElement('div');
+  gain.classList.add('levelup-float');
+  gain.textContent = `+${amount} ${text}`;
+  el.appendChild(gain);
+  gain.addEventListener('animationend', () => gain.remove(), { once: true });
+  setTimeout(() => gain.remove(), 5000);
+  el.classList.add('glow-notify');
+  setTimeout(() => el.classList.remove('glow-notify'), 5000);
+}

--- a/style.css
+++ b/style.css
@@ -1877,6 +1877,20 @@ body.darkenshift-mode .tabsContainer button.active {
     color: white;
 }
 
+.levelup-float {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    color: gold;
+    font-weight: bold;
+    pointer-events: none;
+    z-index: 1;
+    text-shadow: 0 0 2px #000;
+    font-size: 1.4em;
+    animation: damage-float 5s ease-out forwards;
+}
+
 @keyframes damage-float {
     from {
         opacity: 1;
@@ -2087,7 +2101,7 @@ body.darkenshift-mode .tabsContainer button.active {
 }
 
 .glow-notify {
-    animation: glow-pulse 1s infinite alternate;
+    animation: glow-pulse 1s ease-in-out 0s 5 alternate;
 }
 
 /* Distinct look for the Worlds menu container */

--- a/test/combat-stats-xp.test.js
+++ b/test/combat-stats-xp.test.js
@@ -17,13 +17,22 @@ describe('combat stat xp', () => {
     sectState.discipleSkills = {};
   });
 
-  it('gains defense xp proportional to damage taken', () => {
+  it('gains defense xp from incoming damage', () => {
     const d = new Disciple({ id: 1 });
     ensureCombatStats(d.id);
     const start = sectState.discipleCombatStats[d.id].defense;
     applyDamage(d, 5, 'physical');
     const end = sectState.discipleCombatStats[d.id].defense;
     expect(end).to.be.closeTo(start + 1, 0.001);
+  });
+
+  it('earns defense xp even when fully blocked', () => {
+    const d = new Disciple({ id: 3 });
+    ensureCombatStats(d.id);
+    const start = sectState.discipleCombatStats[d.id].defense;
+    applyDamage(d, 1, 'physical');
+    const end = sectState.discipleCombatStats[d.id].defense;
+    expect(end).to.be.closeTo(start + 0.33, 0.01);
   });
 
   it('levels melee damage after sufficient xp', () => {

--- a/test/water-shield.test.js
+++ b/test/water-shield.test.js
@@ -1,4 +1,4 @@
-/* global describe, it, before, after */
+/* global describe, it, before, after, beforeEach */
 import { expect } from 'chai';
 import Disciple from '../game/disciple.js';
 import { initializeDisciple } from '../utils/discipleInit.js';
@@ -52,6 +52,7 @@ describe('water shield', () => {
     expect(d.water).to.equal(2);
     expect(d.currentHp).to.equal(d.maxHp);
 
+    d.defense = 0;
     applyDamage(d, 3);
     expect(d.water).to.equal(0);
     expect(d.currentHp).to.equal(d.maxHp - 1);


### PR DESCRIPTION
## Summary
- grant defense and magic defense XP from all incoming hits
- display '+1 Stat' floating text and glow on combat stat level-ups
- level-up glow and floaters linger for 5 seconds so the effect is noticeable
- document defense XP from blocked hits and add tests for blocked damage

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891592b16e08326aa954a57c0394a32