### PR TITLE
fix: prevent level-up font scaling

### DIFF
--- a/style.css
+++ b/style.css
@@ -1887,7 +1887,7 @@ body.darkenshift-mode .tabsContainer button.active {
     pointer-events: none;
     z-index: 1;
     text-shadow: 0 0 2px #000;
-    font-size: 1.4em;
+    font-size: 1.4rem;
     animation: damage-float 5s ease-out forwards;
 }
 


### PR DESCRIPTION
## Summary
- use root-relative font size for level-up float text

## Testing
- `node - <<'NODE'
import { JSDOM } from 'jsdom';
const css = `.levelup-float { font-size: 1.4rem; }`;
const dom = new JSDOM(`<html><head><style>html{font-size:16px;}${css}</style></head><body><div style="font-size:0"><span class="levelup-float">Level Up</span></div></body></html>`);
const el = dom.window.document.querySelector('.levelup-float');
console.log('Computed font size:', dom.window.getComputedStyle(el).fontSize);
NODE`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68917bde9e408326bbaa671e5d072c76